### PR TITLE
Update invalid list_data_handles reference to list_available_data

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -363,7 +363,7 @@ async def list_tools() -> list[Tool]:
             name="fit_predict_with_data",
             description=(
                 "Fit an estimator and generate predictions using custom data. GUIDELINES: "
-                "1. BEFORE calling this, check 'list_data_handles' or 'load_data_source' output. "
+                "1. BEFORE calling this, check 'list_available_data' (with is_demo=false) or 'load_data_source' output. "
                 "2. If the metadata contains warnings about default target columns or column ambiguity, "
                 "STOP and re-load the data with explicit 'target_column' and 'time_column' mapping."
             ),


### PR DESCRIPTION
#### Reference Issues/PRs
Related to the `list_available_data` unification introduced in #61.  
The tool description in `server.py` was not updated when `list_data_handles` was replaced.

---

#### What does this implement/fix? Explain your changes.
The `fit_predict_with_data` tool description in `server.py` tells LLMs to call `list_data_handles` before using it - but `list_data_handles` is not a registered MCP tool. It was replaced by `list_available_data` (with `is_demo=false` for handles only).

Since this string is the tool's runtime description (read by the LLM at tool-use time, not just documentation), an LLM following the guideline will attempt to call a nonexistent tool and fail.

**Fix:** Replace `list_data_handles` with `list_available_data` (with `is_demo=false`) in the `fit_predict_with_data` tool description.

This is a one-line change in `server.py`.

---

#### Does your contribution introduce a new dependency? If yes, which one?
No.

---

#### What should a reviewer concentrate their feedback on?
- Whether the parenthetical `(with is_demo=false)` is helpful or too verbose for a tool description string  

---

#### Any other comments?
This change targets the MCP tool description (runtime instruction for LLMs), not just documentation.  
Unlike README/docs fixes, this directly affects tool usage behavior at runtime.

---

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors.  
- [ ] Optionally, I've updated sktime's CODEOWNERS to receive notifications about future changes to these files.  
- [ ] I've added unit tests and made sure they pass locally. *(no new code to test — tool description string fix only)*  
