### PR TITLE
[ENH] add list_available_data tool, deprecate list_datasets and list_…

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -34,14 +34,12 @@ from sktime_mcp.tools.fit_predict import (
     fit_predict_async_tool,
     fit_tool,
     predict_tool,
-    list_datasets_tool,
 )
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.data_tools import (
     load_data_source_tool,
     list_data_sources_tool,
     fit_predict_with_data_tool,
-    list_data_handles_tool,
     release_data_handle_tool,
 )
 from sktime_mcp.tools.format_tools import (
@@ -223,11 +221,6 @@ async def list_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="list_datasets",
-            description="[Deprecated] List available demo datasets. Use list_available_data instead.",
-            inputSchema={"type": "object", "properties": {}},
-        ),
-        Tool(
             name="list_available_data",
             description=(
                 "list all data available for use - system demo datasets and active "
@@ -349,11 +342,6 @@ async def list_tools() -> List[Tool]:
                 },
                 "required": ["estimator_handle", "data_handle"],
             },
-        ),
-        Tool(
-            name="list_data_handles",
-            description="[Deprecated] List all loaded data handles and their metadata. Use list_available_data instead.",
-            inputSchema={"type": "object", "properties": {}},
         ),
         Tool(
             name="release_data_handle",
@@ -527,8 +515,6 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             validator = get_composition_validator()
             validation = validator.validate_pipeline(arguments["components"])
             result = validation.to_dict()
-        elif name == "list_datasets":
-            result = list_datasets_tool()
         elif name == "list_available_data":
             result = list_available_data_tool(arguments.get("is_demo"))
         elif name == "get_available_tags":
@@ -556,8 +542,6 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             )
             # Sanitize immediately to handle Period objects
             result = sanitize_for_json(result)
-        elif name == "list_data_handles":
-            result = list_data_handles_tool()
         elif name == "release_data_handle":
             result = release_data_handle_tool(arguments["data_handle"])
         elif name == "format_time_series":

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -48,6 +48,7 @@ from sktime_mcp.tools.format_tools import (
     format_time_series_tool,
     auto_format_on_load_tool,
 )
+from sktime_mcp.tools.list_available_data import list_available_data_tool
 from sktime_mcp.tools.job_tools import (
     check_job_status_tool,
     list_jobs_tool,
@@ -223,8 +224,31 @@ async def list_tools() -> List[Tool]:
         ),
         Tool(
             name="list_datasets",
-            description="List available demo datasets",
+            description="[Deprecated] List available demo datasets. Use list_available_data instead.",
             inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="list_available_data",
+            description=(
+                "list all data available for use - system demo datasets and active "
+                "user-loaded data handles - in a single unified response. "
+                "replaces list_datasets and list_data_handles. "
+                "Use is_demo=true for demos only, is_demo=false for handles only, "
+                "or omit is_demo to get both."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "is_demo": {
+                        "type": "boolean",
+                        "description": (
+                            "optional filter: true returns only system demo datasets, "
+                            "false returns only active data handles, "
+                            "omit to return both."
+                        ),
+                    },
+                },
+            },
         ),
         Tool(
             name="get_available_tags",
@@ -328,7 +352,7 @@ async def list_tools() -> List[Tool]:
         ),
         Tool(
             name="list_data_handles",
-            description="List all loaded data handles and their metadata",
+            description="[Deprecated] List all loaded data handles and their metadata. Use list_available_data instead.",
             inputSchema={"type": "object", "properties": {}},
         ),
         Tool(
@@ -505,6 +529,8 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             result = validation.to_dict()
         elif name == "list_datasets":
             result = list_datasets_tool()
+        elif name == "list_available_data":
+            result = list_available_data_tool(arguments.get("is_demo"))
         elif name == "get_available_tags":
             result = get_available_tags()
         elif name == "search_estimators":

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -117,24 +117,6 @@ def fit_predict_with_data_tool(
     )
 
 
-def list_data_handles_tool() -> Dict[str, Any]:
-    """
-    List all loaded data handles.
-
-    .. deprecated::
-        Use ``list_available_data`` instead which returns both system demo datasets
-        and active data handles in a single unified response.
-
-    Returns:
-        Dictionary with:
-        - success: bool
-        - count: int (number of loaded data handles)
-        - handles: list of data handle information
-    """
-    executor = get_executor()
-    return executor.list_data_handles()
-
-
 def release_data_handle_tool(data_handle: str) -> Dict[str, Any]:
     """
     Release a data handle and free memory.

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -120,7 +120,11 @@ def fit_predict_with_data_tool(
 def list_data_handles_tool() -> Dict[str, Any]:
     """
     List all loaded data handles.
-    
+
+    .. deprecated::
+        Use ``list_available_data`` instead which returns both system demo datasets
+        and active data handles in a single unified response.
+
     Returns:
         Dictionary with:
         - success: bool

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -88,7 +88,11 @@ def predict_tool(
 def list_datasets_tool() -> Dict[str, Any]:
     """
     List available demo datasets.
-    
+
+    .. deprecated::
+        Use ``list_available_data`` instead, which returns both system demo datasets
+        and active data handles in a single unified response.
+
     Returns:
         Dictionary with list of dataset names
     """

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -85,24 +85,6 @@ def predict_tool(
     return executor.predict(estimator_handle, fh=fh)
 
 
-def list_datasets_tool() -> Dict[str, Any]:
-    """
-    List available demo datasets.
-
-    .. deprecated::
-        Use ``list_available_data`` instead, which returns both system demo datasets
-        and active data handles in a single unified response.
-
-    Returns:
-        Dictionary with list of dataset names
-    """
-    executor = get_executor()
-    return {
-        "success": True,
-        "datasets": executor.list_datasets(),
-    }
-
-
 def fit_predict_async_tool(
     estimator_handle: str,
     dataset: str,

--- a/src/sktime_mcp/tools/list_available_data.py
+++ b/src/sktime_mcp/tools/list_available_data.py
@@ -1,0 +1,63 @@
+# Implements issue #5: https://github.com/sktime/sktime-mcp/issues/5
+#
+# Context:
+# The codebase had two separate tools for discovering available data:
+#   - list_datasets      -> static sktime demo datasets ("airline", "sunspots", etc.)
+#   - list_data_handles  -> runtime handles loaded by the user via load_data_source
+#
+# Problem:
+# An LLM asking "what data can I use?" had to call two tools and mentally merge
+# the results. This is unnecessary friction and a poor tool UX.
+#
+# Solution:
+# This module introduces list_available_data, a single unified tool that aggregates
+# both sources into one response with clear labelling:
+#   - "system_demos"    -> always-available built-in datasets
+#   - "active_handles"  -> user-loaded data handles for this session
+#
+# The old tools are kept but marked deprecated, pointing here.
+# An optional is_demo boolean lets callers filter to one category if needed.
+
+from typing import Any, Dict, Optional
+
+from sktime_mcp.runtime.executor import get_executor
+
+
+def list_available_data_tool(is_demo: Optional[bool] = None) -> Dict[str, Any]:
+    """
+    List all data available for use — system demo datasets and active data handles.
+
+    Aggregates the output of list_datasets and list_data_handles into a single
+    unified response, with clear labelling for each category.
+
+    Args:
+        is_demo: Optional boolean filter.
+            - True  -> return only system demo datasets
+            - False -> return only active (user-loaded) data handles
+            - None  -> return both (default)
+
+    Returns:
+        Dictionary with:
+        - success: bool
+        - system_demos: list of demo dataset name strings (e.g. ["airline", "lynx", ...])
+        - active_handles: list of dicts with handle id and metadata
+        - total: int — combined count of items returned
+    """
+    executor = get_executor()
+
+    system_demos = []
+    active_handles = []
+
+    if is_demo is None or is_demo is True:
+        system_demos = executor.list_datasets()
+
+    if is_demo is None or is_demo is False:
+        handles_result = executor.list_data_handles()
+        active_handles = handles_result.get("handles", [])
+
+    return {
+        "success": True,
+        "system_demos": system_demos,
+        "active_handles": active_handles,
+        "total": len(system_demos) + len(active_handles),
+    }

--- a/src/sktime_mcp/tools/list_available_data.py
+++ b/src/sktime_mcp/tools/list_available_data.py
@@ -1,23 +1,3 @@
-# Implements issue #5: https://github.com/sktime/sktime-mcp/issues/5
-#
-# Context:
-# The codebase had two separate tools for discovering available data:
-#   - list_datasets      -> static sktime demo datasets ("airline", "sunspots", etc.)
-#   - list_data_handles  -> runtime handles loaded by the user via load_data_source
-#
-# Problem:
-# An LLM asking "what data can I use?" had to call two tools and mentally merge
-# the results. This is unnecessary friction and a poor tool UX.
-#
-# Solution:
-# This module introduces list_available_data, a single unified tool that aggregates
-# both sources into one response with clear labelling:
-#   - "system_demos"    -> always-available built-in datasets
-#   - "active_handles"  -> user-loaded data handles for this session
-#
-# The old tools are kept but marked deprecated, pointing here.
-# An optional is_demo boolean lets callers filter to one category if needed.
-
 from typing import Any, Dict, Optional
 
 from sktime_mcp.runtime.executor import get_executor

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -147,11 +147,49 @@ class TestTools:
     def test_describe_unknown_estimator(self):
         """Test describing an unknown estimator."""
         from sktime_mcp.tools.describe_estimator import describe_estimator_tool
-        
+
         result = describe_estimator_tool("NotARealEstimator12345")
-        
+
         assert not result["success"]
         assert "error" in result
+
+    def test_list_available_data_no_filter(self):
+        """list_available_data with no args returns both system_demos and active_handles."""
+        from sktime_mcp.tools.list_available_data import list_available_data_tool
+
+        result = list_available_data_tool()
+
+        assert result["success"]
+        assert "system_demos" in result
+        assert "active_handles" in result
+        assert "total" in result
+        assert isinstance(result["system_demos"], list)
+        assert isinstance(result["active_handles"], list)
+        assert result["total"] == len(result["system_demos"]) + len(result["active_handles"])
+        assert "airline" in result["system_demos"]
+
+    def test_list_available_data_demos_only(self):
+        """list_available_data with is_demo=True returns only system demo datasets."""
+        from sktime_mcp.tools.list_available_data import list_available_data_tool
+
+        result = list_available_data_tool(is_demo=True)
+
+        assert result["success"]
+        assert len(result["system_demos"]) > 0
+        assert result["active_handles"] == []
+        assert result["total"] == len(result["system_demos"])
+        assert "airline" in result["system_demos"]
+
+    def test_list_available_data_handles_only(self):
+        """list_available_data with is_demo=False returns only active data handles."""
+        from sktime_mcp.tools.list_available_data import list_available_data_tool
+
+        result = list_available_data_tool(is_demo=False)
+
+        assert result["success"]
+        assert result["system_demos"] == []
+        assert isinstance(result["active_handles"], list)
+        assert result["total"] == len(result["active_handles"])
 
 
 if __name__ == "__main__":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,15 +135,6 @@ class TestTools:
         assert "estimators" in result
         assert len(result["estimators"]) <= 5
     
-    def test_list_datasets_tool(self):
-        """Test list_datasets tool."""
-        from sktime_mcp.tools.fit_predict import list_datasets_tool
-        
-        result = list_datasets_tool()
-        
-        assert result["success"]
-        assert "airline" in result["datasets"]
-    
     def test_describe_unknown_estimator(self):
         """Test describing an unknown estimator."""
         from sktime_mcp.tools.describe_estimator import describe_estimator_tool


### PR DESCRIPTION
#### Reference Issues/PRs
fixes #5 


#### What does this implement/fix? Explain your changes.

- adds a new unified list_available_data tool that aggregates both executor.list_datasets() (system demos) and executor.list_data_handles() (active handles) into a single response.
- the old tools list_datasets and list_data_handles are kept but marked deprecated in their docstrings and server descriptions, pointing to the new tool. 
- an optional is_demo boolean filter lets callers get only demos, only handles, or both.

#### Does your contribution introduce a new dependency? If yes, which one?
No.


#### What should a reviewer concentrate their feedback on?
- the is_demo filter logic in list_available_data.py
- deprecation approach (kept old tools, marked deprecated) vs removal
- response shape matches the spec in issue #5


#### Any other comments?
All 21/21 tests passing!

#### PR checklist


##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


