### PR TITLE
[ENH] Enable background jobs for custom data handles (#7)

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -35,16 +35,16 @@ DEMO_DATASETS = {
 class Executor:
     """
     Execution runtime for sktime estimators.
-    
+
     Handles instantiation, fitting, and prediction.
     """
-    
+
     def __init__(self):
         self._registry = get_registry()
         self._handle_manager = get_handle_manager()
         self._job_manager = get_job_manager()
         self._data_handles = {}  # Store data handles
-    
+
     def instantiate(
         self,
         estimator_name: str,
@@ -54,7 +54,7 @@ class Executor:
         node = self._registry.get_estimator_by_name(estimator_name)
         if node is None:
             return {"success": False, "error": f"Unknown estimator: {estimator_name}"}
-        
+
         try:
             instance = node.class_ref(**(params or {}))
             handle_id = self._handle_manager.create_handle(
@@ -70,7 +70,7 @@ class Executor:
             }
         except Exception as e:
             return {"success": False, "error": str(e)}
-    
+
     # L-7: We can also add custom load_dataset functions here
     def load_dataset(self, name: str) -> Dict[str, Any]:
         """Load a demo dataset."""
@@ -80,30 +80,30 @@ class Executor:
                 "error": f"Unknown dataset: {name}",
                 "available": list(DEMO_DATASETS.keys()),
             }
-        
+
         try:
             module_path = DEMO_DATASETS[name]
             parts = module_path.rsplit(".", 1)
             module = __import__(parts[0], fromlist=[parts[1]])
             loader = getattr(module, parts[1])
             data = loader()
-            
+
             if isinstance(data, tuple):
                 y, X = data[0], data[1] if len(data) > 1 else None
             else:
                 y, X = data, None
-            
+
             return {
                 "success": True,
                 "name": name,
-                "shape": y.shape if hasattr(y, 'shape') else len(y),
+                "shape": y.shape if hasattr(y, "shape") else len(y),
                 "type": str(type(y).__name__),
                 "data": y,
                 "exog": X,
             }
         except Exception as e:
             return {"success": False, "error": str(e)}
-    
+
     def fit(
         self,
         handle_id: str,
@@ -116,7 +116,7 @@ class Executor:
             instance = self._handle_manager.get_instance(handle_id)
         except KeyError:
             return {"success": False, "error": f"Handle not found: {handle_id}"}
-        
+
         try:
             if fh is not None:
                 instance.fit(y, X=X, fh=fh)
@@ -124,12 +124,12 @@ class Executor:
                 instance.fit(y, X=X)
             else:
                 instance.fit(y)
-            
+
             self._handle_manager.mark_fitted(handle_id)
             return {"success": True, "handle": handle_id, "fitted": True}
         except Exception as e:
             return {"success": False, "error": str(e)}
-    
+
     def predict(
         self,
         handle_id: str,
@@ -141,19 +141,19 @@ class Executor:
             instance = self._handle_manager.get_instance(handle_id)
         except KeyError:
             return {"success": False, "error": f"Handle not found: {handle_id}"}
-        
+
         if not self._handle_manager.is_fitted(handle_id):
             return {"success": False, "error": "Estimator not fitted"}
-        
+
         try:
             if fh is None:
                 fh = list(range(1, 13))
-            
+
             if X is not None:
                 predictions = instance.predict(fh=fh, X=X)
             else:
                 predictions = instance.predict(fh=fh)
-            
+
             if isinstance(predictions, pd.Series):
                 # Convert index to string to avoid JSON serialization issues with Period/DatetimeIndex
                 predictions_copy = predictions.copy()
@@ -162,14 +162,18 @@ class Executor:
             elif isinstance(predictions, pd.DataFrame):
                 predictions_copy = predictions.copy()
                 predictions_copy.index = predictions_copy.index.astype(str)
-                result = predictions_copy.to_dict(orient='list')
+                result = predictions_copy.to_dict(orient="list")
             else:
-                result = predictions.tolist() if hasattr(predictions, 'tolist') else predictions
-            
-            return {"success": True, "predictions": result, "horizon": len(fh) if hasattr(fh, '__len__') else fh}
+                result = predictions.tolist() if hasattr(predictions, "tolist") else predictions
+
+            return {
+                "success": True,
+                "predictions": result,
+                "horizon": len(fh) if hasattr(fh, "__len__") else fh,
+            }
         except Exception as e:
             return {"success": False, "error": str(e)}
-    
+
     def fit_predict(
         self,
         handle_id: str,
@@ -180,39 +184,46 @@ class Executor:
         data_result = self.load_dataset(dataset)
         if not data_result["success"]:
             return data_result
-        
+
         y = data_result["data"]
         X = data_result.get("exog")
         fh = list(range(1, horizon + 1))
-        
+
         fit_result = self.fit(handle_id, y, X=X, fh=fh)
         if not fit_result["success"]:
             return fit_result
-        
+
         return self.predict(handle_id, fh=fh, X=X)
-    
+
     async def fit_predict_async(
         self,
         handle_id: str,
-        dataset: str,
+        dataset: Optional[str] = None,
         horizon: int = 12,
         job_id: Optional[str] = None,
+        data_handle: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Async version of fit_predict with job tracking.
-        
-        This method runs the training in the background without blocking the MCP server.
-        Progress is tracked via the JobManager.
-        
+
+        This method runs the training in the background without blocking
+        the MCP server. Progress is tracked via the JobManager.
+
+        Accepts either a demo dataset name or a data_handle from
+        load_data_source. Exactly one must be provided.
+
         Args:
             handle_id: Estimator handle
-            dataset: Dataset name
+            dataset: Demo dataset name (e.g., "airline")
             horizon: Forecast horizon
             job_id: Optional job ID for tracking (created if not provided)
-        
+            data_handle: Handle from load_data_source (for custom data)
+
         Returns:
             Dictionary with success status and job_id
         """
+        source_label = dataset if dataset else data_handle
+
         # Get estimator info for job tracking
         try:
             handle_info = self._handle_manager.get_info(handle_id)
@@ -220,109 +231,116 @@ class Executor:
         except Exception as e:
             logger.warning(f"Could not get estimator name: {e}")
             estimator_name = "Unknown"
-        
+
         # Create job if not provided
         if job_id is None:
             job_id = self._job_manager.create_job(
                 job_type="fit_predict",
                 estimator_handle=handle_id,
                 estimator_name=estimator_name,
-                dataset_name=dataset,
+                dataset_name=source_label,
                 horizon=horizon,
                 total_steps=3,  # load data, fit, predict
             )
-        
+
         try:
             # Update status to RUNNING
             self._job_manager.update_job(job_id, status=JobStatus.RUNNING)
-            
-            # Step 1: Load dataset
+
+            # Step 1: Load data (from data_handle or demo dataset)
             self._job_manager.update_job(
-                job_id,
-                completed_steps=0,
-                current_step=f"Loading dataset '{dataset}'..."
+                job_id, completed_steps=0, current_step=f"Loading data '{source_label}'..."
             )
             await asyncio.sleep(0.01)  # Yield control to event loop
-            
-            data_result = self.load_dataset(dataset)
-            if not data_result["success"]:
-                self._job_manager.update_job(
-                    job_id,
-                    status=JobStatus.FAILED,
-                    errors=[f"Failed to load dataset: {data_result.get('error')}"]
-                )
-                return data_result
-            
-            y = data_result["data"]
-            X = data_result.get("exog")
+
+            if data_handle:
+                # load from custom data handle
+                if data_handle not in self._data_handles:
+                    self._job_manager.update_job(
+                        job_id,
+                        status=JobStatus.FAILED,
+                        errors=[f"Unknown data handle: {data_handle}"],
+                    )
+                    return {
+                        "success": False,
+                        "error": f"Unknown data handle: {data_handle}",
+                        "available_handles": list(self._data_handles.keys()),
+                    }
+                data = self._data_handles[data_handle]
+                y = data["y"]
+                X = data.get("X")
+            else:
+                # load from demo dataset
+                data_result = self.load_dataset(dataset)
+                if not data_result["success"]:
+                    self._job_manager.update_job(
+                        job_id,
+                        status=JobStatus.FAILED,
+                        errors=[f"Failed to load dataset: {data_result.get('error')}"],
+                    )
+                    return data_result
+                y = data_result["data"]
+                X = data_result.get("exog")
+
             fh = list(range(1, horizon + 1))
-            
+
             # Step 2: Fit model
             self._job_manager.update_job(
-                job_id,
-                completed_steps=1,
-                current_step=f"Fitting {estimator_name} on {dataset}..."
+                job_id, completed_steps=1, current_step=f"Fitting {estimator_name} on {source_label}..."
             )
             await asyncio.sleep(0.01)  # Yield control
-            
+
             # Run fit in executor to avoid blocking
             loop = asyncio.get_event_loop()
             fit_result = await loop.run_in_executor(
-                None,
-                lambda: self.fit(handle_id, y, X=X, fh=fh)
+                None, lambda: self.fit(handle_id, y, X=X, fh=fh)
             )
-            
+
             if not fit_result["success"]:
                 self._job_manager.update_job(
                     job_id,
                     status=JobStatus.FAILED,
-                    errors=[f"Fit failed: {fit_result.get('error')}"]
+                    errors=[f"Fit failed: {fit_result.get('error')}"],
                 )
                 return fit_result
-            
+
             # Step 3: Generate predictions
             self._job_manager.update_job(
                 job_id,
                 completed_steps=2,
-                current_step=f"Generating predictions (horizon={horizon})..."
+                current_step=f"Generating predictions (horizon={horizon})...",
             )
             await asyncio.sleep(0.01)  # Yield control
-            
+
             # Run predict in executor
             predict_result = await loop.run_in_executor(
-                None,
-                lambda: self.predict(handle_id, fh=fh, X=X)
+                None, lambda: self.predict(handle_id, fh=fh, X=X)
             )
-            
+
             if not predict_result["success"]:
                 self._job_manager.update_job(
                     job_id,
                     status=JobStatus.FAILED,
-                    errors=[f"Prediction failed: {predict_result.get('error')}"]
+                    errors=[f"Prediction failed: {predict_result.get('error')}"],
                 )
                 return predict_result
-            
+
             # Mark as completed
             self._job_manager.update_job(
                 job_id,
                 status=JobStatus.COMPLETED,
                 completed_steps=3,
                 current_step="Completed",
-                result=predict_result
+                result=predict_result,
             )
-            
+
             return predict_result
-        
+
         except Exception as e:
             logger.exception(f"Error in async fit_predict for job {job_id}")
-            self._job_manager.update_job(
-                job_id,
-                status=JobStatus.FAILED,
-                errors=[str(e)]
-            )
+            self._job_manager.update_job(job_id, status=JobStatus.FAILED, errors=[str(e)])
             return {"success": False, "error": str(e), "job_id": job_id}
-    
-    
+
     # L-9: We can add more methods here to handle diverse use cases and their pipelines
     def instantiate_pipeline(
         self,
@@ -331,22 +349,23 @@ class Executor:
     ) -> Dict[str, Any]:
         """
         Instantiate a pipeline from a list of components.
-        
+
         Args:
             components: List of estimator names in pipeline order
             params_list: Optional list of parameter dicts for each component
-        
+
         Returns:
             Dictionary with success status and handle
         """
         if not components:
             return {"success": False, "error": "Pipeline cannot be empty"}
-        
+
         # Validate the pipeline first
         from sktime_mcp.composition.validator import get_composition_validator
+
         validator = get_composition_validator()
         validation = validator.validate_pipeline(components)
-        
+
         if not validation.valid:
             return {
                 "success": False,
@@ -354,78 +373,88 @@ class Executor:
                 "validation_errors": validation.errors,
                 "suggestions": validation.suggestions,
             }
-        
+
         try:
             # If only one component, just instantiate it directly
             if len(components) == 1:
                 params = params_list[0] if params_list else {}
                 return self.instantiate(components[0], params)
-            
+
             # Build the pipeline
             # Get all component nodes
             component_instances = []
             params_list = params_list or [{}] * len(components)
-            
+
             for i, comp_name in enumerate(components):
                 node = self._registry.get_estimator_by_name(comp_name)
                 if node is None:
                     return {"success": False, "error": f"Unknown estimator: {comp_name}"}
-                
+
                 params = params_list[i] if i < len(params_list) else {}
                 instance = node.class_ref(**params)
                 component_instances.append(instance)
-            
+
             # Determine the type of pipeline to create
             # Check if all but last are transformers
             all_transformers_except_last = all(
                 self._registry.get_estimator_by_name(comp).task == "transformation"
                 for comp in components[:-1]
             )
-            
+
             final_task = self._registry.get_estimator_by_name(components[-1]).task
-            
+
             if all_transformers_except_last and final_task == "forecasting":
                 # Use TransformedTargetForecaster
                 from sktime.forecasting.compose import TransformedTargetForecaster
-                
+
                 # Chain transformers if multiple
                 if len(component_instances) == 2:
-                    pipeline = TransformedTargetForecaster([
-                        ("transformer", component_instances[0]),
-                        ("forecaster", component_instances[1]),
-                    ])
+                    pipeline = TransformedTargetForecaster(
+                        [
+                            ("transformer", component_instances[0]),
+                            ("forecaster", component_instances[1]),
+                        ]
+                    )
                 else:
                     # Multiple transformers - chain them
                     from sktime.transformations.compose import TransformerPipeline
-                    transformer_pipeline = TransformerPipeline([
-                        (f"step_{i}", comp) for i, comp in enumerate(component_instances[:-1])
-                    ])
-                    pipeline = TransformedTargetForecaster([
-                        ("transformers", transformer_pipeline),
-                        ("forecaster", component_instances[-1]),
-                    ])
-            
+
+                    transformer_pipeline = TransformerPipeline(
+                        [(f"step_{i}", comp) for i, comp in enumerate(component_instances[:-1])]
+                    )
+                    pipeline = TransformedTargetForecaster(
+                        [
+                            ("transformers", transformer_pipeline),
+                            ("forecaster", component_instances[-1]),
+                        ]
+                    )
+
             elif all_transformers_except_last and final_task in ("classification", "regression"):
                 # Use sklearn-style Pipeline
                 from sktime.pipeline import Pipeline
-                pipeline = Pipeline([
-                    (f"step_{i}", comp) for i, comp in enumerate(component_instances)
-                ])
-            
-            elif all(self._registry.get_estimator_by_name(comp).task == "transformation" for comp in components):
+
+                pipeline = Pipeline(
+                    [(f"step_{i}", comp) for i, comp in enumerate(component_instances)]
+                )
+
+            elif all(
+                self._registry.get_estimator_by_name(comp).task == "transformation"
+                for comp in components
+            ):
                 # All transformers - use TransformerPipeline
                 from sktime.transformations.compose import TransformerPipeline
-                pipeline = TransformerPipeline([
-                    (f"step_{i}", comp) for i, comp in enumerate(component_instances)
-                ])
-            
+
+                pipeline = TransformerPipeline(
+                    [(f"step_{i}", comp) for i, comp in enumerate(component_instances)]
+                )
+
             else:
                 return {
                     "success": False,
                     "error": "Unsupported pipeline composition type",
-                    "hint": "Currently supports: transformers → forecaster, transformers → classifier/regressor, or transformer chains"
+                    "hint": "Currently supports: transformers → forecaster, transformers → classifier/regressor, or transformer chains",
                 }
-            
+
             # Create a handle for the pipeline
             pipeline_name = " → ".join(components)
             handle_id = self._handle_manager.create_handle(
@@ -433,7 +462,7 @@ class Executor:
                 instance=pipeline,
                 params={"components": components, "params_list": params_list},
             )
-            
+
             return {
                 "success": True,
                 "handle": handle_id,
@@ -441,30 +470,31 @@ class Executor:
                 "components": components,
                 "params_list": params_list,
             }
-        
+
         except Exception as e:
             import traceback
+
             return {
                 "success": False,
                 "error": str(e),
                 "traceback": traceback.format_exc(),
             }
-    
+
     def list_datasets(self) -> List[str]:
         """List available demo datasets."""
         return list(DEMO_DATASETS.keys())
-    
+
     def load_data_source(self, config: Dict[str, Any]) -> Dict[str, Any]:
         """
         Load data from any source (pandas, SQL, file, etc.).
-        
+
         Args:
             config: Data source configuration with 'type' key
                 Examples:
                 - {"type": "pandas", "data": df, "time_column": "date", "target_column": "value"}
                 - {"type": "sql", "connection_string": "...", "query": "...", "time_column": "date"}
                 - {"type": "file", "path": "/path/to/data.csv", "time_column": "date"}
-        
+
         Returns:
             Dictionary with:
             - success: bool
@@ -474,13 +504,13 @@ class Executor:
         """
         try:
             from sktime_mcp.data import DataSourceRegistry
-            
+
             # Create adapter
             adapter = DataSourceRegistry.create_adapter(config)
-            
+
             # Load data
             data = adapter.load()
-            
+
             # Validate
             is_valid, validation_report = adapter.validate(data)
             if not is_valid:
@@ -489,19 +519,19 @@ class Executor:
                     "error": "Data validation failed",
                     "validation": validation_report,
                 }
-            
+
             # Convert to sktime format
             y, X = adapter.to_sktime_format(data)
-            
+
             # Update metadata to reflect the target and used columns
             metadata = adapter.get_metadata().copy()
-            metadata["columns"] = [y.name if hasattr(y, 'name') and y.name else "target"]
+            metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
             if X is not None:
                 metadata["exog_columns"] = list(X.columns)
-            
+
             # Generate handle
             data_handle = f"data_{uuid.uuid4().hex[:8]}"
-            
+
             # Store
             self._data_handles[data_handle] = {
                 "y": y,
@@ -510,15 +540,12 @@ class Executor:
                 "validation": validation_report,
                 "config": config,  # Store config for reference
             }
-            
+
             # Apply auto-formatting if enabled
             if getattr(self, "_auto_format_enabled", True):
                 try:
                     format_result = self.format_data_handle(
-                        data_handle,
-                        auto_infer_freq=True,
-                        fill_missing=True,
-                        remove_duplicates=True
+                        data_handle, auto_infer_freq=True, fill_missing=True, remove_duplicates=True
                     )
                     if format_result["success"]:
                         # Return the NEW handle (formatted)
@@ -534,14 +561,14 @@ class Executor:
                 except Exception as e:
                     logger.warning(f"Auto-formatting failed: {e}")
                     # Continue with unformatted data if formatting fails
-            
+
             return {
                 "success": True,
                 "data_handle": data_handle,
                 "metadata": adapter.get_metadata(),
                 "validation": validation_report,
             }
-        
+
         except Exception as e:
             logger.exception("Error loading data source")
             return {
@@ -549,7 +576,7 @@ class Executor:
                 "error": str(e),
                 "error_type": type(e).__name__,
             }
-    
+
     def format_data_handle(
         self,
         data_handle: str,
@@ -562,78 +589,74 @@ class Executor:
         """
         if data_handle not in self._data_handles:
             return {"success": False, "error": f"Data handle '{data_handle}' not found"}
-        
+
         data_info = self._data_handles[data_handle]
         y = data_info["y"].copy()
         X = data_info["X"].copy() if data_info["X"] is not None else None
-        
+
         changes_made = {
             "frequency_set": False,
             "duplicates_removed": 0,
             "missing_filled": 0,
             "gaps_filled": 0,
         }
-        
+
         # 1. Remove duplicates
         if remove_duplicates and y.index.duplicated().any():
             n_duplicates = y.index.duplicated().sum()
-            y = y[~y.index.duplicated(keep='first')]
+            y = y[~y.index.duplicated(keep="first")]
             if X is not None:
-                X = X[~X.index.duplicated(keep='first')]
+                X = X[~X.index.duplicated(keep="first")]
             changes_made["duplicates_removed"] = n_duplicates
-        
+
         # 2. Sort by index
         y = y.sort_index()
         if X is not None:
             X = X.sort_index()
-        
+
         # 3. Infer and set frequency
         if auto_infer_freq:
             freq = y.index.freq
-            
+
             if freq is None:
                 # Try to infer
                 freq = pd.infer_freq(y.index)
-                
+
                 if freq is None:
                     # Manual inference
                     time_diffs = y.index.to_series().diff().dropna()
                     if len(time_diffs) > 0:
                         most_common_diff = time_diffs.mode()[0]
-                        
+
                         if most_common_diff == pd.Timedelta(days=1):
-                            freq = 'D'
+                            freq = "D"
                         elif most_common_diff == pd.Timedelta(hours=1):
-                            freq = 'h'
+                            freq = "h"
                         elif most_common_diff == pd.Timedelta(minutes=1):
-                            freq = 'min'
+                            freq = "min"
                         elif most_common_diff == pd.Timedelta(seconds=1):
-                            freq = 's'
+                            freq = "s"
                         elif most_common_diff == pd.Timedelta(days=7):
-                            freq = 'W'
+                            freq = "W"
                         elif most_common_diff.days >= 28 and most_common_diff.days <= 31:
-                            freq = 'MS'
+                            freq = "MS"
                         else:
-                            freq = 'D'
-                
+                            freq = "D"
+
                 # Create complete date range
                 if freq:
-                    full_range = pd.date_range(
-                        start=y.index.min(),
-                        end=y.index.max(),
-                        freq=freq
-                    )
-                    
+                    full_range = pd.date_range(start=y.index.min(), end=y.index.max(), freq=freq)
+
                     n_gaps = len(full_range) - len(y)
-                    
+
                     y = y.reindex(full_range)
                     if X is not None:
                         X = X.reindex(full_range)
-                    
+
                     changes_made["gaps_filled"] = n_gaps
                     changes_made["frequency_set"] = True
                     changes_made["frequency"] = freq
-        
+
         # 4. Fill missing values
         if fill_missing and y.isna().any():
             n_missing = y.isna().sum()
@@ -641,16 +664,16 @@ class Executor:
             if X is not None:
                 X = X.ffill().bfill()
             changes_made["missing_filled"] = n_missing
-        
+
         # 5. Set frequency explicitly on index
-        if hasattr(y.index, 'freq') and changes_made.get("frequency"):
+        if hasattr(y.index, "freq") and changes_made.get("frequency"):
             y.index.freq = changes_made["frequency"]
             if X is not None:
                 X.index.freq = changes_made["frequency"]
-        
+
         # Generate new handle
         new_handle = f"data_{uuid.uuid4().hex[:8]}"
-        
+
         # Store formatted data
         self._data_handles[new_handle] = {
             "y": y,
@@ -667,14 +690,14 @@ class Executor:
             "config": data_info.get("config", {}),
             "original_handle": data_handle,
         }
-        
+
         return {
             "success": True,
             "data_handle": new_handle,
             "metadata": self._data_handles[new_handle]["metadata"],
             "changes_made": changes_made,
         }
-    
+
     def fit_predict_with_data(
         self,
         estimator_handle: str,
@@ -683,12 +706,12 @@ class Executor:
     ) -> Dict[str, Any]:
         """
         Fit and predict using a data handle.
-        
+
         Args:
             estimator_handle: Estimator handle from instantiate_estimator
             data_handle: Data handle from load_data_source
             horizon: Forecast horizon
-        
+
         Returns:
             Dictionary with predictions
         """
@@ -698,48 +721,50 @@ class Executor:
                 "error": f"Unknown data handle: {data_handle}",
                 "available_handles": list(self._data_handles.keys()),
             }
-        
+
         data = self._data_handles[data_handle]
         y = data["y"]
         X = data.get("X")
-        
+
         # Fit
         fh = list(range(1, horizon + 1))
         fit_result = self.fit(estimator_handle, y=y, X=X, fh=fh)
         if not fit_result["success"]:
             return fit_result
-        
+
         # Predict
         return self.predict(estimator_handle, fh=fh, X=X)
-    
+
     def list_data_handles(self) -> Dict[str, Any]:
         """
         List all loaded data handles.
-        
+
         Returns:
             Dictionary with list of data handles and their metadata
         """
         handles = []
         for handle_id, data_info in self._data_handles.items():
-            handles.append({
-                "handle": handle_id,
-                "metadata": data_info["metadata"],
-                "validation": data_info["validation"],
-            })
-        
+            handles.append(
+                {
+                    "handle": handle_id,
+                    "metadata": data_info["metadata"],
+                    "validation": data_info["validation"],
+                }
+            )
+
         return {
             "success": True,
             "count": len(handles),
             "handles": handles,
         }
-    
+
     def release_data_handle(self, data_handle: str) -> Dict[str, Any]:
         """
         Release a data handle and free memory.
-        
+
         Args:
             data_handle: Data handle to release
-        
+
         Returns:
             Dictionary with success status
         """

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -60,8 +60,8 @@ from sktime_mcp.composition.validator import get_composition_validator
 # Configure logging to stderr with detailed format
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler()]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
 )
 logger = logging.getLogger(__name__)
 
@@ -75,11 +75,10 @@ def sanitize_for_json(obj):
         return {str(k): sanitize_for_json(v) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple)):
         return [sanitize_for_json(item) for item in obj]
-    elif hasattr(obj, '__dict__') and not isinstance(obj, (str, int, float, bool, type(None))):
+    elif hasattr(obj, "__dict__") and not isinstance(obj, (str, int, float, bool, type(None))):
         return str(obj)
     else:
         return obj
-
 
 
 @server.list_tools()
@@ -185,7 +184,11 @@ async def list_tools() -> List[Tool]:
         ),
         Tool(
             name="fit_predict_async",
-            description="Fit an estimator on a dataset and generate predictions (non-blocking background job)",
+            description=(
+                "Fit an estimator and generate predictions in the background "
+                "(non-blocking). Accepts either a demo dataset name or a "
+                "data_handle from load_data_source."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -195,7 +198,11 @@ async def list_tools() -> List[Tool]:
                     },
                     "dataset": {
                         "type": "string",
-                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                        "description": "Demo dataset name: airline, sunspots, lynx, etc.",
+                    },
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Data handle from load_data_source (for custom data)",
                     },
                     "horizon": {
                         "type": "integer",
@@ -203,7 +210,7 @@ async def list_tools() -> List[Tool]:
                         "default": 12,
                     },
                 },
-                "required": ["estimator_handle", "dataset"],
+                "required": ["estimator_handle"],
             },
         ),
         Tool(
@@ -471,7 +478,7 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
     """Handle tool calls."""
     logger.info(f"=== Tool Call: {name} ===")
     logger.info(f"Arguments: {json.dumps(arguments, indent=2)}")
-    
+
     try:
         if name == "list_estimators":
             result = list_estimators_tool(
@@ -546,8 +553,9 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
         elif name == "fit_predict_async":
             result = fit_predict_async_tool(
                 arguments["estimator_handle"],
-                arguments["dataset"],
-                arguments.get("horizon", 12),
+                dataset=arguments.get("dataset"),
+                data_handle=arguments.get("data_handle"),
+                horizon=arguments.get("horizon", 12),
             )
         elif name == "check_job_status":
             result = check_job_status_tool(arguments["job_id"])
@@ -564,13 +572,13 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             result = cleanup_old_jobs_tool(arguments.get("max_age_hours", 24))
         else:
             result = {"error": f"Unknown tool: {name}"}
-        
+
         logger.info(f"=== Result for {name} ===")
-        
+
         # Sanitize result for JSON serialization
         sanitized_result = sanitize_for_json(result)
         logger.info(f"{json.dumps(sanitized_result, indent=2, default=str)}")
-        
+
         return [TextContent(type="text", text=json.dumps(sanitized_result, indent=2, default=str))]
     except Exception as e:
         logger.exception(f"Error in tool {name}")

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -4,9 +4,12 @@ fit_predict tool for sktime MCP.
 Executes complete forecasting workflows.
 """
 
+import logging
 from typing import Any, Dict, List, Optional, Union
 
 from sktime_mcp.runtime.executor import get_executor
+
+logger = logging.getLogger(__name__)
 
 
 def fit_predict_tool(
@@ -16,18 +19,18 @@ def fit_predict_tool(
 ) -> Dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
-    
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
-    
+
     Returns:
         Dictionary with:
         - success: bool
         - predictions: Forecast values
         - horizon: Number of steps predicted
-    
+
     Example:
         >>> fit_predict_tool("est_abc123", "airline", horizon=12)
         {
@@ -46,11 +49,11 @@ def fit_tool(
 ) -> Dict[str, Any]:
     """
     Fit an estimator on a dataset.
-    
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset
-    
+
     Returns:
         Dictionary with success status
     """
@@ -58,7 +61,7 @@ def fit_tool(
     data_result = executor.load_dataset(dataset)
     if not data_result["success"]:
         return data_result
-    
+
     return executor.fit(
         estimator_handle,
         y=data_result["data"],
@@ -72,11 +75,11 @@ def predict_tool(
 ) -> Dict[str, Any]:
     """
     Generate predictions from a fitted estimator.
-    
+
     Args:
         estimator_handle: Handle of a fitted estimator
         horizon: Forecast horizon
-    
+
     Returns:
         Dictionary with predictions
     """
@@ -88,7 +91,7 @@ def predict_tool(
 def list_datasets_tool() -> Dict[str, Any]:
     """
     List available demo datasets.
-    
+
     Returns:
         Dictionary with list of dataset names
     """
@@ -101,40 +104,68 @@ def list_datasets_tool() -> Dict[str, Any]:
 
 def fit_predict_async_tool(
     estimator_handle: str,
-    dataset: str,
+    dataset: Optional[str] = None,
+    data_handle: Optional[str] = None,
     horizon: int = 12,
 ) -> Dict[str, Any]:
     """
     Execute a fit-predict workflow in the background (non-blocking).
-    
+
     This tool schedules the training as a background job and returns immediately
     with a job_id. Use check_job_status to monitor progress.
-    
+
+    Accepts either a demo dataset name or a data_handle from load_data_source.
+    Exactly one of 'dataset' or 'data_handle' must be provided.
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
+        data_handle: Handle from load_data_source (for custom data)
         horizon: Forecast horizon (default: 12)
-    
+
     Returns:
         Dictionary with:
         - success: bool
         - job_id: Job ID for tracking progress
         - message: Information about the job
-    
+
     Example:
-        >>> fit_predict_async_tool("est_abc123", "airline", horizon=12)
+        >>> fit_predict_async_tool("est_abc123", dataset="airline", horizon=12)
+        {
+            "success": True,
+            "job_id": "abc-123-def-456",
+            "message": "Training job started. Use check_job_status to monitor progress."
+        }
+
+        >>> fit_predict_async_tool("est_abc123", data_handle="data_xyz", horizon=6)
         {
             "success": True,
             "job_id": "abc-123-def-456",
             "message": "Training job started. Use check_job_status to monitor progress."
         }
     """
+    # exactly one of dataset or data_handle must be provided
+    if dataset and data_handle:
+        return {
+            "success": False,
+            "error": "Provide either 'dataset' or 'data_handle', not both.",
+        }
+
+    if not dataset and not data_handle:
+        return {
+            "success": False,
+            "error": (
+                "Either 'dataset' (demo name like 'airline') or "
+                "'data_handle' (from load_data_source) is required."
+            ),
+        }
+
     import asyncio
     from sktime_mcp.runtime.jobs import get_job_manager
-    
+
     executor = get_executor()
     job_manager = get_job_manager()
-    
+
     # Get estimator info
     try:
         handle_info = executor._handle_manager.get_info(estimator_handle)
@@ -142,17 +173,20 @@ def fit_predict_async_tool(
     except Exception as e:
         logger.warning(f"Could not get estimator name: {e}")
         estimator_name = "Unknown"
-    
+
+    # label for job tracking
+    source_label = dataset if dataset else data_handle
+
     # Create job
     job_id = job_manager.create_job(
         job_type="fit_predict",
         estimator_handle=estimator_handle,
         estimator_name=estimator_name,
-        dataset_name=dataset,
+        dataset_name=source_label,
         horizon=horizon,
         total_steps=3,
     )
-    
+
     # Schedule the async coroutine on the event loop
     try:
         loop = asyncio.get_event_loop()
@@ -160,17 +194,21 @@ def fit_predict_async_tool(
         # No event loop in current thread, create one
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-    
+
     # Schedule the coroutine (non-blocking!)
-    coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
+    coro = executor.fit_predict_async(
+        estimator_handle, dataset, horizon, job_id, data_handle=data_handle
+    )
     asyncio.run_coroutine_threadsafe(coro, loop)
-    
+
     return {
         "success": True,
         "job_id": job_id,
-        "message": f"Training job started for {estimator_name} on {dataset}. Use check_job_status('{job_id}') to monitor progress.",
+        "message": (
+            f"Training job started for {estimator_name} on {source_label}. "
+            f"Use check_job_status('{job_id}') to monitor progress."
+        ),
         "estimator": estimator_name,
-        "dataset": dataset,
+        "dataset": source_label,
         "horizon": horizon,
     }
-

--- a/tests/test_async_data_handles.py
+++ b/tests/test_async_data_handles.py
@@ -1,0 +1,111 @@
+"""
+Test async fit_predict with custom data handles (Issue #7).
+
+Verifies that fit_predict_async_tool supports both demo datasets
+and custom data handles loaded via load_data_source.
+"""
+
+import sys
+import asyncio
+import unittest
+
+sys.path.insert(0, "src")
+
+from sktime_mcp.tools.fit_predict import fit_predict_async_tool
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.runtime.jobs import get_job_manager, JobStatus
+
+
+class TestAsyncWithDataset(unittest.TestCase):
+    """Verify existing demo dataset path still works."""
+
+    def test_async_with_dataset(self):
+        """Demo dataset should return a job_id."""
+        executor = get_executor()
+
+        # instantiate a simple forecaster
+        est = executor.instantiate("NaiveForecaster")
+        self.assertTrue(est["success"])
+        handle = est["handle"]
+
+        result = fit_predict_async_tool(handle, dataset="airline", horizon=6)
+        self.assertTrue(result["success"])
+        self.assertIn("job_id", result)
+        self.assertEqual(result["dataset"], "airline")
+
+
+class TestAsyncWithDataHandle(unittest.TestCase):
+    """Verify new custom data handle path works."""
+
+    def test_async_with_data_handle(self):
+        """Custom data handle should return a job_id."""
+        executor = get_executor()
+
+        # load a demo dataset through the normal code path so we
+        # have a real data handle to work with
+        data_result = executor.load_dataset("airline")
+        self.assertTrue(data_result["success"])
+
+        # manually store it as a data handle (same way load_data_source does)
+        test_handle_id = "test_async_handle"
+        executor._data_handles[test_handle_id] = {
+            "y": data_result["data"],
+            "X": data_result.get("exog"),
+            "metadata": {"source": "test"},
+            "validation": {"valid": True},
+        }
+
+        est = executor.instantiate("NaiveForecaster")
+        handle = est["handle"]
+
+        result = fit_predict_async_tool(handle, data_handle=test_handle_id, horizon=6)
+        self.assertTrue(result["success"])
+        self.assertIn("job_id", result)
+        self.assertEqual(result["dataset"], test_handle_id)
+
+        # cleanup
+        del executor._data_handles[test_handle_id]
+
+
+class TestAsyncValidation(unittest.TestCase):
+    """Verify input validation for mutually exclusive params."""
+
+    def test_both_provided_error(self):
+        """Providing both dataset and data_handle should fail."""
+        result = fit_predict_async_tool(
+            "est_fake",
+            dataset="airline",
+            data_handle="data_xyz",
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("not both", result["error"])
+
+    def test_neither_provided_error(self):
+        """Providing neither dataset nor data_handle should fail."""
+        result = fit_predict_async_tool("est_fake")
+        self.assertFalse(result["success"])
+        self.assertIn("required", result["error"])
+
+    def test_invalid_data_handle(self):
+        """Invalid data handle should be caught at the executor level."""
+        executor = get_executor()
+        job_manager = get_job_manager()
+
+        est = executor.instantiate("NaiveForecaster")
+        handle = est["handle"]
+
+        # run the async method directly to test executor-level validation
+        result = asyncio.run(
+            executor.fit_predict_async(
+                handle,
+                dataset=None,
+                horizon=6,
+                data_handle="nonexistent_handle",
+            )
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("Unknown data handle", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Reference Issues/PRs

Fixes #7

### What does this implement/fix? Explain your changes.

Updated `fit_predict_async` to support custom `data_handle` inputs alongside demo datasets. Previously it only worked with built-in datasets like "airline" now users can also train models on their own data in the background.

Changes:
- Added optional `data_handle` param to `fit_predict_async_tool` in `fit_predict.py`
- Updated `Executor.fit_predict_async` to skip `load_dataset` when a `data_handle` is provided
- Updated server schema and dispatch to pass the new parameter
- Also fixed a pre-existing `logger` undefined bug in `fit_predict.py`

### Does your contribution introduce a new dependency? If yes, which one?

No

### What should a reviewer concentrate their feedback on?

- The branching logic in `Executor.fit_predict_async` (Step 1) whether the data_handle vs dataset flow looks clean
- Input validation: exactly one of `dataset` or `data_handle` must be provided

### Any other comments?

Added 5 test cases covering both paths and error handling. All 23 tests pass with no regressions.

#### PR checklist

- [x] I've added unit tests and made sure they pass locally.
