### PR TITLE
[BUG] Add pytest.mark.asyncio decorator to fix async test failure (#41)

### DIFF
--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -4,6 +4,7 @@ Test background job management.
 
 import asyncio
 import time
+import pytest
 from sktime_mcp.runtime.executor import get_executor
 from sktime_mcp.runtime.jobs import get_job_manager, JobStatus
 
@@ -122,6 +123,7 @@ def test_list_jobs():
     job_manager.delete_job(job3)
 
 
+@pytest.mark.asyncio
 async def test_async_fit_predict():
     """Test async fit_predict."""
     executor = get_executor()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #41

### What does this implement/fix? Explain your changes.

The `test_async_fit_predict` function in `tests/test_background_jobs.py` is an async function but was missing the explicit `@pytest.mark.asyncio` decorator. Although `pytest-asyncio` is in our dev dependencies and `asyncio_mode = "auto"` is set in `pyproject.toml`, adding the decorator explicitly ensures pytest correctly identifies and runs the async test without solely relying on auto mode.

Changes:
- Added `import pytest`.
- Added `@pytest.mark.asyncio` decorator to `test_async_fit_predict`.

### Does your contribution introduce a new dependency? If yes, which one?

No. `pytest-asyncio` is already listed in the dev dependencies.

### What should a reviewer concentrate their feedback on?

Nothing specific, just a one-line missing decorator.

#### Any other comments?

N/A

### PR checklist

#### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/all-contributors).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

#### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.
