### PR TITLE
fix(security): prevent SSRF and arbitrary file reads in data adapters

### DIFF
--- a/src/sktime_mcp/data/adapters/file_adapter.py
+++ b/src/sktime_mcp/data/adapters/file_adapter.py
@@ -5,12 +5,28 @@ Supports loading data from local files with automatic format detection.
 """
 
 import contextlib
+import logging
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
 
 from ..base import DataSourceAdapter
+
+logger = logging.getLogger(__name__)
+
+# Sensitive paths that should never be accessed regardless of allowed_directories
+_SENSITIVE_PATHS_UNIX = {
+    "/etc/passwd",
+    "/etc/shadow",
+    "/etc/hosts",
+    "/proc",
+    "/sys",
+    "/dev",
+}
+_SENSITIVE_PATHS_WIN = {
+    r"C:\Windows\System32\config",
+}
 
 
 class FileAdapter(DataSourceAdapter):
@@ -27,6 +43,10 @@ class FileAdapter(DataSourceAdapter):
         "time_column": "date",
         "target_column": "value",
         "exog_columns": ["feature1", "feature2"],
+
+        # Security: restrict file access to specific directories
+        # If not set, defaults to the current working directory
+        "allowed_directories": ["/data", "/home/user/datasets"],
 
         # CSV-specific options
         "csv_options": {
@@ -47,6 +67,54 @@ class FileAdapter(DataSourceAdapter):
     }
     """
 
+    @staticmethod
+    def _validate_path(
+        path: Path,
+        allowed_directories: list[str] | None = None,
+    ) -> None:
+        """Validate that the file path is within allowed directories.
+
+        Resolves symlinks before checking to prevent directory-traversal attacks.
+
+        Args:
+            path: The file path to validate.
+            allowed_directories: Explicit list of allowed directory prefixes.
+                If ``None``, defaults to the current working directory.
+
+        Raises:
+            ValueError: If the path is outside allowed directories or targets
+                a known sensitive location.
+        """
+        # Resolve to a real, absolute path (resolves symlinks and ".." segments)
+        resolved = path.resolve()
+
+        # Block known sensitive paths
+        resolved_str = str(resolved)
+        for sensitive in _SENSITIVE_PATHS_UNIX | _SENSITIVE_PATHS_WIN:
+            if resolved_str.startswith(sensitive):
+                raise ValueError(f"Access to '{resolved}' is blocked: sensitive system path.")
+
+        # Determine allowed roots
+        if allowed_directories:
+            allowed_roots = [Path(d).resolve() for d in allowed_directories]
+        else:
+            allowed_roots = [Path.cwd().resolve()]
+
+        # Check that resolved path falls under at least one allowed root
+        for root in allowed_roots:
+            try:
+                resolved.relative_to(root)
+                return  # Path is within this allowed root
+            except ValueError:
+                continue
+
+        allowed_list = ", ".join(str(r) for r in allowed_roots)
+        raise ValueError(
+            f"Access denied: '{resolved}' is outside the allowed directories "
+            f"({allowed_list}). Configure 'allowed_directories' in the adapter "
+            "config to grant access."
+        )
+
     def load(self) -> pd.DataFrame:
         """Load from file."""
         path_str = self.config.get("path")
@@ -54,6 +122,10 @@ class FileAdapter(DataSourceAdapter):
             raise ValueError("Config must contain 'path' key")
 
         path = Path(path_str)
+
+        # Validate path is within allowed directories
+        allowed_dirs = self.config.get("allowed_directories")
+        self._validate_path(path, allowed_dirs)
 
         if not path.exists():
             raise FileNotFoundError(f"File not found: {path}")

--- a/src/sktime_mcp/data/adapters/url_adapter.py
+++ b/src/sktime_mcp/data/adapters/url_adapter.py
@@ -4,6 +4,9 @@ URL adapter for downloading files directly from the web.
 Supports downloading and loading CSV, Excel, and Parquet files from URLs.
 """
 
+import ipaddress
+import logging
+import socket
 import tempfile
 import urllib.request
 from pathlib import Path
@@ -14,6 +17,10 @@ import pandas as pd
 
 from ..base import DataSourceAdapter
 from .file_adapter import FileAdapter
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_SCHEMES = {"http", "https"}
 
 
 class UrlAdapter(DataSourceAdapter):
@@ -38,10 +45,47 @@ class UrlAdapter(DataSourceAdapter):
     }
     """
 
+    @staticmethod
+    def _validate_url(url: str) -> None:
+        """Validate URL scheme and ensure it does not target internal resources.
+
+        Raises ``ValueError`` for disallowed schemes or private/internal IPs.
+        """
+        parsed = urlparse(url)
+
+        # 1. Scheme check
+        if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+            raise ValueError(
+                f"URL scheme '{parsed.scheme}' is not allowed. "
+                f"Only {_ALLOWED_SCHEMES} are permitted."
+            )
+
+        # 2. Hostname must be present
+        hostname = parsed.hostname
+        if not hostname:
+            raise ValueError("URL must contain a valid hostname.")
+
+        # 3. Resolve hostname and block private / reserved IP ranges
+        try:
+            addr_infos = socket.getaddrinfo(hostname, None)
+        except socket.gaierror as e:
+            raise ValueError(f"Could not resolve hostname '{hostname}': {e}") from e
+
+        for _family, _type, _proto, _canon, sockaddr in addr_infos:
+            ip = ipaddress.ip_address(sockaddr[0])
+            if ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local:
+                raise ValueError(
+                    f"URL resolves to a private/internal address ({ip}). "
+                    "Requests to internal networks are blocked for security."
+                )
+
     def load(self) -> pd.DataFrame:
         url = self.config.get("url")
         if not url:
             raise ValueError("Config must contain 'url' key")
+
+        # Validate URL before making any network request
+        self._validate_url(url)
 
         # Determine a filename / extension from the URL if possible
         parsed_url = urlparse(url)
@@ -63,6 +107,8 @@ class UrlAdapter(DataSourceAdapter):
             file_config = dict(self.config)
             file_config["type"] = "file"
             file_config["path"] = str(temp_file_path)
+            # Allow FileAdapter to read from the temp directory
+            file_config["allowed_directories"] = [temp_dir.name]
 
             # Use FileAdapter to load the data
             file_adapter = FileAdapter(file_config)

--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -293,12 +293,7 @@ def load_model_tool(path: str) -> dict[str, Any]:
             "path": path,
             "message": f"Successfully loaded {estimator_name}",
         }
-<<<<<<< HEAD
-
-    except Exception as e:
-=======
     except Exception as exc:
->>>>>>> 2911302554c2dd23e8fd54a1b1a7fce00e5401d0
         return {
             "success": False,
             "error": f"Failed to load model: {str(exc)}",

--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -298,6 +298,7 @@ def load_model_tool(path: str) -> dict[str, Any]:
             "path": path,
             "message": f"Successfully loaded {estimator_name}",
         }
+
     except Exception as e:
         return {
             "success": False,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes two security vulnerabilities in data adapters:
* **Arbitrary File Read (FileAdapter):** Sandboxes file access to configurable allowed directories (default: CWD) and blocks sensitive system paths (e.g., `/etc/passwd`). 
* **SSRF (UrlAdapter):** Restricts URLs to `http/https` and blocks requests to private/internal IP ranges (e.g., cloud metadata).

#### Does your contribution introduce a new dependency? If yes, which one?
NO

#### What should a reviewer concentrate their feedback on?
* If the IP blocklist in `UrlAdapter._validate_url` covers all necessary environments.

#### Any other comments?
Critical fixes for LLM integration to prevent agents from reading server secrets or hitting internal network endpoints.


#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.

tests pass locally
<img width="1918" height="91" alt="Screenshot 2026-04-07 004939" src="https://github.com/user-attachments/assets/b29bfe66-adab-47b8-abd4-da419cc7de17" />

lint pass locally
<img width="1918" height="156" alt="Screenshot 2026-04-07 004959" src="https://github.com/user-attachments/assets/5b86456b-a8f8-45ad-9843-38cedc0b2a18" />