### PR TITLE
[BUG]: fixing the async `fit_predict` scheduling to use the running event loop

### DIFF
--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -157,17 +157,10 @@ def fit_predict_async_tool(
         total_steps=3,
     )
 
-    # Schedule the async coroutine on the event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # No event loop in current thread, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-    # Schedule the coroutine (non-blocking!)
+    # Schedule the coroutine on the running event loop (call_tool is async)
+    loop = asyncio.get_running_loop()
     coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
+    loop.create_task(coro)
 
     return {
         "success": True,


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Ensure `fit_predict_async_tool` schedules background work on the already running event loop via `asyncio.get_running_loop()` and `loop.create_task`, avoiding the deprecated `get_event_loop` + `run_coroutine_threadsafe` path that could leave jobs stuck pending (`src/sktime_mcp/tools/fit_predict.py:160`).

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies.

#### What should a reviewer concentrate their feedback on?
Confirm this function is always invoked from an async context with a running loop (per current MCP server flow).
Double-check job status transitions now progress as expected after scheduling.

#### Any other comments?
Tests not added; please let me know if a minimal regression test is desired for async job submission.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.

rant the checks locally 
link: https://github.com/user-attachments/assets/893028dc-7d65-476d-abea-4f280456ad44