### PR TITLE
feat: add load_model tool for resolving trained models

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -28,6 +28,7 @@ from sktime_mcp.tools.instantiate import (
     instantiate_pipeline_tool,
     release_handle_tool,
     list_handles_tool,
+    load_model_tool,
 )
 from sktime_mcp.tools.fit_predict import (
     fit_predict_tool,
@@ -473,6 +474,20 @@ async def list_tools() -> List[Tool]:
             },
         ),
         Tool(
+            name="load_model",
+            description="Load a saved sktime model from a local path and register it for use",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the saved model directory",
+                    },
+                },
+                "required": ["path"],
+            },
+        ),
+        Tool(
             name="cleanup_old_jobs",
             description="Remove jobs older than specified hours",
             inputSchema={
@@ -589,6 +604,8 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             result = delete_job_tool(arguments["job_id"])
         elif name == "cleanup_old_jobs":
             result = cleanup_old_jobs_tool(arguments.get("max_age_hours", 24))
+        elif name == "load_model":
+            result = load_model_tool(arguments["path"])
         else:
             result = {"error": f"Unknown tool: {name}"}
         

--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -249,3 +249,57 @@ def list_handles_tool() -> Dict[str, Any]:
         "handles": handles,
         "count": len(handles),
     }
+
+
+def load_model_tool(path: str) -> Dict[str, Any]:
+    """
+    Load a saved model from disk and register its handle.
+
+    Args:
+        path: Path to the saved model directory.
+
+    Returns:
+        Dictionary with success status and the new handle.
+    """
+    import os
+
+    if not os.path.exists(path):
+        return {
+            "success": False,
+            "error": f"Path does not exist: {path}",
+        }
+
+    try:
+        from sktime.utils.mlflow_sktime import load_model
+    except ImportError:
+        return {
+            "success": False,
+            "error": "The 'mlflow' package is required to load saved models. Please install it with: pip install sktime[mlflow]",
+        }
+
+    try:
+        instance = load_model(path)
+        estimator_name = type(instance).__name__
+
+        handle_manager = get_handle_manager()
+        handle_id = handle_manager.create_handle(
+            estimator_name=estimator_name,
+            instance=instance,
+            params={},
+            metadata={"source": "loaded", "path": path},
+        )
+        
+        handle_manager.mark_fitted(handle_id)
+
+        return {
+            "success": True,
+            "handle": handle_id,
+            "estimator": estimator_name,
+            "path": path,
+            "message": f"Successfully loaded {estimator_name}",
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": f"Failed to load model: {str(e)}",
+        }


### PR DESCRIPTION
*Note: I realize #32 was just assigned to someone else, but I had already finished these changes locally before it was assigned because no  contributor asked to take upon this issue at that time. I figured I would put the PR up just in case having it done is helpful to the project.*
#### Reference Issues/PRs
Closes #32 
#### What does this implement/fix? Explain your changes.
This implements a new `load_model` tool to allow LLMs to restore previously trained estimators from a local directory or URI without having to re-fit the data from scratch.
**Implementation Details:**
- Created `load_model_tool` in `src/sktime_mcp/tools/instantiate.py`.
- Gracefully handles the optional `mlflow` dependency. If `mlflow` is missing, it returns a clear error message instructing the user/LLM to run `pip install sktime[mlflow]` rather than crashing the server.
- Registers the loaded estimator instance dynamically back into the `HandleManager` marking it as fitted, allowing the LLM to immediately follow up with a `predict` call using the newly restored handle.
- Added the tool routing logic to `call_tool` in `server.py`.
#### Does your contribution introduce a new dependency? If yes, which one?
No new hard dependencies. `mlflow` is utilized as an optional extension (`sktime[mlflow]`), strictly matching `sktime`'s existing dependency strategy.

#### Demo Video
[load_model.webm](https://github.com/user-attachments/assets/d36c8be5-8736-4ec5-be95-2bd534db799a)
