### PR TITLE
[ENH] Unify fit_predict and fit_predict_with_data tools (#4)

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -8,54 +8,49 @@ that exposes sktime's registry and execution capabilities to LLMs.
 import asyncio
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import Tool, TextContent
+from mcp.types import TextContent, Tool
 
-from sktime_mcp.tools.list_estimators import (
-    list_estimators_tool,
-    get_available_tasks,
-    get_available_tags,
+from sktime_mcp.composition.validator import get_composition_validator
+from sktime_mcp.tools.codegen import export_code_tool
+from sktime_mcp.tools.data_tools import (
+    fit_predict_with_data_tool,
+    list_data_handles_tool,
+    list_data_sources_tool,
+    load_data_source_tool,
+    release_data_handle_tool,
 )
 from sktime_mcp.tools.describe_estimator import (
     describe_estimator_tool,
     search_estimators_tool,
 )
+from sktime_mcp.tools.fit_predict import (
+    fit_predict_async_tool,
+    fit_predict_tool,
+    list_datasets_tool,
+)
+from sktime_mcp.tools.format_tools import (
+    auto_format_on_load_tool,
+    format_time_series_tool,
+)
 from sktime_mcp.tools.instantiate import (
     instantiate_estimator_tool,
     instantiate_pipeline_tool,
-    release_handle_tool,
-    list_handles_tool,
-)
-from sktime_mcp.tools.fit_predict import (
-    fit_predict_tool,
-    fit_predict_async_tool,
-    fit_tool,
-    predict_tool,
-    list_datasets_tool,
-)
-from sktime_mcp.tools.codegen import export_code_tool
-from sktime_mcp.tools.data_tools import (
-    load_data_source_tool,
-    list_data_sources_tool,
-    fit_predict_with_data_tool,
-    list_data_handles_tool,
-    release_data_handle_tool,
-)
-from sktime_mcp.tools.format_tools import (
-    format_time_series_tool,
-    auto_format_on_load_tool,
 )
 from sktime_mcp.tools.job_tools import (
-    check_job_status_tool,
-    list_jobs_tool,
     cancel_job_tool,
-    delete_job_tool,
+    check_job_status_tool,
     cleanup_old_jobs_tool,
+    delete_job_tool,
+    list_jobs_tool,
 )
-from sktime_mcp.composition.validator import get_composition_validator
+from sktime_mcp.tools.list_estimators import (
+    get_available_tags,
+    list_estimators_tool,
+)
 
 # Configure logging to stderr with detailed format
 logging.basicConfig(
@@ -162,7 +157,7 @@ async def list_tools() -> List[Tool]:
         ),
         Tool(
             name="fit_predict",
-            description="Fit an estimator on a dataset and generate predictions",
+            description="Fit an estimator and generate predictions. Accepts either a demo dataset name or a data_handle from load_data_source.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -172,7 +167,11 @@ async def list_tools() -> List[Tool]:
                     },
                     "dataset": {
                         "type": "string",
-                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                        "description": "Demo dataset name: airline, sunspots, lynx, etc.",
+                    },
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Data handle from load_data_source (for custom data)",
                     },
                     "horizon": {
                         "type": "integer",
@@ -180,7 +179,7 @@ async def list_tools() -> List[Tool]:
                         "default": 12,
                     },
                 },
-                "required": ["estimator_handle", "dataset"],
+                "required": ["estimator_handle"],
             },
         ),
         Tool(
@@ -301,10 +300,8 @@ async def list_tools() -> List[Tool]:
         Tool(
             name="fit_predict_with_data",
             description=(
-                "Fit an estimator and generate predictions using custom data. GUIDELINES: "
-                "1. BEFORE calling this, check 'list_data_handles' or 'load_data_source' output. "
-                "2. If the metadata contains warnings about default target columns or column ambiguity, "
-                "STOP and re-load the data with explicit 'target_column' and 'time_column' mapping."
+                "[DEPRECATED] Use 'fit_predict' with 'data_handle' instead. "
+                "Fit an estimator and generate predictions using custom data."
             ),
             inputSchema={
                 "type": "object",
@@ -471,7 +468,7 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
     """Handle tool calls."""
     logger.info(f"=== Tool Call: {name} ===")
     logger.info(f"Arguments: {json.dumps(arguments, indent=2)}")
-    
+
     try:
         if name == "list_estimators":
             result = list_estimators_tool(
@@ -494,8 +491,9 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
         elif name == "fit_predict":
             result = fit_predict_tool(
                 arguments["estimator_handle"],
-                arguments["dataset"],
-                arguments.get("horizon", 12),
+                dataset=arguments.get("dataset"),
+                data_handle=arguments.get("data_handle"),
+                horizon=arguments.get("horizon", 12),
             )
             # Sanitize immediately to handle Period objects
             result = sanitize_for_json(result)
@@ -564,13 +562,13 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             result = cleanup_old_jobs_tool(arguments.get("max_age_hours", 24))
         else:
             result = {"error": f"Unknown tool: {name}"}
-        
+
         logger.info(f"=== Result for {name} ===")
-        
+
         # Sanitize result for JSON serialization
         sanitized_result = sanitize_for_json(result)
         logger.info(f"{json.dumps(sanitized_result, indent=2, default=str)}")
-        
+
         return [TextContent(type="text", text=json.dumps(sanitized_result, indent=2, default=str))]
     except Exception as e:
         logger.exception(f"Error in tool {name}")

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -5,27 +5,28 @@ Provides tools for loading data from various sources.
 """
 
 from typing import Any, Dict
+
 from sktime_mcp.runtime.executor import get_executor
 
 
 def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     Load data from any source (pandas, SQL, file, etc.).
-    
+
     Args:
         config: Data source configuration
             {
                 "type": "pandas" | "sql" | "file",
                 ... (type-specific configuration)
             }
-    
+
     Returns:
         Dictionary with:
         - success: bool
         - data_handle: str (handle ID for the loaded data)
         - metadata: dict (information about the data)
         - validation: dict (validation results)
-    
+
     Examples:
         # Pandas DataFrame
         >>> load_data_source_tool({
@@ -34,7 +35,7 @@ def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
         ...     "time_column": "date",
         ...     "target_column": "value"
         ... })
-        
+
         # SQL Database
         >>> load_data_source_tool({
         ...     "type": "sql",
@@ -43,7 +44,7 @@ def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
         ...     "time_column": "date",
         ...     "target_column": "value"
         ... })
-        
+
         # CSV File
         >>> load_data_source_tool({
         ...     "type": "file",
@@ -59,7 +60,7 @@ def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
 def list_data_sources_tool() -> Dict[str, Any]:
     """
     List all available data source types.
-    
+
     Returns:
         Dictionary with:
         - success: bool
@@ -67,9 +68,9 @@ def list_data_sources_tool() -> Dict[str, Any]:
         - descriptions: dict with descriptions for each source type
     """
     from sktime_mcp.data import DataSourceRegistry
-    
+
     sources = DataSourceRegistry.list_adapters()
-    
+
     # Get descriptions for each source
     descriptions = {}
     for source_type in sources:
@@ -78,7 +79,7 @@ def list_data_sources_tool() -> Dict[str, Any]:
             "class": info["class"],
             "description": info["docstring"].split("\n")[0] if info["docstring"] else "",
         }
-    
+
     return {
         "success": True,
         "sources": sources,
@@ -93,15 +94,18 @@ def fit_predict_with_data_tool(
 ) -> Dict[str, Any]:
     """
     Fit and predict using custom data.
-    
+
+    .. deprecated::
+        Use ``fit_predict_tool`` with ``data_handle`` parameter instead.
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         data_handle: Handle from load_data_source
         horizon: Forecast horizon (default: 12)
-    
+
     Returns:
         Dictionary with predictions
-    
+
     Example:
         >>> fit_predict_with_data_tool(
         ...     estimator_handle="est_abc123",
@@ -120,7 +124,7 @@ def fit_predict_with_data_tool(
 def list_data_handles_tool() -> Dict[str, Any]:
     """
     List all loaded data handles.
-    
+
     Returns:
         Dictionary with:
         - success: bool
@@ -134,10 +138,10 @@ def list_data_handles_tool() -> Dict[str, Any]:
 def release_data_handle_tool(data_handle: str) -> Dict[str, Any]:
     """
     Release a data handle and free memory.
-    
+
     Args:
         data_handle: Data handle to release
-    
+
     Returns:
         Dictionary with success status
     """

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -4,40 +4,64 @@ fit_predict tool for sktime MCP.
 Executes complete forecasting workflows.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 from sktime_mcp.runtime.executor import get_executor
 
 
 def fit_predict_tool(
     estimator_handle: str,
-    dataset: str,
+    dataset: Optional[str] = None,
+    data_handle: Optional[str] = None,
     horizon: int = 12,
 ) -> Dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
-    
+
+    Accepts either a demo dataset name or a data handle from load_data_source.
+    Exactly one of 'dataset' or 'data_handle' must be provided.
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
+        data_handle: Handle from load_data_source (for custom data)
         horizon: Forecast horizon (default: 12)
-    
+
     Returns:
         Dictionary with:
         - success: bool
         - predictions: Forecast values
         - horizon: Number of steps predicted
-    
+
     Example:
-        >>> fit_predict_tool("est_abc123", "airline", horizon=12)
-        {
-            "success": True,
-            "predictions": {1: 450.2, 2: 460.5, ...},
-            "horizon": 12
-        }
+        >>> fit_predict_tool("est_abc123", dataset="airline", horizon=12)
+        {"success": True, "predictions": {...}, "horizon": 12}
+
+        >>> fit_predict_tool("est_abc123", data_handle="data_xyz789", horizon=6)
+        {"success": True, "predictions": {...}, "horizon": 6}
     """
+    # exactly one of dataset or data_handle must be provided
+    if dataset and data_handle:
+        return {
+            "success": False,
+            "error": "Provide either 'dataset' or 'data_handle', not both.",
+        }
+
+    if not dataset and not data_handle:
+        return {
+            "success": False,
+            "error": (
+                "Either 'dataset' (demo name like 'airline') or "
+                "'data_handle' (from load_data_source) is required."
+            ),
+        }
+
     executor = get_executor()
-    return executor.fit_predict(estimator_handle, dataset, horizon)
+
+    if dataset:
+        return executor.fit_predict(estimator_handle, dataset, horizon)
+
+    return executor.fit_predict_with_data(estimator_handle, data_handle, horizon)
 
 
 def fit_tool(
@@ -46,11 +70,11 @@ def fit_tool(
 ) -> Dict[str, Any]:
     """
     Fit an estimator on a dataset.
-    
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset
-    
+
     Returns:
         Dictionary with success status
     """
@@ -58,7 +82,7 @@ def fit_tool(
     data_result = executor.load_dataset(dataset)
     if not data_result["success"]:
         return data_result
-    
+
     return executor.fit(
         estimator_handle,
         y=data_result["data"],
@@ -72,11 +96,11 @@ def predict_tool(
 ) -> Dict[str, Any]:
     """
     Generate predictions from a fitted estimator.
-    
+
     Args:
         estimator_handle: Handle of a fitted estimator
         horizon: Forecast horizon
-    
+
     Returns:
         Dictionary with predictions
     """
@@ -88,7 +112,7 @@ def predict_tool(
 def list_datasets_tool() -> Dict[str, Any]:
     """
     List available demo datasets.
-    
+
     Returns:
         Dictionary with list of dataset names
     """
@@ -106,21 +130,21 @@ def fit_predict_async_tool(
 ) -> Dict[str, Any]:
     """
     Execute a fit-predict workflow in the background (non-blocking).
-    
+
     This tool schedules the training as a background job and returns immediately
     with a job_id. Use check_job_status to monitor progress.
-    
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
-    
+
     Returns:
         Dictionary with:
         - success: bool
         - job_id: Job ID for tracking progress
         - message: Information about the job
-    
+
     Example:
         >>> fit_predict_async_tool("est_abc123", "airline", horizon=12)
         {
@@ -130,11 +154,12 @@ def fit_predict_async_tool(
         }
     """
     import asyncio
+
     from sktime_mcp.runtime.jobs import get_job_manager
-    
+
     executor = get_executor()
     job_manager = get_job_manager()
-    
+
     # Get estimator info
     try:
         handle_info = executor._handle_manager.get_info(estimator_handle)
@@ -142,7 +167,7 @@ def fit_predict_async_tool(
     except Exception as e:
         logger.warning(f"Could not get estimator name: {e}")
         estimator_name = "Unknown"
-    
+
     # Create job
     job_id = job_manager.create_job(
         job_type="fit_predict",
@@ -152,7 +177,7 @@ def fit_predict_async_tool(
         horizon=horizon,
         total_steps=3,
     )
-    
+
     # Schedule the async coroutine on the event loop
     try:
         loop = asyncio.get_event_loop()
@@ -160,11 +185,11 @@ def fit_predict_async_tool(
         # No event loop in current thread, create one
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-    
+
     # Schedule the coroutine (non-blocking!)
     coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
     asyncio.run_coroutine_threadsafe(coro, loop)
-    
+
     return {
         "success": True,
         "job_id": job_id,
@@ -173,4 +198,3 @@ def fit_predict_async_tool(
         "dataset": dataset,
         "horizon": horizon,
     }
-

--- a/tests/test_unified_fit_predict.py
+++ b/tests/test_unified_fit_predict.py
@@ -1,0 +1,108 @@
+"""
+Tests for the unified fit_predict tool.
+
+Verifies that fit_predict_tool handles both demo datasets
+and custom data handles through a single interface.
+"""
+
+import sys
+
+sys.path.insert(0, "src")
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.tools.data_tools import fit_predict_with_data_tool
+from sktime_mcp.tools.fit_predict import fit_predict_tool
+
+
+class TestUnifiedFitPredict:
+    """Tests for the unified fit_predict_tool."""
+
+    def test_fit_predict_with_dataset(self):
+        """Using a demo dataset should work as before."""
+        executor = get_executor()
+        est = executor.instantiate("NaiveForecaster", {"strategy": "last"})
+        assert est["success"]
+
+        result = fit_predict_tool(est["handle"], dataset="airline")
+        assert result["success"]
+        assert "predictions" in result
+
+    def test_fit_predict_with_data_handle(self):
+        """Using a data_handle from load_data_source should work."""
+        import pandas as pd
+
+        executor = get_executor()
+        est = executor.instantiate("NaiveForecaster", {"strategy": "last"})
+        assert est["success"]
+
+        config = {
+            "type": "pandas",
+            "data": {
+                "date": pd.date_range("2020-01-01", periods=30, freq="D"),
+                "value": list(range(30)),
+            },
+            "time_column": "date",
+            "target_column": "value",
+        }
+        data_result = executor.load_data_source(config)
+        assert data_result["success"]
+
+        handle = data_result.get("data_handle")
+        result = fit_predict_tool(est["handle"], data_handle=handle)
+        assert result["success"]
+        assert "predictions" in result
+
+    def test_fit_predict_both_provided_error(self):
+        """Providing both dataset and data_handle should fail."""
+        result = fit_predict_tool(
+            "est_fake",
+            dataset="airline",
+            data_handle="data_fake",
+        )
+        assert not result["success"]
+        assert "not both" in result["error"]
+
+    def test_fit_predict_neither_provided_error(self):
+        """Providing neither dataset nor data_handle should fail."""
+        result = fit_predict_tool("est_fake")
+        assert not result["success"]
+        assert "required" in result["error"]
+
+    def test_fit_predict_invalid_data_handle(self):
+        """An invalid data_handle should return a clear error."""
+        executor = get_executor()
+        est = executor.instantiate("NaiveForecaster", {"strategy": "last"})
+        assert est["success"]
+
+        result = fit_predict_tool(est["handle"], data_handle="bogus_handle")
+        assert not result["success"]
+        assert "bogus_handle" in result["error"]
+
+
+class TestDeprecatedToolStillWorks:
+    """The old fit_predict_with_data_tool should still function."""
+
+    def test_deprecated_tool_still_works(self):
+        """Backward compatibility: old tool still works."""
+        import pandas as pd
+
+        executor = get_executor()
+        est = executor.instantiate("NaiveForecaster", {"strategy": "last"})
+        assert est["success"]
+
+        config = {
+            "type": "pandas",
+            "data": {
+                "date": pd.date_range("2020-01-01", periods=30, freq="D"),
+                "value": list(range(30)),
+            },
+            "time_column": "date",
+            "target_column": "value",
+        }
+        data_result = executor.load_data_source(config)
+        assert data_result["success"]
+
+        handle = data_result.get("data_handle")
+        result = fit_predict_with_data_tool(est["handle"], handle)
+        assert result["success"]
+        assert "predictions" in result


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #4

#### What does this implement/fix? Explain your changes.

Unified the `fit_predict` and `fit_predict_with_data` tools into a single `fit_predict` tool that accepts either a demo dataset name or a data handle from `load_data_source`.

Changes:
- Updated `fit_predict_tool()` in `fit_predict.py` to accept both `dataset` and `data_handle` as optional params (exactly one required).
- Updated the tool schema in `server.py` to reflect the new signature.
- Marked `fit_predict_with_data` as `[DEPRECATED]` in `server.py` and `data_tools.py` it still works for backward compatibility.
- Added `tests/test_unified_fit_predict.py` with 6 test cases.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

- The branching happens at the tool layer rather than inside `Executor.fit_predict` this keeps the executor's clean separation intact
- `fit_predict_with_data` is deprecated but not removed, so nothing breaks for existing users

#### Any other comments?

For the "Ponder Upon" question instead of modifying the executor directly, I branched at the tool level. This avoids changing the executor's internal API and reuses both existing methods (`executor.fit_predict` and `executor.fit_predict_with_data`) as is.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/all-contributors)
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS)
- [x] I've added unit tests and made sure they pass locally.
