### PR TITLE
docs: fix README gaps - missing tools, platform paths, prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ This MCP is **not** just documentation or static code analysis. It is a **semant
 
 3. **Minimal MCP Surface** - Exposes only what an LLM needs: Discovery, Description, Instantiation, Execution, and model persistence.
 
+## 🛠️ Prerequisites
+
+- **Python 3.10+** (3.9 is listed in `pyproject.toml` but the `mcp` package requires 3.10+)
+- **pip** package manager
+
 ## 🛠️ Installation
 
 ```bash
@@ -36,6 +41,10 @@ pip install -e ".[all]"
 # Development installation
 pip install -e ".[dev]"
 ```
+
+> **Note:** On Windows, the `sktime-mcp` command may be installed to a directory
+> not on your `PATH` (e.g., `%APPDATA%\Python\Python3xx\Scripts`). Either add
+> that directory to your `PATH` or use `python -m sktime_mcp.server` instead.
 
 ## 🚀 Quick Start
 
@@ -51,9 +60,15 @@ python -m sktime_mcp.server
 
 ### Connecting from an LLM Client
 
-The server uses stdio transport by default, compatible with Claude Desktop and other MCP clients.
+The server uses stdio transport by default, compatible with Claude Desktop, Claude Code, and other MCP clients.
 
-Add to your Claude Desktop config (`~/.config/claude/claude_desktop_config.json`):
+**Claude Desktop** — add to your config file:
+
+| Platform | Config path |
+|----------|-------------|
+| macOS    | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Linux    | `~/.config/claude/claude_desktop_config.json` |
+| Windows  | `%APPDATA%\Claude\claude_desktop_config.json` |
 
 ```json
 {
@@ -64,6 +79,9 @@ Add to your Claude Desktop config (`~/.config/claude/claude_desktop_config.json`
   }
 }
 ```
+
+If `sktime-mcp` is not on your `PATH`, use the full path to the executable or
+use `python -m sktime_mcp.server` as the command instead.
 
 ## 📚 Available Tools
 
@@ -262,40 +280,104 @@ Persist a fitted estimator or pipeline handle to a local filesystem path using `
 
 ### Datasets
 
-#### 10. `list_datasets`
-List all available demo datasets for testing and experimentation.
-
-**Arguments:** None
-
-**Returns:** `{"success": true, "datasets": ["airline", "sunspots", "lynx", "shampoo", ...]}`
-
----
-
-### Handle Management
-
-#### 11. `list_handles`
-List all active estimator handles and their status.
-
-**Arguments:** None
-
-**Returns:** List of active handles with metadata (estimator name, fitted status, creation time)
-
----
-
-#### 12. `release_handle`
-Release an estimator handle and free memory.
+#### 10. `list_available_data`
+List all available data — both system demo datasets and active user-loaded data handles — in a single unified response.
 
 **Arguments:**
-- `handle` (required): Handle ID to release
+- `is_demo` (optional): `true` returns only demo datasets, `false` returns only active data handles, omit to get both
+
+**Returns:** `{"success": true, "system_demos": ["airline", "sunspots", ...], "active_handles": [...], "total": 8}`
+
+---
+
+### Data Loading
+
+#### 11. `load_data_source`
+Load data from various sources (CSV/Parquet files, pandas DataFrames, SQL databases, URLs).
+
+**Arguments:**
+- `config` (required): Data source configuration object. Must include `"type"` (`"pandas"`, `"sql"`, `"file"`, `"url"`).
 
 **Example:**
 ```json
 {
-  "handle": "est_abc123"
+  "config": {
+    "type": "file",
+    "path": "/absolute/path/to/data.csv",
+    "time_column": "date",
+    "target_column": "value"
+  }
 }
 ```
 
-**Returns:** `{"success": true, "message": "Handle released"}`
+**Returns:** `{"success": true, "data_handle": "data_abc123", "metadata": {...}}`
+
+---
+
+#### 12. `fit_predict_with_data`
+Fit an estimator and generate predictions using a custom data handle (instead of a demo dataset).
+
+**Arguments:**
+- `estimator_handle` (required): Handle from `instantiate_estimator`
+- `data_handle` (required): Handle from `load_data_source`
+- `horizon` (optional): Forecast horizon (default: 12)
+
+**Returns:** Same format as `fit_predict`.
+
+---
+
+### Code & Model Export
+
+#### 13. `export_code`
+Export an estimator or pipeline as executable Python code.
+
+**Arguments:**
+- `handle` (required): Handle ID of the estimator/pipeline
+- `var_name` (optional): Variable name in generated code (default: `"model"`)
+- `include_fit_example` (optional): Include a fit/predict example (default: `false`)
+
+**Returns:** `{"success": true, "code": "from sktime..."}`
+
+---
+
+### Background Jobs
+
+#### 14. `fit_predict_async`
+Non-blocking version of `fit_predict`. Returns a `job_id` immediately; use `check_job_status` to poll.
+
+**Arguments:** Same as `fit_predict`.
+
+**Returns:** `{"success": true, "job_id": "abc-123", "message": "Training job started..."}`
+
+---
+
+#### 15. `check_job_status`
+Check the status and progress of a background job.
+
+**Arguments:**
+- `job_id` (required): Job ID to check
+
+---
+
+#### 16. `list_jobs`
+List all background jobs with optional status filter.
+
+**Arguments:**
+- `status` (optional): Filter by status (`"pending"`, `"running"`, `"completed"`, `"failed"`, `"cancelled"`)
+- `limit` (optional): Maximum results (default: 20)
+
+---
+
+### Data Formatting
+
+#### 17. `format_time_series`
+Automatically format time series data (infer frequency, remove duplicates, fill missing values).
+
+**Arguments:**
+- `data_handle` (required): Handle from `load_data_source`
+- `auto_infer_freq` (optional): Infer and set frequency (default: `true`)
+- `fill_missing` (optional): Fill missing values (default: `true`)
+- `remove_duplicates` (optional): Remove duplicate timestamps (default: `true`)
 
 ## 🔄 Example LLM Flows
 
@@ -357,13 +439,15 @@ Release an estimator handle and free memory.
 ## 📁 Project Structure
 
 ```
-sktime_mcp/
+sktime-mcp/
 ├── src/sktime_mcp/
 │   ├── server.py           # MCP server entry point
 │   ├── registry/           # Registry interface & tag resolver
 │   ├── composition/        # Pipeline composition validator
-│   ├── runtime/            # Execution engine & handle management
+│   ├── runtime/            # Execution engine, handle & job management
+│   ├── data/               # Data adapters (file, pandas, SQL, URL)
 │   └── tools/              # MCP tool implementations
+├── docs/                   # MkDocs documentation source
 ├── examples/               # Usage examples
 └── tests/                  # Test suite
 ```


### PR DESCRIPTION
## Summary
- Add Prerequisites section noting Python 3.10+ requirement (mcp package requires it)
- Add Windows PATH note for the `sktime-mcp` CLI command
- Add platform-specific Claude Desktop config paths (macOS, Linux, Windows)
- Document 8 previously undocumented MCP tools (load_data_source, fit_predict_with_data, export_code, fit_predict_async, check_job_status, list_jobs, format_time_series, etc.)
- Replace incorrect tool names in README (list_datasets → list_available_data; list_handles/release_handle were never registered as MCP tools)
- Update project structure to include data/ and docs/ directories

## Context
Found while setting up the MCP server from scratch following only the README (Task A of the contribution guide). Multiple tools existed in server.py but were not documented, and some documented tools did not match actual implementations.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all documented tool names match `server.py` registrations
- [ ] Verify Claude Desktop config paths are correct per platform

AI was used for basic drafting assistance and refinement; all changes were verified manually.