### PR TITLE
[ENH] Hyperparameter Tuning Tools: GridSearch, RandomSearch, and Optuna for Forecasters

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -906,7 +906,7 @@ class Executor:
             fh: Forecasting horizon for CV evaluation
             window_length: Training window length for CV splitter (None = use full history)
             n_iter: Number of iterations for random search
-            scoring: Metric to optimise (None = default MeanAbsolutePercentageError)
+            scoring: Metric to optimise (None = use sktime's default scoring metric)
 
         Returns:
             Dictionary with best_params, best_score, and a new handle for the best forecaster

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -884,6 +884,143 @@ class Executor:
                 "error": f"Data handle '{data_handle}' not found",
             }
 
+    def tune_forecaster(
+        self,
+        estimator_handle: str,
+        data_handle: str,
+        param_grid: dict,
+        method: str = "grid",
+        fh: int = 12,
+        window_length: Optional[int] = None,
+        n_iter: int = 10,
+        scoring=None,
+    ) -> dict[str, Any]:
+        """
+        Tune a forecaster's hyperparameters using cross-validation search.
+
+        Args:
+            estimator_handle: Handle of the instantiated forecaster to tune
+            data_handle: Handle of the loaded dataset
+            param_grid: Parameter grid to search, e.g. {"strategy": ["mean", "last"]}
+            method: Search method — "grid", "random", or "optuna"
+            fh: Forecasting horizon for CV evaluation
+            window_length: Training window length for CV splitter (None = use full history)
+            n_iter: Number of iterations for random search
+            scoring: Metric to optimise (None = default MeanAbsolutePercentageError)
+
+        Returns:
+            Dictionary with best_params, best_score, and a new handle for the best forecaster
+        """
+        # Retrieve estimator
+        try:
+            forecaster = self._handle_manager.get_instance(estimator_handle)
+        except KeyError:
+            return {
+                "success": False,
+                "error": f"Estimator handle not found: '{estimator_handle}'",
+            }
+
+        # Retrieve data
+        if data_handle not in self._data_handles:
+            return {
+                "success": False,
+                "error": f"Data handle not found: '{data_handle}'",
+            }
+        data = self._data_handles[data_handle]
+        y = data["y"]
+        X = data.get("X")
+
+        # Build CV splitter
+        try:
+            from sktime.split import SingleWindowSplitter
+
+            cv = SingleWindowSplitter(fh=fh, window_length=window_length)
+        except Exception as e:
+            return {"success": False, "error": f"Failed to build CV splitter: {e}"}
+
+        # Build scoring metric
+        if scoring is not None:
+            try:
+                import sktime.performance_metrics.forecasting as pmf
+
+                metric_cls = getattr(pmf, scoring, None)
+                if metric_cls is None:
+                    return {
+                        "success": False,
+                        "error": f"Unknown metric: '{scoring}'. Use list_metrics to see available metrics.",
+                    }
+                scoring = metric_cls()
+            except Exception as e:
+                return {"success": False, "error": f"Failed to build scoring metric: {e}"}
+
+        # Instantiate and fit tuning estimator
+        try:
+            if method == "grid":
+                from sktime.forecasting.model_selection import ForecastingGridSearchCV
+
+                tuner = ForecastingGridSearchCV(
+                    forecaster=forecaster,
+                    cv=cv,
+                    param_grid=param_grid,
+                    scoring=scoring,
+                )
+            elif method == "random":
+                from sktime.forecasting.model_selection import (
+                    ForecastingRandomizedSearchCV,
+                )
+
+                tuner = ForecastingRandomizedSearchCV(
+                    forecaster=forecaster,
+                    cv=cv,
+                    param_distributions=param_grid,
+                    n_iter=n_iter,
+                    scoring=scoring,
+                )
+            elif method == "optuna":
+                try:
+                    from sktime.forecasting.model_selection import (
+                        ForecastingOptunaSearchCV,
+                    )
+                except ImportError:
+                    return {
+                        "success": False,
+                        "error": "optuna is not installed. Run: pip install optuna",
+                    }
+                tuner = ForecastingOptunaSearchCV(
+                    forecaster=forecaster,
+                    cv=cv,
+                    param_grid=param_grid,
+                    scoring=scoring,
+                )
+            else:
+                return {
+                    "success": False,
+                    "error": f"Unknown method: '{method}'. Choose from: grid, random, optuna",
+                }
+
+            tuner.fit(y, X=X)
+        except Exception as e:
+            return {"success": False, "error": f"Tuning failed: {e}"}
+
+        # Store best forecaster as a new handle
+        estimator_info = self._handle_manager.get_info(estimator_handle)
+        estimator_name = estimator_info.estimator_name if estimator_info else "tuned_forecaster"
+        new_handle = self._handle_manager.create_handle(
+            estimator_name=f"{estimator_name}_tuned",
+            instance=tuner.best_forecaster_,
+            params=tuner.best_params_,
+        )
+        self._handle_manager.mark_fitted(new_handle)
+
+        return {
+            "success": True,
+            "method": method,
+            "best_params": tuner.best_params_,
+            "best_score": float(tuner.best_score_),
+            "new_handle": new_handle,
+            "message": f"Tuning complete. Best forecaster stored as handle '{new_handle}'.",
+        }
+
 
 _executor_instance: Optional[Executor] = None
 

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -896,7 +896,7 @@ class Executor:
         scoring=None,
     ) -> dict[str, Any]:
         """
-        Tune a forecaster's hyperparameters using cross-validation search.
+        Tune a forecaster's hyperparameters using single-split evaluation search.
 
         Args:
             estimator_handle: Handle of the instantiated forecaster to tune
@@ -905,7 +905,8 @@ class Executor:
             method: Search method — "grid", "random", or "optuna"
             fh: Forecasting horizon for CV evaluation
             window_length: Training window length for CV splitter (None = use full history)
-            n_iter: Number of iterations for random search
+            n_iter: Number of parameter combinations to try. Used as n_iter for
+                random search and n_evals for optuna. Ignored for grid search.
             scoring: Metric to optimise (None = use sktime's default scoring metric)
 
         Returns:
@@ -930,7 +931,7 @@ class Executor:
         y = data["y"]
         X = data.get("X")
 
-        # Build CV splitter
+        # Build single-split evaluation splitter
         try:
             from sktime.split import SingleWindowSplitter
 
@@ -998,6 +999,7 @@ class Executor:
                     cv=cv,
                     param_grid=param_grid,
                     scoring=scoring,
+                    n_evals=n_iter,
                 )
             else:
                 return {

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -942,16 +942,23 @@ class Executor:
         if scoring is not None:
             try:
                 import sktime.performance_metrics.forecasting as pmf
+            except Exception as e:
+                return {"success": False, "error": f"Failed to load forecasting metrics: {e}"}
 
-                metric_cls = getattr(pmf, scoring, None)
-                if metric_cls is None:
-                    return {
-                        "success": False,
-                        "error": f"Unknown metric: '{scoring}'. Use list_metrics to see available metrics.",
-                    }
+            metric_name = scoring
+            metric_cls = getattr(pmf, metric_name, None)
+            if metric_cls is None:
+                return {
+                    "success": False,
+                    "error": f"Unknown metric: '{metric_name}'. Use list_metrics to see available metrics.",
+                }
+            try:
                 scoring = metric_cls()
             except Exception as e:
-                return {"success": False, "error": f"Failed to build scoring metric: {e}"}
+                return {
+                    "success": False,
+                    "error": f"Failed to instantiate scoring metric '{metric_name}': {e}",
+                }
 
         # Instantiate and fit tuning estimator
         try:

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -47,6 +47,10 @@ from sktime_mcp.tools.list_estimators import (
     list_estimators_tool,
 )
 from sktime_mcp.tools.save_model import save_model_tool
+from sktime_mcp.tools.tuning_tools import (
+    get_param_grid_suggestions_tool,
+    tune_forecaster_tool,
+)
 
 # ---------------------------------------------------------------------------
 # Server configuration via environment variables
@@ -561,6 +565,79 @@ async def list_tools() -> list[Tool]:
                 "required": ["job_id"],
             },
         ),
+        Tool(
+            name="tune_forecaster",
+            description=(
+                "Tune a forecaster's hyperparameters using single-split evaluation search. "
+                "Supports grid search, random search, and Optuna-based search. "
+                "Returns the best parameters, best score, and a new handle for the "
+                "best fitted forecaster. Use get_param_grid_suggestions to build a "
+                "starting param_grid."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle of the instantiated forecaster to tune",
+                    },
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Handle of the loaded dataset",
+                    },
+                    "param_grid": {
+                        "type": "object",
+                        "description": (
+                            "Parameter grid to search, e.g. "
+                            '{\"strategy\": [\"mean\", \"last\"], \"sp\": [1, 12]}'
+                        ),
+                    },
+                    "method": {
+                        "type": "string",
+                        "enum": ["grid", "random", "optuna"],
+                        "description": "Search method: 'grid', 'random', or 'optuna' (requires optuna installed)",
+                    },
+                    "fh": {
+                        "type": "integer",
+                        "description": "Forecasting horizon for CV evaluation (default: 12)",
+                    },
+                    "window_length": {
+                        "type": "integer",
+                        "description": "Training window length for the CV splitter (default: full history)",
+                    },
+                    "n_iter": {
+                        "type": "integer",
+                        "description": "Number of parameter combinations to try: n_iter for random search, n_evals for optuna. Ignored for grid search (default: 10)",
+                    },
+                    "scoring": {
+                        "type": "string",
+                        "description": (
+                            "Metric class name to optimise, e.g. 'MeanAbsolutePercentageError'. "
+                            "Use list_metrics to see all options. Defaults to sktime's default scoring."
+                        ),
+                    },
+                },
+                "required": ["estimator_handle", "data_handle", "param_grid"],
+            },
+        ),
+        Tool(
+            name="get_param_grid_suggestions",
+            description=(
+                "Return a suggested parameter grid for a given estimator based on its "
+                "hyperparameter types and default values. Use this before tune_forecaster "
+                "to get a starting point for the param_grid argument."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_name": {
+                        "type": "string",
+                        "description": "Name of the sktime estimator, e.g. 'NaiveForecaster'",
+                    },
+                },
+                "required": ["estimator_name"],
+            },
+        ),
     ]
 
 
@@ -737,6 +814,19 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
 
             result = cleanup_old_jobs_tool(arguments.get("max_age_hours", 24))
 
+        elif name == "tune_forecaster":
+            result = tune_forecaster_tool(
+                estimator_handle=arguments["estimator_handle"],
+                data_handle=arguments["data_handle"],
+                param_grid=arguments["param_grid"],
+                method=arguments.get("method", "grid"),
+                fh=arguments.get("fh", 12),
+                window_length=arguments.get("window_length"),
+                n_iter=arguments.get("n_iter", 10),
+                scoring=arguments.get("scoring"),
+            )
+        elif name == "get_param_grid_suggestions":
+            result = get_param_grid_suggestions_tool(arguments["estimator_name"])
         else:
             result = {"error": f"Unknown tool: {name}"}
 

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -589,7 +589,7 @@ async def list_tools() -> list[Tool]:
                         "type": "object",
                         "description": (
                             "Parameter grid to search, e.g. "
-                            '{\"strategy\": [\"mean\", \"last\"], \"sp\": [1, 12]}'
+                            '{"strategy": ["mean", "last"], "sp": [1, 12]}'
                         ),
                     },
                     "method": {

--- a/src/sktime_mcp/tools/tuning_tools.py
+++ b/src/sktime_mcp/tools/tuning_tools.py
@@ -22,7 +22,7 @@ def tune_forecaster_tool(
     scoring: Optional[str] = None,
 ) -> dict[str, Any]:
     """
-    Tune a forecaster's hyperparameters using cross-validation search.
+    Tune a forecaster's hyperparameters using single-split evaluation search.
 
     Args:
         estimator_handle: Handle of the instantiated forecaster to tune
@@ -77,7 +77,8 @@ def get_param_grid_suggestions_tool(estimator_name: str) -> dict[str, Any]:
         if isinstance(default, bool):
             suggestions[param] = [True, False]
         elif isinstance(default, int):
-            suggestions[param] = list(dict.fromkeys([default - 1, default, default + 1]))
+            candidates = [default - 1, default, default + 1] if default > 0 else [default, default + 1]
+            suggestions[param] = list(dict.fromkeys(candidates))
         elif isinstance(default, float):
             suggestions[param] = [default * 0.5, default, default * 2.0]
         elif isinstance(default, str):

--- a/src/sktime_mcp/tools/tuning_tools.py
+++ b/src/sktime_mcp/tools/tuning_tools.py
@@ -1,0 +1,97 @@
+"""
+Hyperparameter tuning tools for sktime-mcp.
+
+Exposes sktime's ForecastingGridSearchCV, ForecastingRandomizedSearchCV,
+and ForecastingOptunaSearchCV as MCP tools.
+"""
+
+from typing import Any, Optional
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.registry.interface import get_registry
+
+
+def tune_forecaster_tool(
+    estimator_handle: str,
+    data_handle: str,
+    param_grid: dict,
+    method: str = "grid",
+    fh: int = 12,
+    window_length: Optional[int] = None,
+    n_iter: int = 10,
+    scoring: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Tune a forecaster's hyperparameters using cross-validation search.
+
+    Args:
+        estimator_handle: Handle of the instantiated forecaster to tune
+        data_handle: Handle of the loaded dataset
+        param_grid: Parameter grid to search, e.g. {"strategy": ["mean", "last"]}
+        method: Search method — "grid", "random", or "optuna"
+        fh: Forecasting horizon for CV evaluation
+        window_length: Training window length for the CV splitter (None = full history)
+        n_iter: Number of iterations for random search (ignored for grid/optuna)
+        scoring: Metric class name to optimise, e.g. "MeanAbsolutePercentageError"
+                 (None = default sktime scoring). Use list_metrics to see options.
+
+    Returns:
+        Dictionary with best_params, best_score, and new_handle for the best forecaster
+    """
+    executor = get_executor()
+    return executor.tune_forecaster(
+        estimator_handle=estimator_handle,
+        data_handle=data_handle,
+        param_grid=param_grid,
+        method=method,
+        fh=fh,
+        window_length=window_length,
+        n_iter=n_iter,
+        scoring=scoring,
+    )
+
+
+def get_param_grid_suggestions_tool(estimator_name: str) -> dict[str, Any]:
+    """
+    Return a suggested parameter grid for a given estimator.
+
+    Inspects the estimator's hyperparameters and produces a grid of sensible
+    values to try during tuning. Use this before calling tune_forecaster to
+    build a starting param_grid.
+
+    Args:
+        estimator_name: Name of the sktime estimator, e.g. "NaiveForecaster"
+
+    Returns:
+        Dictionary with the estimator name and a suggested param_grid
+    """
+    registry = get_registry()
+    node = registry.get_estimator_by_name(estimator_name)
+    if node is None:
+        return {"success": False, "error": f"Unknown estimator: '{estimator_name}'"}
+
+    suggestions = {}
+    for param, info in node.hyperparameters.items():
+        # hyperparameters are stored as {'default': value, 'required': bool}
+        default = info.get("default") if isinstance(info, dict) else info
+        if isinstance(default, bool):
+            suggestions[param] = [True, False]
+        elif isinstance(default, int):
+            low = max(1, default - 1)
+            suggestions[param] = [low, default, default + 1]
+        elif isinstance(default, float):
+            suggestions[param] = [default * 0.5, default, default * 2.0]
+        elif isinstance(default, str):
+            # Single value — user will need to fill in alternatives
+            suggestions[param] = [default]
+        # Skip None / complex defaults (callables, objects)
+
+    return {
+        "success": True,
+        "estimator": estimator_name,
+        "suggested_param_grid": suggestions,
+        "note": (
+            "This is a starting suggestion based on parameter types and defaults. "
+            "Review and adjust values before passing to tune_forecaster."
+        ),
+    }

--- a/src/sktime_mcp/tools/tuning_tools.py
+++ b/src/sktime_mcp/tools/tuning_tools.py
@@ -7,8 +7,8 @@ and ForecastingOptunaSearchCV as MCP tools.
 
 from typing import Any, Optional
 
-from sktime_mcp.runtime.executor import get_executor
 from sktime_mcp.registry.interface import get_registry
+from sktime_mcp.runtime.executor import get_executor
 
 
 def tune_forecaster_tool(
@@ -77,8 +77,7 @@ def get_param_grid_suggestions_tool(estimator_name: str) -> dict[str, Any]:
         if isinstance(default, bool):
             suggestions[param] = [True, False]
         elif isinstance(default, int):
-            low = max(1, default - 1)
-            suggestions[param] = [low, default, default + 1]
+            suggestions[param] = list(dict.fromkeys([default - 1, default, default + 1]))
         elif isinstance(default, float):
             suggestions[param] = [default * 0.5, default, default * 2.0]
         elif isinstance(default, str):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -215,5 +215,161 @@ class TestTools:
         assert calls["serialization_format"] == "pickle"
 
 
+class TestTuningTools:
+    """Tests for hyperparameter tuning tools."""
+
+    def _make_data_handle(self, executor):
+        """Insert an airline data handle directly into the executor."""
+        import uuid
+
+        from sktime.datasets import load_airline
+
+        y = load_airline()
+        data_handle = f"data_{uuid.uuid4().hex[:8]}"
+        executor._data_handles[data_handle] = {
+            "y": y,
+            "X": None,
+            "metadata": {},
+            "validation": {},
+            "config": {},
+        }
+        return data_handle
+
+    def test_get_param_grid_suggestions_known_estimator(self):
+        """get_param_grid_suggestions returns a dict for a known estimator."""
+        from sktime_mcp.tools.tuning_tools import get_param_grid_suggestions_tool
+
+        result = get_param_grid_suggestions_tool("NaiveForecaster")
+
+        assert result["success"]
+        assert result["estimator"] == "NaiveForecaster"
+        assert isinstance(result["suggested_param_grid"], dict)
+
+    def test_get_param_grid_suggestions_unknown_estimator(self):
+        """get_param_grid_suggestions returns an error for an unknown estimator."""
+        from sktime_mcp.tools.tuning_tools import get_param_grid_suggestions_tool
+
+        result = get_param_grid_suggestions_tool("NotARealEstimator99999")
+
+        assert not result["success"]
+        assert "error" in result
+
+    def test_tune_forecaster_grid_search(self):
+        """tune_forecaster with grid search returns best_params and a new handle."""
+        from sktime_mcp.runtime.executor import Executor
+
+        executor = Executor()
+        h = executor.instantiate("NaiveForecaster", {})
+        assert h["success"]
+
+        data_handle = self._make_data_handle(executor)
+
+        result = executor.tune_forecaster(
+            estimator_handle=h["handle"],
+            data_handle=data_handle,
+            param_grid={"strategy": ["mean", "last", "drift"]},
+            method="grid",
+            fh=12,
+        )
+
+        assert result["success"]
+        assert "best_params" in result
+        assert result["best_params"]["strategy"] in ["mean", "last", "drift"]
+        assert isinstance(result["best_score"], float)
+        assert result["new_handle"].startswith("est_")
+
+    def test_tune_forecaster_random_search(self):
+        """tune_forecaster with random search returns best_params and a new handle."""
+        from sktime_mcp.runtime.executor import Executor
+
+        executor = Executor()
+        h = executor.instantiate("NaiveForecaster", {})
+        data_handle = self._make_data_handle(executor)
+
+        result = executor.tune_forecaster(
+            estimator_handle=h["handle"],
+            data_handle=data_handle,
+            param_grid={"strategy": ["mean", "last", "drift"]},
+            method="random",
+            fh=12,
+            n_iter=2,
+        )
+
+        assert result["success"]
+        assert "best_params" in result
+        assert result["new_handle"].startswith("est_")
+
+    def test_tune_forecaster_invalid_estimator_handle(self):
+        """tune_forecaster returns an error for a non-existent estimator handle."""
+        from sktime_mcp.runtime.executor import Executor
+
+        executor = Executor()
+        data_handle = self._make_data_handle(executor)
+
+        result = executor.tune_forecaster(
+            estimator_handle="est_doesnotexist",
+            data_handle=data_handle,
+            param_grid={"strategy": ["mean"]},
+        )
+
+        assert not result["success"]
+        assert "error" in result
+
+    def test_tune_forecaster_invalid_data_handle(self):
+        """tune_forecaster returns an error for a non-existent data handle."""
+        from sktime_mcp.runtime.executor import Executor
+
+        executor = Executor()
+        h = executor.instantiate("NaiveForecaster", {})
+
+        result = executor.tune_forecaster(
+            estimator_handle=h["handle"],
+            data_handle="data_doesnotexist",
+            param_grid={"strategy": ["mean"]},
+        )
+
+        assert not result["success"]
+        assert "error" in result
+
+    def test_tune_forecaster_invalid_method(self):
+        """tune_forecaster returns an error for an unsupported search method."""
+        from sktime_mcp.runtime.executor import Executor
+
+        executor = Executor()
+        h = executor.instantiate("NaiveForecaster", {})
+        data_handle = self._make_data_handle(executor)
+
+        result = executor.tune_forecaster(
+            estimator_handle=h["handle"],
+            data_handle=data_handle,
+            param_grid={"strategy": ["mean"]},
+            method="unsupported_method",
+        )
+
+        assert not result["success"]
+        assert "error" in result
+
+    def test_tune_forecaster_best_handle_is_fitted(self):
+        """The new handle returned by tune_forecaster is marked as fitted."""
+        from sktime_mcp.runtime.executor import Executor
+        from sktime_mcp.runtime.handles import get_handle_manager
+
+        executor = Executor()
+        h = executor.instantiate("NaiveForecaster", {})
+        data_handle = self._make_data_handle(executor)
+
+        result = executor.tune_forecaster(
+            estimator_handle=h["handle"],
+            data_handle=data_handle,
+            param_grid={"strategy": ["mean", "last"]},
+            method="grid",
+            fh=12,
+        )
+
+        assert result["success"]
+        handle_manager = get_handle_manager()
+        assert handle_manager.is_fitted(result["new_handle"])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -329,6 +329,46 @@ class TestTuningTools:
         assert not result["success"]
         assert "error" in result
 
+    def test_tune_forecaster_valid_scoring_metric(self):
+        """tune_forecaster accepts a valid metric name and runs successfully."""
+        from sktime_mcp.runtime.executor import Executor
+
+        executor = Executor()
+        h = executor.instantiate("NaiveForecaster", {})
+        data_handle = self._make_data_handle(executor)
+
+        result = executor.tune_forecaster(
+            estimator_handle=h["handle"],
+            data_handle=data_handle,
+            param_grid={"strategy": ["mean", "last"]},
+            method="grid",
+            fh=12,
+            scoring="MeanAbsolutePercentageError",
+        )
+
+        assert result["success"]
+        assert "best_params" in result
+
+    def test_tune_forecaster_invalid_scoring_metric(self):
+        """tune_forecaster returns a structured error for an unknown metric name."""
+        from sktime_mcp.runtime.executor import Executor
+
+        executor = Executor()
+        h = executor.instantiate("NaiveForecaster", {})
+        data_handle = self._make_data_handle(executor)
+
+        result = executor.tune_forecaster(
+            estimator_handle=h["handle"],
+            data_handle=data_handle,
+            param_grid={"strategy": ["mean"]},
+            method="grid",
+            fh=12,
+            scoring="NotARealMetric",
+        )
+
+        assert not result["success"]
+        assert "NotARealMetric" in result["error"]
+
     def test_tune_forecaster_invalid_method(self):
         """tune_forecaster returns an error for an unsupported search method."""
         from sktime_mcp.runtime.executor import Executor

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -219,21 +219,19 @@ class TestTuningTools:
     """Tests for hyperparameter tuning tools."""
 
     def _make_data_handle(self, executor):
-        """Insert an airline data handle directly into the executor."""
-        import uuid
-
+        """Create an airline data handle via the public load_data_source API."""
         from sktime.datasets import load_airline
 
         y = load_airline()
-        data_handle = f"data_{uuid.uuid4().hex[:8]}"
-        executor._data_handles[data_handle] = {
-            "y": y,
-            "X": None,
-            "metadata": {},
-            "validation": {},
-            "config": {},
-        }
-        return data_handle
+        result = executor.load_data_source(
+            {
+                "type": "pandas",
+                "data": y.to_frame(),
+                "target_column": y.name,
+            }
+        )
+        assert result["success"], f"Failed to create data handle: {result.get('error')}"
+        return result["data_handle"]
 
     def test_get_param_grid_suggestions_known_estimator(self):
         """get_param_grid_suggestions returns a dict for a known estimator."""
@@ -348,6 +346,31 @@ class TestTuningTools:
 
         assert not result["success"]
         assert "error" in result
+
+    def test_tune_forecaster_optuna(self):
+        """tune_forecaster with optuna runs if optuna is installed, errors clearly if not."""
+        import importlib
+
+        from sktime_mcp.runtime.executor import Executor
+
+        executor = Executor()
+        h = executor.instantiate("NaiveForecaster", {})
+        data_handle = self._make_data_handle(executor)
+
+        result = executor.tune_forecaster(
+            estimator_handle=h["handle"],
+            data_handle=data_handle,
+            param_grid={"strategy": ["mean", "last"]},
+            method="optuna",
+            fh=12,
+        )
+
+        if importlib.util.find_spec("optuna") is None:
+            assert not result["success"]
+            assert "optuna" in result["error"].lower()
+        else:
+            assert result["success"]
+            assert "best_params" in result
 
     def test_tune_forecaster_best_handle_is_fitted(self):
         """The new handle returned by tune_forecaster is marked as fitted."""


### PR DESCRIPTION
#### Reference Issues/PRs
Closes: #80 


#### What does this implement/fix? Explain your changes.
Adds two new MCP tools for hyperparameter tuning of sktime forecasters:

- **tune_forecaster** - wraps sktime's ForecastingGridSearchCV, ForecastingRandomizedSearchCV, and ForecastingOptunaSearchCV. Accepts an estimator handle, a data handle, a param grid, and a search method. Returns the best params, best score, and a new fitted handle for the best forecaster.

- **get_param_grid_suggestions** - inspects an estimator's hyperparameters from the registry and returns a starting param grid, so the LLM doesn't need prior knowledge of valid parameter values.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
NA, the PR is ready for review.
P.S Used AI to generate the docstrings. 



#### PR checklist

##### For all contributions - There's no list of contributers yet.
- I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.


<!--
Thanks for contributing!
-->
