### PR TITLE
[ENH] Add data_handle support to sync fit_predict tool (#42)

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -176,14 +176,28 @@ class Executor:
         handle_id: str,
         dataset: str,
         horizon: int = 12,
+        data_handle: Optional[str] = None,
     ) -> dict[str, Any]:
         """Convenience method: load data, fit, and predict."""
-        data_result = self.load_dataset(dataset)
-        if not data_result["success"]:
-            return data_result
+        if data_handle is not None:
+            # Use custom loaded data
+            if data_handle not in self._data_handles:
+                return {
+                    "success": False,
+                    "error": f"Unknown data handle: {data_handle}",
+                    "available_handles": list(self._data_handles.keys()),
+                }
+            data_info = self._data_handles[data_handle]
+            y = data_info["y"]
+            X = data_info.get("X")
+        else:
+            # Use demo dataset
+            data_result = self.load_dataset(dataset)
+            if not data_result["success"]:
+                return data_result
+            y = data_result["data"]
+            X = data_result.get("exog")
 
-        y = data_result["data"]
-        X = data_result.get("exog")
         fh = list(range(1, horizon + 1))
 
         fit_result = self.fit(handle_id, y, X=X, fh=fh)

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -158,7 +158,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="fit_predict",
-            description="Fit an estimator on a dataset and generate predictions",
+            description="Fit an estimator on a dataset and generate predictions. Accepts either a demo dataset name or a data_handle from load_data_source.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -170,13 +170,17 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Dataset name: airline, sunspots, lynx, etc.",
                     },
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Handle from load_data_source (use this instead of dataset for custom data)",
+                    },
                     "horizon": {
                         "type": "integer",
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
                     },
                 },
-                "required": ["estimator_handle", "dataset"],
+                "required": ["estimator_handle"],
             },
         ),
         Tool(
@@ -565,8 +569,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         elif name == "fit_predict":
             result = fit_predict_tool(
                 arguments["estimator_handle"],
-                arguments["dataset"],
+                arguments.get("dataset", ""),
                 arguments.get("horizon", 12),
+                data_handle=arguments.get("data_handle"),
             )
             # Sanitize immediately to handle Period objects
             result = sanitize_for_json(result)

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -6,7 +6,7 @@ Executes complete forecasting workflows.
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from sktime_mcp.runtime.executor import get_executor
 
@@ -17,6 +17,7 @@ def fit_predict_tool(
     estimator_handle: str,
     dataset: str,
     horizon: int = 12,
+    data_handle: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
@@ -25,6 +26,7 @@ def fit_predict_tool(
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
+        data_handle: Optional handle from load_data_source for custom data
 
     Returns:
         Dictionary with:
@@ -41,7 +43,7 @@ def fit_predict_tool(
         }
     """
     executor = get_executor()
-    return executor.fit_predict(estimator_handle, dataset, horizon)
+    return executor.fit_predict(estimator_handle, dataset, horizon, data_handle=data_handle)
 
 
 def fit_tool(


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #42

### What does this implement/fix? Explain your changes.

The sync `fit_predict` tool was missing `data_handle` support only the async version had it after #7. This PR adds an optional `data_handle` parameter so users can use their custom loaded data with the synchronous workflow too.

Changes:
- `Executor.fit_predict()` now accepts an optional `data_handle` param. When provided, it pulls data from the stored handles instead of calling `load_dataset`.
- `fit_predict_tool()` passes the new param through to the executor.
- Updated the MCP tool schema to expose `data_handle` as an optional input and made `dataset` no longer strictly required.

### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies.

### What should a reviewer concentrate their feedback on?

- The `data_handle` lookup logic in `Executor.fit_predict()` follows the same pattern as the existing `fit_predict_with_data()` method.
- `dataset` is now optional in the schema. When `data_handle` is provided, `dataset` can be omitted.

#### Any other comments?

N/A

### PR checklist

#### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/all-contributors).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

#### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.
