### PR TITLE
chore: add project  PR template

### DIFF
--- a/.github/workflows/PULL_REQUEST_TEMPLATE.md
+++ b/.github/workflows/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!--
+Thanks for contributing a pull request! Please ensure you have taken a look
+at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
+-->
+
+#### Reference Issues/PRs
+<!--
+Example: Fixes #1234. See also #3456.
+
+Please use keywords (e.g., Fixes) to create link to the issues or pull requests
+you resolved, so that they will automatically be closed when your pull request
+is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
+-->
+
+
+#### What does this implement/fix? Explain your changes.
+<!--
+A clear and concise description of what you have implemented.
+-->
+
+#### Does your contribution introduce a new dependency? If yes, which one?
+
+<!--
+If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
+-->
+
+#### What should a reviewer concentrate their feedback on?
+
+<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
+
+#### Any other comments?
+<!--
+Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
+-->
+
+#### PR checklist
+<!--
+Please go through the checklist below. Please feel free to remove points if they are not applicable.
+-->
+
+##### For all contributions
+- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
+- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
+- [ ] I've added unit tests and made sure they pass locally.
+
+##### For new estimators
+- [ ] I've added the estimator to the online documentation.
+- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.
+
+
+<!--
+Thanks for contributing!
+-->


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR introduces a standard Pull Request template (`.github/PULL_REQUEST_TEMPLATE.md`) to the repository. This template will automatically populate the description of all new pull requests.

#### Does your contribution introduce a new dependency? If yes, which one?
None

#### What should a reviewer concentrate their feedback on?
- [x] Reviewing the sections included in the template to ensure they cover all necessary information for our specific team workflow.

#### Any other comments?
None

#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.