### PR TITLE
Fix NameError caused by undefined logger in fit_predict_async_tool.

### DIFF
--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -5,8 +5,12 @@ Executes complete forecasting workflows.
 """
 
 from typing import Any, Dict, List, Optional, Union
+import logging
 
 from sktime_mcp.runtime.executor import get_executor
+
+# ✅ Logger added here
+logger = logging.getLogger(__name__)
 
 
 def fit_predict_tool(
@@ -173,4 +177,3 @@ def fit_predict_async_tool(
         "dataset": dataset,
         "horizon": horizon,
     }
-


### PR DESCRIPTION
## Problem

The function calls:

```python
logger.warning(...)
```

However, `logger` is not defined or imported in the file, which results in a runtime error when the exception handling path is triggered.

## Fix

Added logger initialization:

```python
import logging
logger = logging.getLogger(__name__)
```

## Impact

* Prevents runtime errors in error-handling scenarios
* Ensures proper logging behavior

Fixes #26
