### PR TITLE
[BUG] Fix thread-unsafe singleton initialization in factory functions

### DIFF
--- a/src/sktime_mcp/composition/validator.py
+++ b/src/sktime_mcp/composition/validator.py
@@ -15,6 +15,7 @@ This prevents invalid pipelines at planning time.
 """
 
 import logging
+import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
@@ -400,11 +401,14 @@ class CompositionValidator:
 
 # Singleton instance
 _validator_instance: Optional[CompositionValidator] = None
+_validator_lock = threading.Lock()
 
 
 def get_composition_validator() -> CompositionValidator:
     """Get the singleton composition validator instance."""
     global _validator_instance
     if _validator_instance is None:
-        _validator_instance = CompositionValidator()
+        with _validator_lock:
+            if _validator_instance is None:
+                _validator_instance = CompositionValidator()
     return _validator_instance

--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -7,6 +7,7 @@ exposing structured semantic information about all available estimators.
 
 import inspect
 import logging
+import threading
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -333,11 +334,14 @@ class RegistryInterface:
 
 # Singleton instance for shared use
 _registry_instance: Optional[RegistryInterface] = None
+_registry_lock = threading.Lock()
 
 
 def get_registry() -> RegistryInterface:
     """Get the singleton registry instance."""
     global _registry_instance
     if _registry_instance is None:
-        _registry_instance = RegistryInterface()
+        with _registry_lock:
+            if _registry_instance is None:
+                _registry_instance = RegistryInterface()
     return _registry_instance

--- a/src/sktime_mcp/registry/tag_resolver.py
+++ b/src/sktime_mcp/registry/tag_resolver.py
@@ -6,6 +6,7 @@ utilities for working with tags and understanding their meanings.
 """
 
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -286,11 +287,14 @@ class TagResolver:
 
 # Singleton instance
 _resolver_instance: Optional[TagResolver] = None
+_resolver_lock = threading.Lock()
 
 
 def get_tag_resolver() -> TagResolver:
     """Get the singleton tag resolver instance."""
     global _resolver_instance
     if _resolver_instance is None:
-        _resolver_instance = TagResolver()
+        with _resolver_lock:
+            if _resolver_instance is None:
+                _resolver_instance = TagResolver()
     return _resolver_instance

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -7,6 +7,7 @@ and running fit/predict operations.
 
 import asyncio
 import logging
+import threading
 import uuid
 from typing import Any, Optional, Union
 
@@ -879,10 +880,14 @@ class Executor:
 
 
 _executor_instance: Optional[Executor] = None
+_executor_lock = threading.Lock()
 
 
 def get_executor() -> Executor:
+    """Get the singleton executor instance."""
     global _executor_instance
     if _executor_instance is None:
-        _executor_instance = Executor()
+        with _executor_lock:
+            if _executor_instance is None:
+                _executor_instance = Executor()
     return _executor_instance

--- a/src/sktime_mcp/runtime/handles.py
+++ b/src/sktime_mcp/runtime/handles.py
@@ -5,6 +5,7 @@ Manages references to instantiated estimator objects.
 """
 
 import logging
+import threading
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -111,10 +112,14 @@ class HandleManager:
 
 
 _handle_manager_instance: Optional[HandleManager] = None
+_handle_manager_lock = threading.Lock()
 
 
 def get_handle_manager() -> HandleManager:
+    """Get the singleton handle manager instance."""
     global _handle_manager_instance
     if _handle_manager_instance is None:
-        _handle_manager_instance = HandleManager()
+        with _handle_manager_lock:
+            if _handle_manager_instance is None:
+                _handle_manager_instance = HandleManager()
     return _handle_manager_instance


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

All five singleton factory functions (get_registry, get_handle_manager, get_executor, get_tag_resolver, get_composition_validator) used a simple if None check with no locking, making them unsafe under concurrent access. When fit_predict_async offloads work to thread pool executors via loop.run_in_executor(), multiple threads can race through the if _instance is None check simultaneously, creating duplicate instances and leading to inconsistent state (e.g., duplicate registry loads, split handle stores).
This PR applies the double-checked locking pattern to all five singletons using threading.Lock
```python
if _instance is None:          # Fast path
    with _lock:                # Serialize only during first initialization
        if _instance is None:  # Re-check under lock
            _instance = Class()
```

* Each file receives two minimal changes:
1. `import threading` added to `imports`
2. A module-level `threading.Lock()` and the double-checked locking pattern in the `factory function`

#### Does your contribution introduce a new dependency? If yes, which one?
No. threading is part of the Python standard library.

#### What should a reviewer concentrate their feedback on?
1. Correctness of the double-checked locking pattern across all five files
2. Whether any of these singletons should additionally protect their internal mutable state with locks for thread-safe mutation, beyond just safe initialization   .

#### Any other comments?
Double-checked locking was used instead of `functools.lru_cache(maxsize=1)` because it keeps the existing global pattern (so reset/tests stay simple), avoids `cache-related overhead` and `GC` complications, and ensures the fast path has no lock overhead—just a quick None check.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
None

`pytest` pass locally
<img width="1919" height="160" alt="image" src="https://github.com/user-attachments/assets/98a986d9-a614-4d13-a097-f4d5ce369c98" />

lint pass locally
<img width="1910" height="149" alt="image" src="https://github.com/user-attachments/assets/52efd31e-3873-43f3-b3d0-9d8d0c9f36e8" />