### PR TITLE
fix: harden async job scheduling across tool entrypoints

### DIFF
--- a/src/sktime_mcp/runtime/async_scheduler.py
+++ b/src/sktime_mcp/runtime/async_scheduler.py
@@ -1,0 +1,75 @@
+"""Utilities for scheduling background coroutines safely."""
+
+import asyncio
+import logging
+import threading
+import time
+from typing import Any, Coroutine
+
+logger = logging.getLogger(__name__)
+
+_loop_lock = threading.Lock()
+_background_loop: asyncio.AbstractEventLoop | None = None
+_background_thread: threading.Thread | None = None
+
+
+def _run_loop_forever(loop: asyncio.AbstractEventLoop) -> None:
+    """Run an event loop forever in a dedicated daemon thread."""
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+def _get_background_loop() -> asyncio.AbstractEventLoop:
+    """Get a long-lived background event loop, creating it if needed."""
+    global _background_loop, _background_thread
+
+    with _loop_lock:
+        if _background_loop is not None and _background_loop.is_running():
+            return _background_loop
+
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(
+            target=_run_loop_forever,
+            args=(loop,),
+            daemon=True,
+            name="sktime-mcp-background-loop",
+        )
+        thread.start()
+
+        # Wait briefly for loop startup.
+        for _ in range(100):
+            if loop.is_running():
+                break
+            time.sleep(0.01)
+
+        _background_loop = loop
+        _background_thread = thread
+        return _background_loop
+
+
+def _log_future_exception(future) -> None:
+    """Log unhandled exceptions raised by background tasks."""
+    try:
+        exception = future.exception()
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Failed to retrieve background task exception")
+        return
+
+    if exception is not None:
+        logger.error("Background task failed", exc_info=exception)
+
+
+def schedule_coroutine(coro: Coroutine[Any, Any, Any]) -> None:
+    """Schedule a coroutine from sync code without event-loop warnings."""
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+
+    if running_loop is not None and running_loop.is_running():
+        running_loop.create_task(coro)
+        return
+
+    loop = _get_background_loop()
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    future.add_done_callback(_log_future_exception)

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -6,6 +6,8 @@ Provides tools for loading data from various sources.
 
 import logging
 from typing import Any, Dict
+
+from sktime_mcp.runtime.async_scheduler import schedule_coroutine
 from sktime_mcp.runtime.executor import get_executor
 
 logger = logging.getLogger(__name__)
@@ -14,21 +16,21 @@ logger = logging.getLogger(__name__)
 def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     Load data from any source (pandas, SQL, file, etc.).
-    
+
     Args:
         config: Data source configuration
             {
                 "type": "pandas" | "sql" | "file",
                 ... (type-specific configuration)
             }
-    
+
     Returns:
         Dictionary with:
         - success: bool
         - data_handle: str (handle ID for the loaded data)
         - metadata: dict (information about the data)
         - validation: dict (validation results)
-    
+
     Examples:
         # Pandas DataFrame
         >>> load_data_source_tool({
@@ -37,7 +39,7 @@ def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
         ...     "time_column": "date",
         ...     "target_column": "value"
         ... })
-        
+
         # SQL Database
         >>> load_data_source_tool({
         ...     "type": "sql",
@@ -46,7 +48,7 @@ def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
         ...     "time_column": "date",
         ...     "target_column": "value"
         ... })
-        
+
         # CSV File
         >>> load_data_source_tool({
         ...     "type": "file",
@@ -62,7 +64,7 @@ def load_data_source_tool(config: Dict[str, Any]) -> Dict[str, Any]:
 def list_data_sources_tool() -> Dict[str, Any]:
     """
     List all available data source types.
-    
+
     Returns:
         Dictionary with:
         - success: bool
@@ -70,9 +72,9 @@ def list_data_sources_tool() -> Dict[str, Any]:
         - descriptions: dict with descriptions for each source type
     """
     from sktime_mcp.data import DataSourceRegistry
-    
+
     sources = DataSourceRegistry.list_adapters()
-    
+
     # Get descriptions for each source
     descriptions = {}
     for source_type in sources:
@@ -81,7 +83,7 @@ def list_data_sources_tool() -> Dict[str, Any]:
             "class": info["class"],
             "description": info["docstring"].split("\n")[0] if info["docstring"] else "",
         }
-    
+
     return {
         "success": True,
         "sources": sources,
@@ -96,15 +98,15 @@ def fit_predict_with_data_tool(
 ) -> Dict[str, Any]:
     """
     Fit and predict using custom data.
-    
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         data_handle: Handle from load_data_source
         horizon: Forecast horizon (default: 12)
-    
+
     Returns:
         Dictionary with predictions
-    
+
     Example:
         >>> fit_predict_with_data_tool(
         ...     estimator_handle="est_abc123",
@@ -123,10 +125,10 @@ def fit_predict_with_data_tool(
 def release_data_handle_tool(data_handle: str) -> Dict[str, Any]:
     """
     Release a data handle and free memory.
-    
+
     Args:
         data_handle: Data handle to release
-    
+
     Returns:
         Dictionary with success status
     """
@@ -166,7 +168,6 @@ def load_data_source_async_tool(
             "message": "Data loading job started..."
         }
     """
-    import asyncio
     from sktime_mcp.runtime.jobs import get_job_manager
 
     executor = get_executor()
@@ -182,15 +183,9 @@ def load_data_source_async_tool(
         total_steps=3,  # load, validate, format
     )
 
-    # schedule on event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
+    # Schedule the coroutine (non-blocking)
     coro = executor.load_data_source_async(config, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
+    schedule_coroutine(coro)
 
     return {
         "success": True,

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -4,9 +4,10 @@ fit_predict tool for sktime MCP.
 Executes complete forecasting workflows.
 """
 
-from typing import Any, Dict, List, Optional, Union
 import logging
+from typing import Any, Dict
 
+from sktime_mcp.runtime.async_scheduler import schedule_coroutine
 from sktime_mcp.runtime.executor import get_executor
 
 # ✅ Logger added here
@@ -20,18 +21,18 @@ def fit_predict_tool(
 ) -> Dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
-    
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
-    
+
     Returns:
         Dictionary with:
         - success: bool
         - predictions: Forecast values
         - horizon: Number of steps predicted
-    
+
     Example:
         >>> fit_predict_tool("est_abc123", "airline", horizon=12)
         {
@@ -50,11 +51,11 @@ def fit_tool(
 ) -> Dict[str, Any]:
     """
     Fit an estimator on a dataset.
-    
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset
-    
+
     Returns:
         Dictionary with success status
     """
@@ -62,7 +63,7 @@ def fit_tool(
     data_result = executor.load_dataset(dataset)
     if not data_result["success"]:
         return data_result
-    
+
     return executor.fit(
         estimator_handle,
         y=data_result["data"],
@@ -76,11 +77,11 @@ def predict_tool(
 ) -> Dict[str, Any]:
     """
     Generate predictions from a fitted estimator.
-    
+
     Args:
         estimator_handle: Handle of a fitted estimator
         horizon: Forecast horizon
-    
+
     Returns:
         Dictionary with predictions
     """
@@ -96,21 +97,21 @@ def fit_predict_async_tool(
 ) -> Dict[str, Any]:
     """
     Execute a fit-predict workflow in the background (non-blocking).
-    
+
     This tool schedules the training as a background job and returns immediately
     with a job_id. Use check_job_status to monitor progress.
-    
+
     Args:
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
-    
+
     Returns:
         Dictionary with:
         - success: bool
         - job_id: Job ID for tracking progress
         - message: Information about the job
-    
+
     Example:
         >>> fit_predict_async_tool("est_abc123", "airline", horizon=12)
         {
@@ -119,12 +120,11 @@ def fit_predict_async_tool(
             "message": "Training job started. Use check_job_status to monitor progress."
         }
     """
-    import asyncio
     from sktime_mcp.runtime.jobs import get_job_manager
-    
+
     executor = get_executor()
     job_manager = get_job_manager()
-    
+
     # Get estimator info
     try:
         handle_info = executor._handle_manager.get_info(estimator_handle)
@@ -132,7 +132,7 @@ def fit_predict_async_tool(
     except Exception as e:
         logger.warning(f"Could not get estimator name: {e}")
         estimator_name = "Unknown"
-    
+
     # Create job
     job_id = job_manager.create_job(
         job_type="fit_predict",
@@ -142,19 +142,11 @@ def fit_predict_async_tool(
         horizon=horizon,
         total_steps=3,
     )
-    
-    # Schedule the async coroutine on the event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # No event loop in current thread, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    
-    # Schedule the coroutine (non-blocking!)
+
+    # Schedule the coroutine (non-blocking)
     coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
-    
+    schedule_coroutine(coro)
+
     return {
         "success": True,
         "job_id": job_id,

--- a/tests/test_async_data_loading.py
+++ b/tests/test_async_data_loading.py
@@ -5,15 +5,16 @@ Verifies that load_data_source_async_tool schedules data loading
 as a background job and resolves to a valid data_handle.
 """
 
-import sys
 import asyncio
+import sys
 import unittest
+import warnings
 
 sys.path.insert(0, "src")
 
-from sktime_mcp.tools.data_tools import load_data_source_async_tool
 from sktime_mcp.runtime.executor import get_executor
-from sktime_mcp.runtime.jobs import get_job_manager, JobStatus
+from sktime_mcp.runtime.jobs import JobStatus, get_job_manager
+from sktime_mcp.tools.data_tools import load_data_source_async_tool
 
 
 class TestAsyncDataLoadingTool(unittest.TestCase):
@@ -23,8 +24,7 @@ class TestAsyncDataLoadingTool(unittest.TestCase):
         """Async load should return a job_id immediately."""
         config = {
             "type": "pandas",
-            "data": {"date": ["2020-01", "2020-02", "2020-03"],
-                     "value": [10, 20, 30]},
+            "data": {"date": ["2020-01", "2020-02", "2020-03"], "value": [10, 20, 30]},
             "time_column": "date",
             "target_column": "value",
         }
@@ -32,6 +32,26 @@ class TestAsyncDataLoadingTool(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIn("job_id", result)
         self.assertEqual(result["source_type"], "pandas")
+
+    def test_does_not_emit_get_event_loop_deprecation_warning(self):
+        """Tool scheduling should avoid deprecated get_event_loop access."""
+        config = {
+            "type": "pandas",
+            "data": {"date": ["2020-01", "2020-02", "2020-03"], "value": [10, 20, 30]},
+            "time_column": "date",
+            "target_column": "value",
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = load_data_source_async_tool(config)
+
+        self.assertTrue(result["success"])
+        warning_messages = [str(w.message) for w in caught]
+        self.assertFalse(
+            any("There is no current event loop" in msg for msg in warning_messages),
+            f"Unexpected warning(s): {warning_messages}",
+        )
 
 
 class TestAsyncDataLoadingExecutor(unittest.TestCase):
@@ -43,14 +63,11 @@ class TestAsyncDataLoadingExecutor(unittest.TestCase):
 
         config = {
             "type": "pandas",
-            "data": {"date": ["2020-01", "2020-02", "2020-03"],
-                     "value": [10, 20, 30]},
+            "data": {"date": ["2020-01", "2020-02", "2020-03"], "value": [10, 20, 30]},
             "time_column": "date",
             "target_column": "value",
         }
-        result = asyncio.run(
-            executor.load_data_source_async(config)
-        )
+        result = asyncio.run(executor.load_data_source_async(config))
         self.assertTrue(result["success"])
         self.assertIn("data_handle", result)
 
@@ -61,20 +78,15 @@ class TestAsyncDataLoadingExecutor(unittest.TestCase):
 
         config = {
             "type": "pandas",
-            "data": {"date": ["2020-01", "2020-02", "2020-03"],
-                     "value": [10, 20, 30]},
+            "data": {"date": ["2020-01", "2020-02", "2020-03"], "value": [10, 20, 30]},
             "time_column": "date",
             "target_column": "value",
         }
-        result = asyncio.run(
-            executor.load_data_source_async(config)
-        )
+        asyncio.run(executor.load_data_source_async(config))
 
         # find the most recent data_loading job
         jobs = job_manager.list_jobs()
-        data_jobs = [
-            j for j in jobs if j.job_type == "data_loading"
-        ]
+        data_jobs = [j for j in jobs if j.job_type == "data_loading"]
         self.assertTrue(len(data_jobs) > 0)
 
         latest = data_jobs[0]
@@ -88,20 +100,15 @@ class TestAsyncDataLoadingExecutor(unittest.TestCase):
 
         config = {
             "type": "pandas",
-            "data": {"date": ["2020-01", "2020-02", "2020-03"],
-                     "value": [10, 20, 30]},
+            "data": {"date": ["2020-01", "2020-02", "2020-03"], "value": [10, 20, 30]},
             "time_column": "date",
             "target_column": "value",
         }
-        result = asyncio.run(
-            executor.load_data_source_async(config)
-        )
+        result = asyncio.run(executor.load_data_source_async(config))
         handle = result["data_handle"]
 
         # verify the handle exists
-        self.assertIn(
-            handle, executor._data_handles
-        )
+        self.assertIn(handle, executor._data_handles)
 
 
 class TestAsyncDataLoadingErrors(unittest.TestCase):
@@ -113,9 +120,7 @@ class TestAsyncDataLoadingErrors(unittest.TestCase):
 
         config = {"type": "nonexistent_source"}
 
-        result = asyncio.run(
-            executor.load_data_source_async(config)
-        )
+        result = asyncio.run(executor.load_data_source_async(config))
         self.assertFalse(result["success"])
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR improves reliability of background async workflows by removing fragile event-loop assumptions in tool entrypoints and introducing a safe scheduling utility.
### Problem
`fit_predict_async` and `load_data_source_async` tool functions scheduled coroutines using direct `asyncio.get_event_loop()` / `run_coroutine_threadsafe()` patterns, which can be unstable depending on runtime context and can emit warnings such as:
- `DeprecationWarning: There is no current event loop`
### Changes
- Added a dedicated scheduler utility:
  - `src/sktime_mcp/runtime/async_scheduler.py`
  - Provides `schedule_coroutine(coro)` that:
    - Uses current running loop when available
    - Otherwise uses a long-lived background daemon event loop
    - Logs unhandled background task exceptions safely
- Updated async tool entrypoints to use the new scheduler:
  - `src/sktime_mcp/tools/fit_predict.py`
  - `src/sktime_mcp/tools/data_tools.py`
- Extended async tests:
  - `tests/test_async_data_loading.py`
  - Added coverage to ensure `load_data_source_async_tool` does not emit the known event-loop deprecation warning path.
### Result
Background jobs are now scheduled more robustly across different execution contexts without relying on deprecated loop access patterns.
#### Does your contribution introduce a new dependency? If yes, which one?
No. This PR introduces no new dependency.
#### What should a reviewer concentrate their feedback on?
- [x] Correctness/safety of `schedule_coroutine` behavior in both “running loop” and “no loop” contexts.
- [x] Whether async tool entrypoints still preserve non-blocking semantics.
- [x] Test adequacy for regression coverage around warning-free scheduling.
#### Any other comments?
This PR is intentionally scoped to async scheduling hardening only (no API surface changes), to keep review focused and low-risk for early integration.
#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.
##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.