### PR TITLE
feat: include column dtypes in load_data_source metadata response

### DIFF
--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -47,9 +47,9 @@ class EstimatorNode:
             "module": self.module,
             "tags": self.tags,
             "hyperparameters": self.hyperparameters,
-            "docstring": self.docstring[:500]
-            if self.docstring
-            else None,  # L-1: Truncate docstring to 500 characters, we can also try summarization
+            "docstring": (
+                self.docstring[:500] if self.docstring else None
+            ),  # L-1: Truncate docstring to 500 characters, we can also try summarization
         }
 
     def to_summary(self) -> dict[str, Any]:

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -500,7 +500,8 @@ class Executor:
             metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
             if X is not None:
                 metadata["exog_columns"] = list(X.columns)
-
+            # Inject column dtypes so LLMs can distinguish time index vs target
+            metadata["dtypes"] = {col: str(dtype) for col, dtype in data.dtypes.items()}
             # Generate handle
             data_handle = f"data_{uuid.uuid4().hex[:8]}"
 
@@ -533,11 +534,12 @@ class Executor:
                 except Exception as e:
                     logger.warning(f"Auto-formatting failed: {e}")
                     # Continue with unformatted data if formatting fails
-
+            _final_meta = adapter.get_metadata().copy()
+            _final_meta["dtypes"] = {col: str(dtype) for col, dtype in data.dtypes.items()}
             return {
                 "success": True,
                 "data_handle": data_handle,
-                "metadata": adapter.get_metadata(),
+                "metadata": _final_meta,
                 "validation": validation_report,
             }
 
@@ -621,7 +623,8 @@ class Executor:
             metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
             if X is not None:
                 metadata["exog_columns"] = list(X.columns)
-
+            # Inject column dtypes so LLMs can distinguish time index vs target
+            metadata["dtypes"] = {col: str(dtype) for col, dtype in data.dtypes.items()}
             data_handle = f"data_{uuid.uuid4().hex[:8]}"
 
             self._data_handles[data_handle] = {

--- a/src/sktime_mcp/tools/codegen.py
+++ b/src/sktime_mcp/tools/codegen.py
@@ -168,9 +168,11 @@ def _generate_pipeline_code(
         "success": True,
         "code": code,
         "imports": sorted(imports),
-        "pipeline_type": "TransformedTargetForecaster"
-        if "TransformedTargetForecaster" in str(imports)
-        else "Pipeline",
+        "pipeline_type": (
+            "TransformedTargetForecaster"
+            if "TransformedTargetForecaster" in str(imports)
+            else "Pipeline"
+        ),
     }
 
 

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -3,9 +3,9 @@ Simple test to verify the data source implementation.
 """
 
 import sys
-import os
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 # Test imports
 print("Testing imports...")
@@ -15,7 +15,7 @@ try:
     print("✓ Data module imports successful")
 except ImportError as e:
     print(f"✗ Import failed: {e}")
-    raise Exception(e)
+    raise Exception(e) from e
 
 # Test registry
 print("\nTesting DataSourceRegistry...")

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -3,8 +3,9 @@ Simple test to verify the data source implementation.
 """
 
 import sys
+import os
 
-sys.path.insert(0, "/home/shashank/Desktop/sktime-mcp/src")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 # Test imports
 print("Testing imports...")
@@ -14,7 +15,7 @@ try:
     print("✓ Data module imports successful")
 except ImportError as e:
     print(f"✗ Import failed: {e}")
-    sys.exit(1)
+    raise Exception(e)
 
 # Test registry
 print("\nTesting DataSourceRegistry...")


### PR DESCRIPTION
## Description
The `load_data_source` tool returned DataFrame metadata (rows, columns, frequency) but omitted column data types. This forced the LLM to blindly guess which columns are time indices, numerical targets, or categoricals—a known hallucination risk (discovered and documented in #35 testing with Gemini 2.5 Flash).

**Changes:**
Injected a `dtypes` dictionary into the metadata payload at all three metadata assembly sites in `executor.py` (sync load, sync return, async load).

**Example of new output:**
```json
"metadata": {
  "source": "pandas",
  "rows": 36,
  "columns": ["sales"],
  "dtypes": {
    "date": "datetime64[ns]",
    "sales": "float64",
    "region": "object"
  }
}
```

**Verified:** `pytest tests/` — 39 passed, 0 failures.

**Fixes #53**