### PR TITLE
[BUG] register list_handles and release_handle tools in server.py

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -39,6 +39,8 @@ from sktime_mcp.tools.instantiate import (
     instantiate_estimator_tool,
     instantiate_pipeline_tool,
     load_model_tool,
+    list_handles_tool,
+    release_handle_tool,
 )
 from sktime_mcp.tools.job_tools import (
     cancel_job_tool,

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -157,6 +157,25 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="list_handles",
+            description="List all active estimator handles in memory",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="release_handle",
+            description="Release an estimator handle and free it from memory",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "handle": {
+                        "type": "string",
+                        "description": "Handle ID to release",
+                    },
+                },
+                "required": ["handle"],
+            },
+        ),
+        Tool(
             name="fit_predict",
             description="Fit an estimator on a dataset and generate predictions",
             inputSchema={
@@ -562,6 +581,11 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["components"],
                 arguments.get("params_list"),
             )
+        elif name == "list_handles":
+            result = list_handles_tool()
+        elif name == "release_handle":
+            result = release_handle_tool(arguments["handle"])
+
         elif name == "fit_predict":
             result = fit_predict_tool(
                 arguments["estimator_handle"],

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -38,8 +38,8 @@ from sktime_mcp.tools.format_tools import (
 from sktime_mcp.tools.instantiate import (
     instantiate_estimator_tool,
     instantiate_pipeline_tool,
-    load_model_tool,
     list_handles_tool,
+    load_model_tool,
     release_handle_tool,
 )
 from sktime_mcp.tools.job_tools import (


### PR DESCRIPTION
#### Reference Issues/PRs
fixes #57 

#### What does this implement/fix? Explain your changes.
`release_handle_tool` and `list_handles_tool` were imported in `server.py` but never registered in `list_tools()` or handled in `call_tool()`, so LLMs had no way to list or free estimator handles through MCP.

#### Does your contribution introduce a new dependency? If yes, which one?
no.

#### What should a reviewer concentrate their feedback on?
- Tool definitions added in `list_tools()`
- Handlers added in `call_tool()`
