### PR TITLE
fix: add mlflow as optional dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ files = [
     "openpyxl>=3.0.0",  # Excel
     "pyarrow>=10.0.0",  # Parquet
 ]
+
+# MLflow model registry support
+mlflow = [
+    "mlflow>=2.0",
+]
 # All optional dependencies
 all = [
     "pmdarima>=2.0.0",
@@ -77,6 +82,7 @@ all = [
     "pymysql>=1.0.0",
     "openpyxl>=3.0.0",
     "pyarrow>=10.0.0",
+    "mlflow>=2.0", 
 ]
 
 [project.scripts]

--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -272,7 +272,7 @@ def load_model_tool(path: str) -> dict[str, Any]:
             "success": False,
             "error": (
                 "The 'mlflow' package is required to load saved models. "
-                "Please install it with: pip install sktime[mlflow]"
+                "Please install it with: pip install sktime-mcp[mlflow]"
             ),
         }
     try:


### PR DESCRIPTION
Closes #97 

## Changes
- `pyproject.toml` — added `mlflow = ["mlflow>=2.0"]` extra
- `pyproject.toml` — added `"mlflow>=2.0"` to `all` extra
- `instantiate.py` line 275 — fixed error message: `sktime[mlflow]` → `sktime-mcp[mlflow]`