### PR TITLE
[ENH] Add async data loading tool (#6)

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -550,6 +550,151 @@ class Executor:
                 "error_type": type(e).__name__,
             }
     
+    async def load_data_source_async(
+        self,
+        config: Dict[str, Any],
+        job_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Async version of load_data_source with job tracking.
+        
+        Runs data loading in the background without blocking the
+        MCP server. Progress is tracked via the JobManager.
+        
+        Args:
+            config: Data source configuration
+            job_id: Optional job ID (created if not provided)
+        
+        Returns:
+            Dictionary with data_handle and metadata
+        """
+        source_type = config.get("type", "unknown")
+        
+        if job_id is None:
+            job_id = self._job_manager.create_job(
+                job_type="data_loading",
+                estimator_handle="",
+                dataset_name=source_type,
+                total_steps=3,
+            )
+        
+        try:
+            self._job_manager.update_job(
+                job_id, status=JobStatus.RUNNING
+            )
+            
+            # Step 1: Load raw data
+            self._job_manager.update_job(
+                job_id,
+                completed_steps=0,
+                current_step=f"Loading data from '{source_type}'..."
+            )
+            await asyncio.sleep(0.01)
+            
+            from sktime_mcp.data import DataSourceRegistry
+            
+            loop = asyncio.get_event_loop()
+            adapter = DataSourceRegistry.create_adapter(config)
+            data = await loop.run_in_executor(
+                None, adapter.load
+            )
+            
+            # Step 2: Validate
+            self._job_manager.update_job(
+                job_id,
+                completed_steps=1,
+                current_step="Validating data..."
+            )
+            await asyncio.sleep(0.01)
+            
+            is_valid, validation_report = adapter.validate(data)
+            if not is_valid:
+                self._job_manager.update_job(
+                    job_id,
+                    status=JobStatus.FAILED,
+                    errors=["Data validation failed"]
+                )
+                return {
+                    "success": False,
+                    "error": "Data validation failed",
+                    "validation": validation_report,
+                }
+            
+            # Step 3: Convert, store, and format
+            self._job_manager.update_job(
+                job_id,
+                completed_steps=2,
+                current_step="Converting to sktime format..."
+            )
+            await asyncio.sleep(0.01)
+            
+            y, X = adapter.to_sktime_format(data)
+            
+            metadata = adapter.get_metadata().copy()
+            metadata["columns"] = [
+                y.name if hasattr(y, 'name') and y.name else "target"
+            ]
+            if X is not None:
+                metadata["exog_columns"] = list(X.columns)
+            
+            data_handle = f"data_{uuid.uuid4().hex[:8]}"
+            
+            self._data_handles[data_handle] = {
+                "y": y,
+                "X": X,
+                "metadata": metadata,
+                "validation": validation_report,
+                "config": config,
+            }
+            
+            # auto-format if enabled
+            if getattr(self, "_auto_format_enabled", True):
+                try:
+                    format_result = self.format_data_handle(
+                        data_handle,
+                        auto_infer_freq=True,
+                        fill_missing=True,
+                        remove_duplicates=True
+                    )
+                    if format_result["success"]:
+                        data_handle = format_result["data_handle"]
+                        metadata = format_result["metadata"]
+                except Exception as e:
+                    logger.warning(f"Auto-formatting failed: {e}")
+            
+            result = {
+                "success": True,
+                "data_handle": data_handle,
+                "metadata": metadata,
+                "validation": validation_report,
+            }
+            
+            # mark completed with the data_handle in the result
+            self._job_manager.update_job(
+                job_id,
+                status=JobStatus.COMPLETED,
+                completed_steps=3,
+                current_step="Completed",
+                result=result
+            )
+            
+            return result
+        
+        except Exception as e:
+            logger.exception(
+                f"Error in async data loading for job {job_id}"
+            )
+            self._job_manager.update_job(
+                job_id,
+                status=JobStatus.FAILED,
+                errors=[str(e)]
+            )
+            return {
+                "success": False,
+                "error": str(e),
+                "job_id": job_id,
+            }
+    
     def format_data_handle(
         self,
         data_handle: str,

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -39,6 +39,7 @@ from sktime_mcp.tools.fit_predict import (
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.data_tools import (
     load_data_source_tool,
+    load_data_source_async_tool,
     list_data_sources_tool,
     fit_predict_with_data_tool,
     list_data_handles_tool,
@@ -294,6 +295,28 @@ async def list_tools() -> List[Tool]:
             },
         ),
         Tool(
+            name="load_data_source_async",
+            description=(
+                "Load data from any source in the background "
+                "(non-blocking). Returns a job_id to track "
+                "progress. The data_handle is available in "
+                "the job result when completed."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "type": "object",
+                        "description": (
+                            "Data source configuration. "
+                            "Same format as load_data_source."
+                        ),
+                    },
+                },
+                "required": ["config"],
+            },
+        ),
+        Tool(
             name="list_data_sources",
             description="List all available data source types and their descriptions",
             inputSchema={"type": "object", "properties": {}},
@@ -520,6 +543,10 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             )
         elif name == "load_data_source":
             result = load_data_source_tool(arguments["config"])
+        elif name == "load_data_source_async":
+            result = load_data_source_async_tool(
+                arguments["config"]
+            )
         elif name == "list_data_sources":
             result = list_data_sources_tool()
         elif name == "fit_predict_with_data":

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -4,8 +4,11 @@ Data loading tools for sktime MCP.
 Provides tools for loading data from various sources.
 """
 
+import logging
 from typing import Any, Dict
 from sktime_mcp.runtime.executor import get_executor
+
+logger = logging.getLogger(__name__)
 
 
 def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -143,3 +146,72 @@ def release_data_handle_tool(data_handle: str) -> Dict[str, Any]:
     """
     executor = get_executor()
     return executor.release_data_handle(data_handle)
+
+
+def load_data_source_async_tool(
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Load data from any source in the background (non-blocking).
+
+    Schedules the data loading as a background job and returns
+    immediately with a job_id. Use check_job_status to monitor
+    progress and retrieve the data_handle when done.
+
+    Args:
+        config: Data source configuration (same as load_data_source)
+
+    Returns:
+        Dictionary with:
+        - success: bool
+        - job_id: Job ID for tracking progress
+        - message: Information about the job
+
+    Example:
+        >>> load_data_source_async_tool({
+        ...     "type": "file",
+        ...     "path": "/path/to/large_data.csv",
+        ...     "time_column": "date",
+        ...     "target_column": "value"
+        ... })
+        {
+            "success": True,
+            "job_id": "abc-123-def-456",
+            "message": "Data loading job started..."
+        }
+    """
+    import asyncio
+    from sktime_mcp.runtime.jobs import get_job_manager
+
+    executor = get_executor()
+    job_manager = get_job_manager()
+
+    source_type = config.get("type", "unknown")
+
+    # create a background job for data loading
+    job_id = job_manager.create_job(
+        job_type="data_loading",
+        estimator_handle="",
+        dataset_name=source_type,
+        total_steps=3,  # load, validate, format
+    )
+
+    # schedule on event loop
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    coro = executor.load_data_source_async(config, job_id)
+    asyncio.run_coroutine_threadsafe(coro, loop)
+
+    return {
+        "success": True,
+        "job_id": job_id,
+        "message": (
+            f"Data loading job started for source type '{source_type}'. "
+            f"Use check_job_status('{job_id}') to monitor progress."
+        ),
+        "source_type": source_type,
+    }

--- a/tests/test_async_data_loading.py
+++ b/tests/test_async_data_loading.py
@@ -1,0 +1,123 @@
+"""
+Test async data loading tool (Issue #6).
+
+Verifies that load_data_source_async_tool schedules data loading
+as a background job and resolves to a valid data_handle.
+"""
+
+import sys
+import asyncio
+import unittest
+
+sys.path.insert(0, "src")
+
+from sktime_mcp.tools.data_tools import load_data_source_async_tool
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.runtime.jobs import get_job_manager, JobStatus
+
+
+class TestAsyncDataLoadingTool(unittest.TestCase):
+    """Test the tool-level function returns a job_id."""
+
+    def test_returns_job_id(self):
+        """Async load should return a job_id immediately."""
+        config = {
+            "type": "pandas",
+            "data": {"date": ["2020-01", "2020-02", "2020-03"],
+                     "value": [10, 20, 30]},
+            "time_column": "date",
+            "target_column": "value",
+        }
+        result = load_data_source_async_tool(config)
+        self.assertTrue(result["success"])
+        self.assertIn("job_id", result)
+        self.assertEqual(result["source_type"], "pandas")
+
+
+class TestAsyncDataLoadingExecutor(unittest.TestCase):
+    """Test the executor-level async method directly."""
+
+    def test_async_load_completes(self):
+        """Async load should complete and produce a data_handle."""
+        executor = get_executor()
+
+        config = {
+            "type": "pandas",
+            "data": {"date": ["2020-01", "2020-02", "2020-03"],
+                     "value": [10, 20, 30]},
+            "time_column": "date",
+            "target_column": "value",
+        }
+        result = asyncio.run(
+            executor.load_data_source_async(config)
+        )
+        self.assertTrue(result["success"])
+        self.assertIn("data_handle", result)
+
+    def test_job_resolves_to_data_handle(self):
+        """Job result should contain the data_handle."""
+        executor = get_executor()
+        job_manager = get_job_manager()
+
+        config = {
+            "type": "pandas",
+            "data": {"date": ["2020-01", "2020-02", "2020-03"],
+                     "value": [10, 20, 30]},
+            "time_column": "date",
+            "target_column": "value",
+        }
+        result = asyncio.run(
+            executor.load_data_source_async(config)
+        )
+
+        # find the most recent data_loading job
+        jobs = job_manager.list_jobs()
+        data_jobs = [
+            j for j in jobs if j.job_type == "data_loading"
+        ]
+        self.assertTrue(len(data_jobs) > 0)
+
+        latest = data_jobs[0]
+        self.assertEqual(latest.status, JobStatus.COMPLETED)
+        self.assertIsNotNone(latest.result)
+        self.assertIn("data_handle", latest.result)
+
+    def test_data_handle_usable(self):
+        """Data handle from async load should work for fit_predict."""
+        executor = get_executor()
+
+        config = {
+            "type": "pandas",
+            "data": {"date": ["2020-01", "2020-02", "2020-03"],
+                     "value": [10, 20, 30]},
+            "time_column": "date",
+            "target_column": "value",
+        }
+        result = asyncio.run(
+            executor.load_data_source_async(config)
+        )
+        handle = result["data_handle"]
+
+        # verify the handle exists
+        self.assertIn(
+            handle, executor._data_handles
+        )
+
+
+class TestAsyncDataLoadingErrors(unittest.TestCase):
+    """Test error handling for async data loading."""
+
+    def test_invalid_config(self):
+        """Bad config should fail the job."""
+        executor = get_executor()
+
+        config = {"type": "nonexistent_source"}
+
+        result = asyncio.run(
+            executor.load_data_source_async(config)
+        )
+        self.assertFalse(result["success"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Reference Issues/PRs

Fixes #6

### What does this implement/fix? Explain your changes.

Added `load_data_source_async` an async version of `load_data_source` that runs data loading as a background job instead of blocking the MCP server.

Previously, loading a large CSV or querying a slow database would block the server until done. Now it returns a `job_id` immediately, and the user can check progress via `check_job_status`.

Changes:
- Added `load_data_source_async_tool` in `data_tools.py`.
- Added `Executor.load_data_source_async` with 3-step job tracking (load → validate → format).
- The completed job result contains the `data_handle`, so the user can retrieve it from `check_job_status`.
- Added server schema and dispatch for the new tool.
- Used `job_type="data_loading"` to differentiate from `fit_predict` jobs.

### Does your contribution introduce a new dependency? If yes, which one?

No

### What should a reviewer concentrate their feedback on?

- The 3-step async flow in `Executor.load_data_source_async` whether the load/validate/format split makes sense
- Whether `estimator_handle=""` is acceptable for data-only jobs (no estimator involved)

### Any other comments?

Added 5 test cases covering success path, job resolution, data handle usability, and error handling. All 23 tests pass with no regressions.

#### PR checklist

- [x] I've added unit tests and made sure they pass locally.
