### PR TITLE
Add Makefile for standardized local checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: check test lint format help format-fix
+
+help:
+	@echo "Available commands:"
+	@echo "  make check      - Run all CI checks (format check, lint, test)"
+	@echo "  make lint       - Run ruff linter"
+	@echo "  make format     - Run black formatter (check only)"
+	@echo "  make test       - Run pytest"
+	@echo "  make format-fix - Auto-fix formatting and fixable lint issues"
+
+check: format lint test
+
+format:
+	black --check .
+
+lint:
+	ruff check .
+
+test:
+	pytest
+
+format-fix:
+	black .
+	ruff check --fix .

--- a/README.md
+++ b/README.md
@@ -348,3 +348,25 @@ sktime_mcp/
 ```bash
 pytest tests/
 ```
+
+## Local Quality Checks
+
+Run standardized local checks before raising a PR:
+
+```bash
+make check
+```
+
+Auto-fix formatting and fixable lint issues:
+
+```bash
+make format-fix
+```
+
+If `make` is unavailable (common on Windows), run the equivalent commands:
+
+```bash
+python -m black --check .
+python -m ruff check .
+python -m pytest
+```

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -35,6 +35,28 @@ python -m sktime_mcp.server
 pytest
 ```
 
+## Standard Local Checks
+
+From the repo root:
+
+```bash
+make check
+```
+
+Auto-fix formatting and fixable lint issues:
+
+```bash
+make format-fix
+```
+
+If `make` is unavailable (common on Windows), run:
+
+```bash
+python -m black --check .
+python -m ruff check .
+python -m pytest
+```
+
 ## Project Layout
 
 - `src/sktime_mcp/server.py` MCP entry point and tool router


### PR DESCRIPTION
#### What does this implement
This PR standardizes local developer checks by adding a root `Makefile` and documenting in it `README.md`, `docs/dev-guide.md` , for how to ue it

Changes included:
1. Added `Makefile` targets for local quality workflows:
  - `make help`
  - `make check` (format check + lint + tests)
  - `make format`
  - `make lint`
  - `make test`
  - `make format-fix`

2. Updated `README.md` with a **Local Quality Checks** section.
3. Updated `docs/dev-guide.md` with a **Standard Local Checks** section.
4. Documented Windows fallback commands when `make` is unavailable:
  - `python -m black --check .`
  - `python -m ruff check .`
  - `python -m pytest`

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependency is introduced.

#### What should a reviewer concentrate their feedback on?
- Correctness and clarity of `Makefile` target behavior.
- Consistency between `Makefile`, `README.md`, and `docs/dev-guide.md`.
- Whether the documented workflow is clear for Linux/macOS and Windows contributors.

#### Any other comments?
This PR is focused on developer experience with change in the documentation 
No runtime/package behavior is changed.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.

Currently when the command `make check` is used in the `Linux` environment currently reports pre-existing repo formatting issues.
<img width="1854" height="177" alt="image" src="https://github.com/user-attachments/assets/e7ee15af-6d4d-4797-9b4c-b46e6c5d686b" />

Formatting/lint failures are pre-existing in the repo. They can be addressed by running \make format-fix`; I plan to open a separate follow-up PR for those repo-wide formatting changes.`

the test cases ran locally pass
<img width="1734" height="178" alt="image" src="https://github.com/user-attachments/assets/77106dc3-4b60-4823-84bc-644c8573f7a8" />
