### PR TITLE
[ENH] Add type validation for params in instantiate_estimator (#3)

### DIFF
--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -8,6 +8,48 @@ from typing import Any, Dict, List, Optional
 
 from sktime_mcp.runtime.executor import get_executor
 from sktime_mcp.runtime.handles import get_handle_manager
+from sktime_mcp.registry.interface import get_registry
+
+
+def _is_safe_param_value(value: Any) -> bool:
+    """Return whether a parameter value is JSON-like and safe to pass through."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True
+
+    if isinstance(value, (list, tuple)):
+        return all(_is_safe_param_value(v) for v in value)
+
+    if isinstance(value, dict):
+        return all(isinstance(k, str) and _is_safe_param_value(v) for k, v in value.items())
+
+    return False
+
+
+def _validate_instantiate_params(estimator: str, params: Optional[Dict[str, Any]]) -> None:
+    """Validate estimator params before instantiation."""
+    if params is None:
+        return
+
+    if not isinstance(params, dict):
+        raise TypeError("params must be a dict or None")
+
+    for key, value in params.items():
+        if not isinstance(key, str):
+            raise TypeError("all params keys must be strings")
+        if not _is_safe_param_value(value):
+            raise TypeError(f"unsupported parameter type for key '{key}'")
+
+    node = get_registry().get_estimator_by_name(estimator)
+    if node is None:
+        return
+
+    valid_keys = set(node.hyperparameters.keys())
+    if not valid_keys:
+        return
+
+    unknown = sorted(set(params.keys()) - valid_keys)
+    if unknown:
+        raise ValueError(f"Unknown parameter(s) for {estimator}: {unknown}")
 
 
 def instantiate_estimator_tool(
@@ -37,6 +79,8 @@ def instantiate_estimator_tool(
             "params": {"order": [1, 1, 1]}
         }
     """
+    _validate_instantiate_params(estimator, params)
+
     executor = get_executor()
     return executor.instantiate(estimator, params)
 

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -1,0 +1,39 @@
+"""Tests for instantiate parameter validation."""
+
+import sys
+
+import pytest
+
+sys.path.insert(0, "src")
+
+from sktime_mcp.registry.interface import get_registry
+from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+
+
+def _requires_naive_forecaster() -> None:
+    """Skip test when NaiveForecaster is unavailable in registry."""
+    node = get_registry().get_estimator_by_name("NaiveForecaster")
+    if node is None:
+        pytest.skip("NaiveForecaster not available in current sktime registry")
+
+
+def test_rejects_non_dict_params() -> None:
+    """params must be dict or None."""
+    with pytest.raises(TypeError, match="params must be a dict or None"):
+        instantiate_estimator_tool("NaiveForecaster", params="bad")
+
+
+def test_rejects_unsafe_param_value() -> None:
+    """Unsafe/unsupported param value types should fail validation."""
+    _requires_naive_forecaster()
+
+    with pytest.raises(TypeError, match="unsupported parameter type"):
+        instantiate_estimator_tool("NaiveForecaster", params={"strategy": object()})
+
+
+def test_rejects_unknown_param_key() -> None:
+    """Unknown parameter names should fail validation."""
+    _requires_naive_forecaster()
+
+    with pytest.raises(ValueError, match=r"Unknown parameter\(s\)"):
+        instantiate_estimator_tool("NaiveForecaster", params={"not_a_real_param": 1})


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3

---

#### What does this implement/fix? 

Adds pre-instantiation parameter validation to `instantiate_estimator_tool`
in `src/sktime_mcp/tools/instantiate.py`.

Changes:
- `_is_safe_param_value()` — recursively validates values are JSON-like
  primitives (`str`, `int`, `float`, `bool`, `None`, `list`, `tuple`,
  nested `dict`). Rejects callables, classes, modules, and arbitrary objects.
- `_validate_instantiate_params()` — enforces:
  - `params` is `None` or a `dict` (raises `TypeError` otherwise)
  - All keys are strings (raises `TypeError` otherwise)
  - All values pass `_is_safe_param_value()` (raises `TypeError` otherwise)
  - Keys are validated against the estimator's known hyperparameters from
    `node.hyperparameters.keys()` (raises `ValueError` for unknown keys)
- Validation is called at the top of `instantiate_estimator_tool()` before
  any executor call.

**Tests added** in `tests/test_param_validation.py`:
- `test_rejects_non_dict_params`
- `test_rejects_unsafe_param_value`
- `test_rejects_unknown_param_key`

![Tests passing]
<img width="911" height="308" alt="Screenshot from 2026-04-03 18-59-40" src="https://github.com/user-attachments/assets/e1187c4d-1790-42ca-94c4-cd3e17b4c7b2" />


---




#### PR checklist

- [x] `params` type validation added (`dict` or `None`)
- [x] Unsafe complex-object guard added
- [x] Unknown key validation added via registry
- [x] Unit tests added and pass locally (3 passed in 1.86s)
- [x] Backward-compatible — valid existing usage unaffected
