### PR TITLE
fix(docs): add missing instantiation step in forecasting workflow

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -76,12 +76,24 @@ The `sktime-mcp` server exposes a suite of tools designed for Large Language Mod
 {"tool": "list_estimators", "arguments": {"task": "forecasting", "limit": 5}}
 ```
 
-**Step 3: Instantiate & Run**
+**Step 3: Instantiate the Estimator**
+```json
+{
+  "tool": "instantiate_estimator",
+  "arguments": {
+    "estimator": "NaiveForecaster"
+  }
+}
+```
+Returns a handle, e.g. `{"success": true, "handle": "est_abc123", ...}`.  
+Use the returned `handle` value in the next step as `estimator_handle`.
+
+**Step 4: Fit & Predict**
 ```json
 {
   "tool": "fit_predict",
   "arguments": {
-    "estimator_handle": "est_id_from_step_2",
+    "estimator_handle": "est_abc123",
     "dataset": "airline",
     "horizon": 12
   }


### PR DESCRIPTION
#### Reference Issues/PRs
None - identified while testing the Hello World workflow locally.

---

#### What does this implement/fix? Explain your changes.
The "Hello World" forecasting workflow in `docs/user-guide.md` skips a required step.

Step 2 calls `list_estimators`, which returns estimator names (e.g. `"NaiveForecaster"`). Step 3 then passes a placeholder `"est_id_from_step_2"` directly to `fit_predict` as `estimator_handle` — but `fit_predict` requires a real handle, which is only created by `instantiate_estimator` or `instantiate_pipeline`.

This means the documented workflow cannot work as written.

**Fix:** Split the old Step 3 into two steps:
- **Step 3** — call `instantiate_estimator` with a concrete estimator name, showing the handle it returns  
- **Step 4** — call `fit_predict` using that handle  

This now matches the pattern already used by the Pipeline Composition workflow (Workflow 2) in the same file.

---

#### Does your contribution introduce a new dependency? If yes, which one?
No.

---

#### What should a reviewer concentrate their feedback on?
- Whether the example estimator name (`NaiveForecaster`) is a good default choice for a Hello World example  
- Whether the brief return-value note between Steps 3 and 4 is clear enough  

---

#### Any other comments?
Single-file, docs-only change.

The fix was verified against:
- `instantiate_estimator_tool()` in `src/sktime_mcp/tools/instantiate.py` - confirms it returns a handle  
- `list_estimators_tool()` in `src/sktime_mcp/tools/list_estimators.py` - confirms it returns names, not handles  
- `fit_predict` schema in `server.py` — confirms it requires `estimator_handle`  

---

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors.  
- [ ] Optionally, I've updated sktime's CODEOWNERS to receive notifications about future changes to these files.  
- [ ] I've added unit tests and made sure they pass locally. *(docs-only change - no new code to test)*  