### PR TITLE
[FIX] Explicitly include capability tags in list_estimators summary return

### DIFF
--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -49,12 +49,13 @@ class EstimatorNode:
             "docstring": self.docstring[:500] if self.docstring else None, # L-1: Truncate docstring to 500 characters, we can also try summarization
         }
     
-    def to_summary(self) -> Dict[str, str]:
+    def to_summary(self) -> Dict[str, Any]:
         """Return a minimal summary for list operations."""
         return {
             "name": self.name,
             "task": self.task,
             "module": self.module,
+            "tags": self.tags,
         }
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
fixes #43 

#### What does this implement/fix? Explain your changes.
Because `sktime_mcp.tools.list_estimators` uses `to_summary()` from the registry interface, the resulting JSON array strictly included only `name`, `task`, and `module`. This stripped away all capability tags.

This PR updates `to_summary()` to explicitly include `"tags": self.tags`. It also updates the typing of the method from `Dict[str, str]` to `Dict[str, Any]` to safely return the tag sets.

#### Does your contribution introduce a new dependency? If yes, which one?
No.
