### PR TITLE
Expose fit/predict and handle tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,31 @@ Execute a complete workflow: load dataset, fit estimator, and generate predictio
 
 ---
 
+#### 9. `fit`
+Fit an estimator on a dataset without generating predictions.
+
+**Arguments:**
+- `estimator_handle` (required): Handle from `instantiate_estimator` or `instantiate_pipeline`
+- `dataset` (required): Dataset name (e.g., `"airline"`, `"sunspots"`, `"lynx"`)
+
+**Returns:** `{"success": true, ...}`
+
+---
+
+#### 10. `predict`
+Generate predictions from a previously fitted estimator.
+
+**Arguments:**
+- `estimator_handle` (required): Handle of a fitted estimator
+- `horizon` (optional): Forecast horizon (default: 12)
+
+**Returns:** `{"success": true, "predictions": {...}, "horizon": 12}`
+
+---
+
 ### Datasets
 
-#### 9. `list_datasets`
+#### 11. `list_datasets`
 List all available demo datasets for testing and experimentation.
 
 **Arguments:** None
@@ -248,7 +270,7 @@ List all available demo datasets for testing and experimentation.
 
 ### Handle Management
 
-#### 10. `list_handles`
+#### 12. `list_handles`
 List all active estimator handles and their status.
 
 **Arguments:** None
@@ -257,7 +279,7 @@ List all active estimator handles and their status.
 
 ---
 
-#### 11. `release_handle`
+#### 13. `release_handle`
 Release an estimator handle and free memory.
 
 **Arguments:**

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -162,6 +162,25 @@ async def list_tools() -> List[Tool]:
             },
         ),
         Tool(
+            name="list_handles",
+            description="List all active estimator handles and their metadata",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="release_handle",
+            description="Release an estimator handle and free memory",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "handle": {
+                        "type": "string",
+                        "description": "Handle to release",
+                    },
+                },
+                "required": ["handle"],
+            },
+        ),
+        Tool(
             name="fit_predict",
             description="Fit an estimator on a dataset and generate predictions",
             inputSchema={
@@ -182,6 +201,43 @@ async def list_tools() -> List[Tool]:
                     },
                 },
                 "required": ["estimator_handle", "dataset"],
+            },
+        ),
+        Tool(
+            name="fit",
+            description="Fit an estimator on a dataset",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle from instantiate_estimator",
+                    },
+                    "dataset": {
+                        "type": "string",
+                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                    },
+                },
+                "required": ["estimator_handle", "dataset"],
+            },
+        ),
+        Tool(
+            name="predict",
+            description="Generate predictions from a fitted estimator",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle of a fitted estimator",
+                    },
+                    "horizon": {
+                        "type": "integer",
+                        "description": "Forecast horizon (default: 12)",
+                        "default": 12,
+                    },
+                },
+                "required": ["estimator_handle"],
             },
         ),
         Tool(
@@ -514,10 +570,26 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
                 arguments["components"],
                 arguments.get("params_list"),
             )
+        elif name == "list_handles":
+            result = list_handles_tool()
+        elif name == "release_handle":
+            result = release_handle_tool(arguments["handle"])
         elif name == "fit_predict":
             result = fit_predict_tool(
                 arguments["estimator_handle"],
                 arguments["dataset"],
+                arguments.get("horizon", 12),
+            )
+            # Sanitize immediately to handle Period objects
+            result = sanitize_for_json(result)
+        elif name == "fit":
+            result = fit_tool(
+                arguments["estimator_handle"],
+                arguments["dataset"],
+            )
+        elif name == "predict":
+            result = predict_tool(
+                arguments["estimator_handle"],
                 arguments.get("horizon", 12),
             )
             # Sanitize immediately to handle Period objects

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@ Tests for sktime-mcp core functionality.
 """
 
 import pytest
+import asyncio
 import sys
 sys.path.insert(0, "src")
 
@@ -152,6 +153,38 @@ class TestTools:
         
         assert not result["success"]
         assert "error" in result
+
+    def test_list_handles_and_release_handle_tools(self):
+        """Test handle listing and release tool flow."""
+        from sktime_mcp.tools.instantiate import (
+            instantiate_estimator_tool,
+            list_handles_tool,
+            release_handle_tool,
+        )
+
+        create_result = instantiate_estimator_tool("NaiveForecaster")
+        assert create_result["success"]
+        handle = create_result["handle"]
+
+        handles_result = list_handles_tool()
+        assert handles_result["success"]
+        handle_ids = {h["handle_id"] for h in handles_result["handles"]}
+        assert handle in handle_ids
+
+        release_result = release_handle_tool(handle)
+        assert release_result["success"]
+
+    def test_server_exposes_quick_win_tools(self):
+        """Test MCP server lists the newly exposed tools."""
+        from sktime_mcp.server import list_tools
+
+        tools = asyncio.run(list_tools())
+        tool_names = {tool.name for tool in tools}
+
+        assert "list_handles" in tool_names
+        assert "release_handle" in tool_names
+        assert "fit" in tool_names
+        assert "predict" in tool_names
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR closes a gap between implemented functionality and exposed MCP API by wiring existing quick-win capabilities into the server and syncing docs/tests.

### What changed

- Exposed additional MCP tools in `src/sktime_mcp/server.py`:
  - `list_handles`
  - `release_handle`
  - `fit`
  - `predict`
- Added corresponding tool schemas in `list_tools()`.
- Added dispatch routing in `call_tool()` for the new tool names.
- Added JSON sanitization for `predict` responses (consistent with existing forecast-returning tools).
- Updated `README.md` tool catalog to document newly exposed execution capabilities (`fit`, `predict`) and adjusted numbering.
- Added test coverage in `tests/test_core.py`:
  - `test_list_handles_and_release_handle_tools`
  - `test_server_exposes_quick_win_tools`
- Fixed test assertion to use `handle_id` from actual handle schema returned by `list_handles_tool()`.

## Why

The codebase already had these operations implemented at tool/runtime level, but they were not fully exposed through the MCP server interface. This caused:

- mismatch between available backend capabilities and MCP-visible API,
- drift between docs and runtime behavior,
- missing regression coverage for tool exposure.

This PR makes those capabilities first-class MCP tools and aligns implementation, docs, and tests.

## Scope / Non-goals

- No algorithmic changes to sktime model behavior.
- No changes to pipeline composition logic.
- No changes to data-source adapters or job manager semantics.
- No new external dependencies.

## Validation

Executed locally in WSL:

- Targeted tests:
  - `pytest tests/test_core.py -k "list_handles_and_release_handle_tools or server_exposes_quick_win_tools" -v`
- Full core suite:
  - `pytest tests/test_core.py -v`

Result:
- `14 passed`, `0 failed`
- One existing numpy/WSL warning (`numpy.longdouble` signature mismatch), non-blocking and unrelated to this PR’s changes.

## Backward compatibility

- Additive API change only (new MCP tools exposed).
- Existing tool names and behavior unchanged.
- Clients can continue current flows; they now also have explicit fit/predict and handle-management endpoints.

## Follow-up ideas

- Add a dedicated evaluation tool (`evaluate_forecast`) with MAE/MAPE/RMSE.
- Add splitter/backtesting MCP tools for temporal CV workflows.
- Add end-to-end server-level MCP contract tests for tool schemas and dispatch paths.