### PR TITLE
[BUG] Remove Python 3.9 from CI matrix - mcp not compatible (#39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "MCP (Model Context Protocol) layer for sktime - Registry-Driven for LLMs"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "sktime-mcp contributors" }
 ]
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -95,7 +94,7 @@ include = [
 
 [tool.black]
 line-length = 100
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #39

### What does this implement/fix? Explain your changes.

The `mcp>=1.0.0` dependency requires Python >= 3.10, so the CI test job for Python 3.9 always fails at the install step. This removes Python 3.9 from the test matrix and updates `pyproject.toml` to reflect the actual minimum supported version.

Changes:
- Removed `"3.9"` from the test matrix in `.github/workflows/ci.yml`.
- Updated `requires-python` from `">=3.9"` to `">=3.10"` in `pyproject.toml`.
- Removed Python 3.9 from classifiers and black `target-version`.

### Does your contribution introduce a new dependency? If yes, which one?

No.

### What should a reviewer concentrate their feedback on?

- Whether dropping Python 3.9 support is fine given the `mcp` dependency constraint.

#### Any other comments?

The remaining lint CI failure is pre-existing and tracked in #40.

### PR checklist

#### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/all-contributors).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

#### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.
