### PR TITLE
fix: preserve database dialect in SQL connection string sanitization

### DIFF
--- a/src/sktime_mcp/data/adapters/sql_adapter.py
+++ b/src/sktime_mcp/data/adapters/sql_adapter.py
@@ -167,11 +167,16 @@ class SQLAdapter(DataSourceAdapter):
 
     def _sanitize_connection_string(self, conn_string: str) -> str:
         """Remove credentials from connection string for metadata."""
-        # Hide password in connection string
+        # Hide password in connection string but preserve the dialect/protocol
         if "@" in conn_string:
-            parts = conn_string.split("@")
-            if len(parts) == 2:
-                return f"***@{parts[1]}"
+            try:
+                protocol_auth, rest = conn_string.split("@", 1)
+                if "://" in protocol_auth:
+                    protocol, _ = protocol_auth.split("://", 1)
+                    return f"{protocol}://***@{rest}"
+                return f"***@{rest}"
+            except Exception:
+                return f"***@{conn_string.split('@')[-1]}"
         return conn_string
 
     def validate(self, data: pd.DataFrame) -> tuple[bool, dict[str, Any]]:


### PR DESCRIPTION
### Description

This PR fixes an issue where `_sanitize_connection_string` would aggressively split on `@` and replace everything before it with `***`, destroying the database dialect (e.g., `postgresql://`). This caused the LLM agent to lose context on what SQL dialect to use when reading metadata.

The new logic preserves the protocol scheme before applying the mask.

Fixes #70
