### PR TITLE
fix: load_model supports MLflow URIs by removing os.path.exists pre-check

### DIFF
--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -253,34 +253,31 @@ def list_handles_tool() -> dict[str, Any]:
 
 def load_model_tool(path: str) -> dict[str, Any]:
     """
-    Load a saved model from disk and register its handle.
+    Load a saved model from a local path or MLflow URI and register its handle.
 
     Args:
-        path: Path to the saved model directory.
-
+        path: Local directory path or MLflow URI to the saved model.
+              Examples:
+                - "/tmp/my_arima_model"
+                - "runs:/<run_id>/model"
+                - "mlflow-artifacts:/<run_id>/artifacts/model"
+                - "models:/<model_name>/<version>"
     Returns:
         Dictionary with success status and the new handle.
     """
-    from pathlib import Path
-
-    if not Path(path).exists():
-        return {
-            "success": False,
-            "error": f"Path does not exist: {path}",
-        }
-
     try:
         from sktime.utils.mlflow_sktime import load_model
     except ImportError:
         return {
             "success": False,
-            "error": "The 'mlflow' package is required to load saved models. Please install it with: pip install sktime[mlflow]",
+            "error": (
+                "The 'mlflow' package is required to load saved models. "
+                "Please install it with: pip install sktime[mlflow]"
+            ),
         }
-
     try:
         instance = load_model(path)
         estimator_name = type(instance).__name__
-
         handle_manager = get_handle_manager()
         handle_id = handle_manager.create_handle(
             estimator_name=estimator_name,
@@ -288,9 +285,7 @@ def load_model_tool(path: str) -> dict[str, Any]:
             params={},
             metadata={"source": "loaded", "path": path},
         )
-
         handle_manager.mark_fitted(handle_id)
-
         return {
             "success": True,
             "handle": handle_id,
@@ -298,8 +293,9 @@ def load_model_tool(path: str) -> dict[str, Any]:
             "path": path,
             "message": f"Successfully loaded {estimator_name}",
         }
-    except Exception as e:
+    except Exception as exc:
         return {
             "success": False,
-            "error": f"Failed to load model: {str(e)}",
+            "error": f"Failed to load model: {str(exc)}",
+            "path": path,
         }


### PR DESCRIPTION
## Summary

Fixes #87

Removes the `os.path.exists(path)` pre-check from `load_model_tool` 
that was blocking valid MLflow model URIs.

---

## Changes

- **`src/sktime_mcp/tools/instantiate.py`**: removed the `os.path.exists` 
  guard so URIs are passed directly to `sktime.utils.mlflow_sktime.load_model`
- **`src/sktime_mcp/server.py`**: updated tool description to mention 
  MLflow URI support

---

## Before vs After

**Before:**
<img width="968" height="113" alt="Screenshot from 2026-04-06 17-18-03" src="https://github.com/user-attachments/assets/59bad781-8c49-4f45-820f-4219f2c44376" />
load_model_tool("runs:/abc123/model")
→ {'success': False, 'error': 'Path does not exist: runs:/abc123/model'}


**After:**
<img width="961" height="134" alt="Screenshot from 2026-04-06 17-52-08" src="https://github.com/user-attachments/assets/dbe75f90-666b-4283-86df-f8cbebc84b84" />


The URI now reaches MLflow directly. With a real run ID this returns 
`success: True` and a valid handle.

---

## Input Types Handled

| Input | Before | After |
|---|---|---|
| Local path (exists) | ✅ Works | ✅ Works |
| Local path (missing) | ❌ Wrong early error | ✅ Proper sktime error |
| `runs:/<run_id>/model` | ❌ Blocked | ✅ Reaches MLflow |
| `mlflow-artifacts:/...` | ❌ Blocked | ✅ Reaches MLflow |
| `models:/<name>/<version>` | ❌ Blocked | ✅ Reaches MLflow |
