### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with managed scheduler

### DIFF
--- a/src/sktime_mcp/runtime/async_scheduler.py
+++ b/src/sktime_mcp/runtime/async_scheduler.py
@@ -1,0 +1,96 @@
+"""
+Async scheduler for sktime MCP.
+
+Provides reliable coroutine scheduling from synchronous code
+without relying on deprecated asyncio.get_event_loop().
+"""
+
+import asyncio
+import logging
+import threading
+from collections.abc import Coroutine
+from concurrent.futures import Future
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncScheduler:
+    """
+    Manages a dedicated background event loop for scheduling coroutines
+    from synchronous code paths.
+
+    Uses a long-lived daemon thread with its own event loop, avoiding
+    the deprecated ``asyncio.get_event_loop()`` pattern in sync contexts.
+    """
+
+    def __init__(self):
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+
+    def _ensure_loop(self) -> asyncio.AbstractEventLoop:
+        """Start the background loop thread if not already running."""
+        if self._loop is not None and self._loop.is_running():
+            return self._loop
+
+        with self._lock:
+            # Double-check after acquiring lock
+            if self._loop is not None and self._loop.is_running():
+                return self._loop
+
+            self._loop = asyncio.new_event_loop()
+            self._thread = threading.Thread(
+                target=self._loop.run_forever,
+                daemon=True,
+                name="sktime-mcp-async-scheduler",
+            )
+            self._thread.start()
+            return self._loop
+
+    def schedule(self, coro: Coroutine[Any, Any, Any]) -> Future:
+        """
+        Schedule a coroutine on the background event loop.
+
+        Returns a ``concurrent.futures.Future`` that resolves when the
+        coroutine completes. Failures are logged via a done-callback.
+
+        Args:
+            coro: The coroutine to schedule.
+
+        Returns:
+            A Future representing the coroutine's result.
+        """
+        loop = self._ensure_loop()
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        future.add_done_callback(self._done_callback)
+        return future
+
+    @staticmethod
+    def _done_callback(future: Future) -> None:
+        """Log unhandled exceptions from background tasks."""
+        try:
+            exc = future.exception()
+            if exc is not None:
+                logger.error(
+                    "Background task failed with unhandled exception: %s",
+                    exc,
+                    exc_info=exc,
+                )
+        except Exception:
+            # Future was cancelled or callback itself errored; nothing to do.
+            pass
+
+
+_scheduler_instance: AsyncScheduler | None = None
+_scheduler_lock = threading.Lock()
+
+
+def get_async_scheduler() -> AsyncScheduler:
+    """Return the singleton AsyncScheduler instance."""
+    global _scheduler_instance
+    if _scheduler_instance is None:
+        with _scheduler_lock:
+            if _scheduler_instance is None:
+                _scheduler_instance = AsyncScheduler()
+    return _scheduler_instance

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -167,8 +167,7 @@ def load_data_source_async_tool(
             "message": "Data loading job started..."
         }
     """
-    import asyncio
-
+    from sktime_mcp.runtime.async_scheduler import get_async_scheduler
     from sktime_mcp.runtime.jobs import get_job_manager
 
     executor = get_executor()
@@ -184,15 +183,10 @@ def load_data_source_async_tool(
         total_steps=3,  # load, validate, format
     )
 
-    # schedule on event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
+    # Schedule via the managed async scheduler (non-blocking)
+    scheduler = get_async_scheduler()
     coro = executor.load_data_source_async(config, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
+    scheduler.schedule(coro)
 
     return {
         "success": True,

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -4,7 +4,6 @@ fit_predict tool for sktime MCP.
 Executes complete forecasting workflows.
 """
 
-import asyncio
 import logging
 from typing import Any
 
@@ -134,6 +133,7 @@ def fit_predict_async_tool(
         }
     """
 
+    from sktime_mcp.runtime.async_scheduler import get_async_scheduler
     from sktime_mcp.runtime.jobs import get_job_manager
 
     executor = get_executor()
@@ -157,17 +157,10 @@ def fit_predict_async_tool(
         total_steps=3,
     )
 
-    # Schedule the async coroutine on the event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # No event loop in current thread, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-    # Schedule the coroutine (non-blocking!)
+    # Schedule via the managed async scheduler (non-blocking)
+    scheduler = get_async_scheduler()
     coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
+    scheduler.schedule(coro)
 
     return {
         "success": True,

--- a/tests/test_async_scheduler.py
+++ b/tests/test_async_scheduler.py
@@ -1,0 +1,136 @@
+"""
+Tests for the async scheduler utility (Issue #65).
+
+Verifies that the scheduler reliably schedules coroutines from
+synchronous code without using deprecated asyncio.get_event_loop().
+"""
+
+import asyncio
+import sys
+import time
+import warnings
+
+import pytest
+
+sys.path.insert(0, "src")
+
+from sktime_mcp.runtime.async_scheduler import AsyncScheduler, get_async_scheduler
+
+
+class TestAsyncScheduler:
+    """Tests for the AsyncScheduler class."""
+
+    def test_schedule_coroutine_completes(self):
+        """Scheduled coroutine should run to completion."""
+        scheduler = AsyncScheduler()
+
+        async def simple_task():
+            return 42
+
+        future = scheduler.schedule(simple_task())
+        result = future.result(timeout=5)
+        assert result == 42
+
+    def test_schedule_from_sync_no_deprecation_warning(self):
+        """Scheduling from sync code should not emit event loop warnings."""
+        scheduler = AsyncScheduler()
+
+        async def noop():
+            return True
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            future = scheduler.schedule(noop())
+            future.result(timeout=5)
+
+        event_loop_warnings = [
+            w for w in caught if "no current event loop" in str(w.message).lower()
+        ]
+        assert len(event_loop_warnings) == 0, (
+            f"Got event loop deprecation warnings: {event_loop_warnings}"
+        )
+
+    def test_schedule_exception_is_logged(self):
+        """Failed coroutines should not raise in the caller; errors are logged."""
+        scheduler = AsyncScheduler()
+
+        async def failing_task():
+            raise ValueError("test error")
+
+        future = scheduler.schedule(failing_task())
+
+        # The future should contain the exception
+        with pytest.raises(ValueError, match="test error"):
+            future.result(timeout=5)
+
+    def test_multiple_coroutines(self):
+        """Multiple coroutines should all complete."""
+        scheduler = AsyncScheduler()
+        results = []
+
+        async def append_value(val):
+            await asyncio.sleep(0.01)
+            return val
+
+        futures = [scheduler.schedule(append_value(i)) for i in range(5)]
+        results = [f.result(timeout=5) for f in futures]
+        assert sorted(results) == [0, 1, 2, 3, 4]
+
+    def test_singleton_returns_same_instance(self):
+        """get_async_scheduler should return the same instance."""
+        s1 = get_async_scheduler()
+        s2 = get_async_scheduler()
+        assert s1 is s2
+
+
+class TestAsyncToolIntegration:
+    """Integration tests: async tools should use the scheduler without warnings."""
+
+    def test_fit_predict_async_no_event_loop_warning(self):
+        """fit_predict_async_tool should not emit event loop warnings."""
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+
+        result = instantiate_estimator_tool("NaiveForecaster")
+        if not result["success"]:
+            pytest.skip("Could not instantiate NaiveForecaster")
+
+        handle = result["handle"]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            from sktime_mcp.tools.fit_predict import fit_predict_async_tool
+
+            async_result = fit_predict_async_tool(handle, "airline", horizon=3)
+
+        assert async_result["success"]
+        assert "job_id" in async_result
+
+        event_loop_warnings = [
+            w for w in caught if "no current event loop" in str(w.message).lower()
+        ]
+        assert len(event_loop_warnings) == 0
+
+    def test_load_data_source_async_no_event_loop_warning(self):
+        """load_data_source_async_tool should not emit event loop warnings."""
+        config = {
+            "type": "pandas",
+            "data": {"date": ["2020-01", "2020-02", "2020-03"], "value": [10, 20, 30]},
+            "time_column": "date",
+            "target_column": "value",
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            from sktime_mcp.tools.data_tools import load_data_source_async_tool
+
+            result = load_data_source_async_tool(config)
+
+        assert result["success"]
+        assert "job_id" in result
+
+        event_loop_warnings = [
+            w for w in caught if "no current event loop" in str(w.message).lower()
+        ]
+        assert len(event_loop_warnings) == 0


### PR DESCRIPTION
## Summary
- Introduce `AsyncScheduler` in `src/sktime_mcp/runtime/async_scheduler.py` that manages a dedicated background thread with its own event loop
- Replace direct `asyncio.get_event_loop()` calls in `fit_predict_async_tool` and `load_data_source_async_tool` with the new scheduler
- Add done-callback logging so unhandled background exceptions are observable
- Add 7 tests covering scheduler behavior and tool-level integration

## Context
Fixes #65. The async tool entrypoints (`fit_predict_async_tool`, `load_data_source_async_tool`) used `asyncio.get_event_loop()` from synchronous code, which is deprecated in Python 3.10+ and emits `DeprecationWarning: There is no current event loop`. The new scheduler avoids this by maintaining a long-lived background loop thread.

## Test plan
- [x] All 7 new tests in `test_async_scheduler.py` pass
- [x] No `DeprecationWarning` about event loops in test output
- [x] All 20 existing tests in `test_core.py` still pass (no regressions)
- [x] All 4 existing tests in `test_async_data_loading.py` still pass
- [x] `ruff check` passes on all changed files

AI was used for basic drafting assistance and refinement; all changes were verified manually.