### PR TITLE
Add supervised execution tools for classifiers and regressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Discover estimators by task type and capability tags.
 }
 ```
 
-**Returns:** List of matching estimators with name, task, and summary info.
+**Returns:** List of matching estimators with name, task, tags, tag counts, hyperparameter counts, and a short docstring preview.
 
 ---
 
@@ -215,7 +215,7 @@ Check if a proposed pipeline composition is valid before instantiation.
 ### Execution
 
 #### 8. `fit_predict`
-Execute a complete workflow: load dataset, fit estimator, and generate predictions.
+Execute a complete forecasting workflow on a built-in demo dataset.
 
 **Arguments:**
 - `estimator_handle` (required): Handle from `instantiate_estimator` or `instantiate_pipeline`
@@ -235,7 +235,51 @@ Execute a complete workflow: load dataset, fit estimator, and generate predictio
 
 ---
 
-#### 9. `save_model`
+#### 9. `fit_predict_classification`
+Fit a classifier on supervised data and predict class labels.
+
+**Arguments:**
+- `estimator_handle` (required): Handle from `instantiate_estimator` or `instantiate_pipeline`
+- `train_data_handle` (required): Handle loaded with `target_column` set
+- `predict_data_handle` (optional): Feature-only or supervised handle for inference. If omitted, predictions are generated on the training features.
+- `return_probabilities` (optional): Include `predict_proba` output when supported
+
+**Example:**
+```json
+{
+  "estimator_handle": "est_cls123",
+  "train_data_handle": "data_train123",
+  "predict_data_handle": "data_test123",
+  "return_probabilities": true
+}
+```
+
+**Returns:** `{"success": true, "predictions": ["class_a", "class_b"], "probabilities": [[0.8, 0.2], ...], "classes": ["class_a", "class_b"]}`
+
+---
+
+#### 10. `fit_predict_regression`
+Fit a regressor on supervised data and predict numeric targets.
+
+**Arguments:**
+- `estimator_handle` (required): Handle from `instantiate_estimator` or `instantiate_pipeline`
+- `train_data_handle` (required): Handle loaded with `target_column` set
+- `predict_data_handle` (optional): Feature-only or supervised handle for inference. If omitted, predictions are generated on the training features.
+
+**Example:**
+```json
+{
+  "estimator_handle": "est_reg123",
+  "train_data_handle": "data_train123",
+  "predict_data_handle": "data_test123"
+}
+```
+
+**Returns:** `{"success": true, "predictions": [10.2, 10.5, 10.7], "task": "regression"}`
+
+---
+
+#### 11. `save_model`
 Persist a fitted estimator or pipeline handle to a local filesystem path using `sktime.utils.mlflow_sktime.save_model`.
 
 **Arguments:**

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -88,6 +88,25 @@ Fit a model and generate predictions using custom data.
 }
 ```
 
+### `fit_predict_classification`
+
+Fit a classifier on supervised training data and predict class labels.
+
+**Arguments:**
+- `estimator_handle` (str): Handle from `instantiate_estimator`
+- `train_data_handle` (str): Handle loaded with `target_column`
+- `predict_data_handle` (str, optional): Feature-only or supervised handle for inference
+- `return_probabilities` (bool, optional): Include `predict_proba` output when available
+
+### `fit_predict_regression`
+
+Fit a regressor on supervised training data and predict numeric targets.
+
+**Arguments:**
+- `estimator_handle` (str): Handle from `instantiate_estimator`
+- `train_data_handle` (str): Handle loaded with `target_column`
+- `predict_data_handle` (str, optional): Feature-only or supervised handle for inference
+
 ### `list_data_sources`
 
 List all available data source types.
@@ -121,6 +140,8 @@ Release a data handle and free memory.
     "data": df_or_dict,  # DataFrame or dict
     "time_column": "date",  # Optional, will try to detect
     "target_column": "sales",  # Optional, defaults to first column
+    "feature_only": False,  # Optional, set True for inference-only feature handles
+    "feature_columns": ["sensor_1", "sensor_2"],  # Optional explicit feature subset
     "exog_columns": ["temp", "promo"],  # Optional
     "frequency": "D"  # Optional, will try to infer
 }
@@ -211,6 +232,18 @@ Validation results are included in the response:
     "warnings": ["Missing values detected: {'sales': 5.0}"]  # Non-critical issues
 }
 ```
+
+For supervised classification/regression inference, load the prediction set with:
+
+```python
+{
+    "type": "pandas",
+    "data": X_test,
+    "feature_only": True
+}
+```
+
+This stores all columns as features without assuming there is a target column.
 
 ## Installation
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -52,7 +52,7 @@ The `sktime-mcp` server exposes a suite of tools designed for Large Language Mod
 |----------|-------|-------------|
 | **Discovery** | `list_estimators`, `search_estimators`, `describe_estimator` | Find the right model for your task (Forecasting, Classification, etc.). |
 | **Instantiation** | `instantiate_estimator`, `instantiate_pipeline` | Create model instances or complex pipelines. |
-| **Execution** | `fit_predict`, `fit`, `predict` | Train models and generate forecasts. |
+| **Execution** | `fit_predict`, `fit_predict_classification`, `fit_predict_regression` | Train models and generate forecasts, class labels, or regression outputs. |
 | **Data** | `load_data_source`, `list_available_data` | Load data from Pandas, CSV/Parquet, or SQL, and inspect demo datasets plus active handles. |
 | **Export** | `export_code`, `save_model` | Generate Python code or persist fitted estimators to a local path. |
 
@@ -114,7 +114,52 @@ Check if components work together (e.g., Deseasonalizer -> Detrender -> ARIMA).
 }
 ```
 
-### 3. Save a Fitted Model
+### 3. Supervised Classification with Data Handles
+
+#### Query - Train a classifier on custom data and predict labels on a second dataset.
+
+**Step 1: Load supervised training data**
+```json
+{
+  "tool": "load_data_source",
+  "arguments": {
+    "config": {
+      "type": "pandas",
+      "data": "X_train_with_target",
+      "target_column": "label"
+    }
+  }
+}
+```
+
+**Step 2: Load feature-only prediction data**
+```json
+{
+  "tool": "load_data_source",
+  "arguments": {
+    "config": {
+      "type": "pandas",
+      "data": "X_test_only",
+      "feature_only": true
+    }
+  }
+}
+```
+
+**Step 3: Instantiate and run the classifier**
+```json
+{
+  "tool": "fit_predict_classification",
+  "arguments": {
+    "estimator_handle": "est_classifier123",
+    "train_data_handle": "data_train123",
+    "predict_data_handle": "data_test123",
+    "return_probabilities": true
+  }
+}
+```
+
+### 4. Save a Fitted Model
 
 Persist a trained estimator to a local filesystem path using sktime's MLflow integration.
 

--- a/src/sktime_mcp/data/adapters/pandas_adapter.py
+++ b/src/sktime_mcp/data/adapters/pandas_adapter.py
@@ -170,7 +170,14 @@ class PandasAdapter(DataSourceAdapter):
 
         # Check for constant values
         for col in data.columns:
-            if data[col].nunique() == 1:
+            try:
+                unique_count = data[col].nunique()
+            except TypeError:
+                # Nested sktime panel columns contain Series objects that are not hashable.
+                # Skip constant-value detection for those columns.
+                continue
+
+            if unique_count == 1:
                 warnings.append(f"Column '{col}' has constant values")
 
         # Check frequency

--- a/src/sktime_mcp/data/base.py
+++ b/src/sktime_mcp/data/base.py
@@ -58,7 +58,9 @@ class DataSourceAdapter(ABC):
         """
         pass
 
-    def to_sktime_format(self, data: pd.DataFrame) -> tuple[pd.Series, Optional[pd.DataFrame]]:
+    def to_sktime_format(
+        self, data: pd.DataFrame
+    ) -> tuple[Optional[pd.Series], Optional[pd.DataFrame]]:
         """
         Convert to sktime format (y, X).
 
@@ -67,12 +69,28 @@ class DataSourceAdapter(ABC):
 
         Returns:
             Tuple of (y, X) where:
-            - y: Target time series (pd.Series with DatetimeIndex)
-            - X: Exogenous variables (pd.DataFrame, optional)
+            - y: Target values (pd.Series) or None for feature-only inference handles
+            - X: Feature matrix / exogenous variables (pd.DataFrame, optional)
         """
+        if self.config.get("feature_only", False):
+            feature_cols = self.config.get("feature_columns")
+            if feature_cols:
+                missing = [col for col in feature_cols if col not in data.columns]
+                if missing:
+                    raise ValueError(
+                        f"Feature columns not found in data: {missing}. "
+                        f"Available columns: {list(data.columns)}"
+                    )
+                X = data[feature_cols]
+            else:
+                X = data.copy()
+
+            return None, X
+
         # Get target column from config
         target_col = self.config.get("target_column")
-        exog_cols = self.config.get("exog_columns", [])
+        feature_cols = self.config.get("feature_columns")
+        exog_cols = feature_cols or self.config.get("exog_columns", [])
 
         if target_col and target_col in data.columns:
             y = data[target_col]

--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -59,6 +59,9 @@ class EstimatorNode:
             "task": self.task,
             "module": self.module,
             "tags": self.tags,
+            "tag_count": len(self.tags),
+            "hyperparameter_count": len(self.hyperparameters),
+            "docstring_preview": self.docstring[:200] if self.docstring else None,
         }
 
 

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -32,6 +32,21 @@ DEMO_DATASETS = {
 }
 
 
+def _serialize_predictions(predictions: Any) -> Any:
+    """Convert model outputs to JSON-safe primitives."""
+    if isinstance(predictions, pd.Series):
+        predictions_copy = predictions.copy()
+        predictions_copy.index = predictions_copy.index.astype(str)
+        return predictions_copy.to_dict()
+
+    if isinstance(predictions, pd.DataFrame):
+        predictions_copy = predictions.copy()
+        predictions_copy.index = predictions_copy.index.astype(str)
+        return predictions_copy.to_dict(orient="list")
+
+    return predictions.tolist() if hasattr(predictions, "tolist") else predictions
+
+
 class Executor:
     """
     Execution runtime for sktime estimators.
@@ -61,6 +76,7 @@ class Executor:
                 estimator_name=estimator_name,
                 instance=instance,
                 params=params or {},
+                metadata={"task": node.task},
             )
             return {
                 "success": True,
@@ -113,12 +129,25 @@ class Executor:
     ) -> dict[str, Any]:
         """Fit an estimator."""
         try:
-            instance = self._handle_manager.get_instance(handle_id)
+            handle_info = self._handle_manager.get_info(handle_id)
+            instance = handle_info.instance
         except KeyError:
             return {"success": False, "error": f"Handle not found: {handle_id}"}
 
         try:
-            if fh is not None:
+            task = self._get_handle_task(handle_info)
+
+            if task in ("classification", "regression"):
+                if X is None:
+                    return {
+                        "success": False,
+                        "error": (
+                            f"{task.capitalize()} estimators require feature data X during fit. "
+                            "Load supervised data with a target column for training."
+                        ),
+                    }
+                instance.fit(X, y)
+            elif fh is not None:
                 instance.fit(y, X=X, fh=fh)
             elif X is not None:
                 instance.fit(y, X=X)
@@ -146,26 +175,34 @@ class Executor:
             return {"success": False, "error": "Estimator not fitted"}
 
         try:
+            task = self._get_handle_task(handle_id)
+
+            if task in ("classification", "regression"):
+                if X is None:
+                    return {
+                        "success": False,
+                        "error": (
+                            f"{task.capitalize()} prediction requires feature data X. "
+                            "Pass a feature-only or supervised data handle with columns matching training."
+                        ),
+                    }
+
+                predictions = instance.predict(X)
+                return {
+                    "success": True,
+                    "predictions": _serialize_predictions(predictions),
+                    "task": task,
+                    "n_predictions": len(predictions) if hasattr(predictions, "__len__") else None,
+                }
+
             if fh is None:
                 fh = list(range(1, 13))
 
             predictions = instance.predict(fh=fh, X=X) if X is not None else instance.predict(fh=fh)
 
-            if isinstance(predictions, pd.Series):
-                # Convert index to string to avoid JSON serialization issues with Period/DatetimeIndex
-                predictions_copy = predictions.copy()
-                predictions_copy.index = predictions_copy.index.astype(str)
-                result = predictions_copy.to_dict()
-            elif isinstance(predictions, pd.DataFrame):
-                predictions_copy = predictions.copy()
-                predictions_copy.index = predictions_copy.index.astype(str)
-                result = predictions_copy.to_dict(orient="list")
-            else:
-                result = predictions.tolist() if hasattr(predictions, "tolist") else predictions
-
             return {
                 "success": True,
-                "predictions": result,
+                "predictions": _serialize_predictions(predictions),
                 "horizon": len(fh) if hasattr(fh, "__len__") else fh,
             }
         except Exception as e:
@@ -433,6 +470,7 @@ class Executor:
                 estimator_name=pipeline_name,
                 instance=pipeline,
                 params={"components": components, "params_list": params_list},
+                metadata={"task": final_task, "components": components},
             )
 
             return {
@@ -497,9 +535,11 @@ class Executor:
 
             # Update metadata to reflect the target and used columns
             metadata = adapter.get_metadata().copy()
-            metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
+            metadata["columns"] = list(data.columns)
+            metadata["target_column"] = y.name if hasattr(y, "name") and y.name else None
+            metadata["feature_only"] = y is None
             if X is not None:
-                metadata["exog_columns"] = list(X.columns)
+                metadata["feature_columns"] = list(X.columns)
             # Inject column dtypes so LLMs can distinguish time index vs target
             metadata["dtypes"] = {col: str(dtype) for col, dtype in data.dtypes.items()}
             # Generate handle
@@ -515,7 +555,10 @@ class Executor:
             }
 
             # Apply auto-formatting if enabled
-            if getattr(self, "_auto_format_enabled", True):
+            should_auto_format = y is not None and isinstance(
+                y.index, (pd.DatetimeIndex, pd.PeriodIndex)
+            )
+            if should_auto_format and getattr(self, "_auto_format_enabled", True):
                 try:
                     format_result = self.format_data_handle(
                         data_handle, auto_infer_freq=True, fill_missing=True, remove_duplicates=True
@@ -534,12 +577,10 @@ class Executor:
                 except Exception as e:
                     logger.warning(f"Auto-formatting failed: {e}")
                     # Continue with unformatted data if formatting fails
-            _final_meta = adapter.get_metadata().copy()
-            _final_meta["dtypes"] = {col: str(dtype) for col, dtype in data.dtypes.items()}
             return {
                 "success": True,
                 "data_handle": data_handle,
-                "metadata": _final_meta,
+                "metadata": metadata,
                 "validation": validation_report,
             }
 
@@ -620,9 +661,11 @@ class Executor:
             y, X = adapter.to_sktime_format(data)
 
             metadata = adapter.get_metadata().copy()
-            metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
+            metadata["columns"] = list(data.columns)
+            metadata["target_column"] = y.name if hasattr(y, "name") and y.name else None
+            metadata["feature_only"] = y is None
             if X is not None:
-                metadata["exog_columns"] = list(X.columns)
+                metadata["feature_columns"] = list(X.columns)
             # Inject column dtypes so LLMs can distinguish time index vs target
             metadata["dtypes"] = {col: str(dtype) for col, dtype in data.dtypes.items()}
             data_handle = f"data_{uuid.uuid4().hex[:8]}"
@@ -636,7 +679,10 @@ class Executor:
             }
 
             # auto-format if enabled
-            if getattr(self, "_auto_format_enabled", True):
+            should_auto_format = y is not None and isinstance(
+                y.index, (pd.DatetimeIndex, pd.PeriodIndex)
+            )
+            if should_auto_format and getattr(self, "_auto_format_enabled", True):
                 try:
                     format_result = self.format_data_handle(
                         data_handle, auto_infer_freq=True, fill_missing=True, remove_duplicates=True
@@ -688,6 +734,15 @@ class Executor:
             return {"success": False, "error": f"Data handle '{data_handle}' not found"}
 
         data_info = self._data_handles[data_handle]
+        if data_info["y"] is None:
+            return {
+                "success": False,
+                "error": (
+                    "Feature-only data handles cannot be auto-formatted as time series. "
+                    "Use them directly for classification/regression inference."
+                ),
+            }
+
         y = data_info["y"].copy()
         X = data_info["X"].copy() if data_info["X"] is not None else None
 
@@ -823,6 +878,15 @@ class Executor:
         y = data["y"]
         X = data.get("X")
 
+        if y is None:
+            return {
+                "success": False,
+                "error": (
+                    "fit_predict_with_data requires a target column. "
+                    "Feature-only handles are only valid for supervised inference."
+                ),
+            }
+
         # Fit
         fh = list(range(1, horizon + 1))
         fit_result = self.fit(estimator_handle, y=y, X=X, fh=fh)
@@ -831,6 +895,82 @@ class Executor:
 
         # Predict
         return self.predict(estimator_handle, fh=fh, X=X)
+
+    def fit_predict_classification_with_data(
+        self,
+        estimator_handle: str,
+        train_data_handle: str,
+        predict_data_handle: Optional[str] = None,
+        return_probabilities: bool = False,
+    ) -> dict[str, Any]:
+        """Fit a classifier on supervised data and predict labels on feature data."""
+        train_result = self._get_supervised_data(train_data_handle, require_target=True)
+        if not train_result["success"]:
+            return train_result
+
+        predict_result = self._get_supervised_data(
+            predict_data_handle or train_data_handle,
+            require_target=False,
+        )
+        if not predict_result["success"]:
+            return predict_result
+
+        fit_result = self.fit(estimator_handle, y=train_result["y"], X=train_result["X"])
+        if not fit_result["success"]:
+            return fit_result
+
+        predictions = self.predict(estimator_handle, X=predict_result["X"])
+        if not predictions["success"]:
+            return predictions
+
+        result = {
+            **predictions,
+            "train_data_handle": train_data_handle,
+            "predict_data_handle": predict_data_handle or train_data_handle,
+            "prediction_scope": "external" if predict_data_handle else "train",
+        }
+
+        if return_probabilities:
+            proba_result = self.predict_proba(estimator_handle, X=predict_result["X"])
+            if not proba_result["success"]:
+                return proba_result
+            result["probabilities"] = proba_result["probabilities"]
+            result["classes"] = proba_result["classes"]
+
+        return result
+
+    def fit_predict_regression_with_data(
+        self,
+        estimator_handle: str,
+        train_data_handle: str,
+        predict_data_handle: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Fit a regressor on supervised data and predict numeric targets."""
+        train_result = self._get_supervised_data(train_data_handle, require_target=True)
+        if not train_result["success"]:
+            return train_result
+
+        predict_result = self._get_supervised_data(
+            predict_data_handle or train_data_handle,
+            require_target=False,
+        )
+        if not predict_result["success"]:
+            return predict_result
+
+        fit_result = self.fit(estimator_handle, y=train_result["y"], X=train_result["X"])
+        if not fit_result["success"]:
+            return fit_result
+
+        predictions = self.predict(estimator_handle, X=predict_result["X"])
+        if not predictions["success"]:
+            return predictions
+
+        return {
+            **predictions,
+            "train_data_handle": train_data_handle,
+            "predict_data_handle": predict_data_handle or train_data_handle,
+            "prediction_scope": "external" if predict_data_handle else "train",
+        }
 
     def list_data_handles(self) -> dict[str, Any]:
         """
@@ -876,6 +1016,101 @@ class Executor:
                 "success": False,
                 "error": f"Data handle '{data_handle}' not found",
             }
+
+    def _get_handle_task(self, handle_or_id: Union[str, Any]) -> Optional[str]:
+        """Resolve a handle's task, preferring explicit metadata."""
+        if isinstance(handle_or_id, str):
+            handle_info = self._handle_manager.get_info(handle_or_id)
+        else:
+            handle_info = handle_or_id
+
+        task = handle_info.metadata.get("task")
+        if task:
+            return task
+
+        node = self._registry.get_estimator_by_name(handle_info.estimator_name)
+        if node is not None:
+            return node.task
+
+        instance = handle_info.instance
+        object_type = None
+        try:
+            if hasattr(instance, "get_tag"):
+                object_type = instance.get_tag("object_type", raise_error=False)
+            elif hasattr(instance, "get_class_tag"):
+                object_type = instance.get_class_tag("object_type")
+        except Exception:
+            object_type = None
+
+        return self._registry.TASK_MAP.get(object_type, object_type)
+
+    def _get_supervised_data(
+        self,
+        data_handle: str,
+        require_target: bool,
+    ) -> dict[str, Any]:
+        """Fetch stored y/X pairs from a data handle for supervised tasks."""
+        if data_handle not in self._data_handles:
+            return {
+                "success": False,
+                "error": f"Unknown data handle: {data_handle}",
+                "available_handles": list(self._data_handles.keys()),
+            }
+
+        data = self._data_handles[data_handle]
+        y = data.get("y")
+        X = data.get("X")
+
+        if require_target and y is None:
+            return {
+                "success": False,
+                "error": (
+                    f"Data handle '{data_handle}' does not contain a target column. "
+                    "Load training data with target_column set."
+                ),
+            }
+
+        if X is None:
+            return {
+                "success": False,
+                "error": (
+                    f"Data handle '{data_handle}' does not contain feature columns. "
+                    "Load data with exogenous columns or feature_only=true."
+                ),
+            }
+
+        return {"success": True, "y": y, "X": X}
+
+    def predict_proba(
+        self,
+        handle_id: str,
+        X: Any,
+    ) -> dict[str, Any]:
+        """Generate classification probabilities from a fitted estimator."""
+        try:
+            instance = self._handle_manager.get_instance(handle_id)
+        except KeyError:
+            return {"success": False, "error": f"Handle not found: {handle_id}"}
+
+        if not self._handle_manager.is_fitted(handle_id):
+            return {"success": False, "error": "Estimator not fitted"}
+
+        if not hasattr(instance, "predict_proba"):
+            return {
+                "success": False,
+                "error": "Estimator does not expose predict_proba",
+            }
+
+        try:
+            probabilities = instance.predict_proba(X)
+            classes = getattr(instance, "classes_", None)
+            return {
+                "success": True,
+                "probabilities": _serialize_predictions(probabilities),
+                "classes": classes.tolist() if hasattr(classes, "tolist") else classes,
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
 
 
 _executor_instance: Optional[Executor] = None

--- a/src/sktime_mcp/runtime/jobs.py
+++ b/src/sktime_mcp/runtime/jobs.py
@@ -305,7 +305,7 @@ class JobManager:
         cutoff = datetime.now() - timedelta(hours=max_age_hours)
 
         with self.lock:
-            old_job_ids = [job_id for job_id, job in self.jobs.items() if job.created_at < cutoff]
+            old_job_ids = [job_id for job_id, job in self.jobs.items() if job.created_at <= cutoff]
 
             for job_id in old_job_ids:
                 del self.jobs[job_id]

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -55,6 +55,10 @@ from sktime_mcp.tools.list_estimators import (
     list_estimators_tool,
 )
 from sktime_mcp.tools.save_model import save_model_tool
+from sktime_mcp.tools.supervised import (
+    fit_predict_classification_tool,
+    fit_predict_regression_tool,
+)
 
 # Configure logging to stderr with detailed format
 logging.basicConfig(
@@ -388,6 +392,63 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="fit_predict_classification",
+            description=(
+                "Fit a classifier on supervised data and predict class labels. "
+                "Use a training handle loaded with target_column set, and optionally "
+                "a second feature-only handle loaded with feature_only=true."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle from instantiate_estimator or instantiate_pipeline",
+                    },
+                    "train_data_handle": {
+                        "type": "string",
+                        "description": "Data handle with target and feature columns",
+                    },
+                    "predict_data_handle": {
+                        "type": "string",
+                        "description": "Optional feature-only or supervised data handle for inference",
+                    },
+                    "return_probabilities": {
+                        "type": "boolean",
+                        "description": "Include predict_proba output when available",
+                        "default": False,
+                    },
+                },
+                "required": ["estimator_handle", "train_data_handle"],
+            },
+        ),
+        Tool(
+            name="fit_predict_regression",
+            description=(
+                "Fit a regressor on supervised data and predict numeric targets. "
+                "Use a training handle loaded with target_column set, and optionally "
+                "a second feature-only handle loaded with feature_only=true."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle from instantiate_estimator or instantiate_pipeline",
+                    },
+                    "train_data_handle": {
+                        "type": "string",
+                        "description": "Data handle with target and feature columns",
+                    },
+                    "predict_data_handle": {
+                        "type": "string",
+                        "description": "Optional feature-only or supervised data handle for inference",
+                    },
+                },
+                "required": ["estimator_handle", "train_data_handle"],
+            },
+        ),
+        Tool(
             name="release_data_handle",
             description="Release a data handle and free memory",
             inputSchema={
@@ -628,6 +689,21 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments.get("horizon", 12),
             )
             # Sanitize immediately to handle Period objects
+            result = sanitize_for_json(result)
+        elif name == "fit_predict_classification":
+            result = fit_predict_classification_tool(
+                arguments["estimator_handle"],
+                arguments["train_data_handle"],
+                arguments.get("predict_data_handle"),
+                arguments.get("return_probabilities", False),
+            )
+            result = sanitize_for_json(result)
+        elif name == "fit_predict_regression":
+            result = fit_predict_regression_tool(
+                arguments["estimator_handle"],
+                arguments["train_data_handle"],
+                arguments.get("predict_data_handle"),
+            )
             result = sanitize_for_json(result)
         elif name == "release_data_handle":
             result = release_data_handle_tool(arguments["data_handle"])

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -10,6 +10,10 @@ from sktime_mcp.tools.format_tools import (
 from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 from sktime_mcp.tools.list_estimators import list_estimators_tool
 from sktime_mcp.tools.save_model import save_model_tool
+from sktime_mcp.tools.supervised import (
+    fit_predict_classification_tool,
+    fit_predict_regression_tool,
+)
 
 __all__ = [
     "list_estimators_tool",
@@ -20,4 +24,6 @@ __all__ = [
     "save_model_tool",
     "format_time_series_tool",
     "auto_format_on_load_tool",
+    "fit_predict_classification_tool",
+    "fit_predict_regression_tool",
 ]

--- a/src/sktime_mcp/tools/supervised.py
+++ b/src/sktime_mcp/tools/supervised.py
@@ -1,0 +1,62 @@
+"""
+Supervised execution tools for sktime MCP.
+
+Provides dedicated classification and regression workflows.
+"""
+
+from typing import Any, Optional
+
+from sktime_mcp.runtime.executor import get_executor
+
+
+def fit_predict_classification_tool(
+    estimator_handle: str,
+    train_data_handle: str,
+    predict_data_handle: Optional[str] = None,
+    return_probabilities: bool = False,
+) -> dict[str, Any]:
+    """
+    Fit a classifier on supervised data and predict class labels.
+
+    Args:
+        estimator_handle: Handle from instantiate_estimator or instantiate_pipeline
+        train_data_handle: Data handle containing target and feature columns
+        predict_data_handle: Optional feature-only or supervised data handle for inference.
+            If omitted, predictions are generated on the training features.
+        return_probabilities: Whether to include predict_proba output when available
+
+    Returns:
+        Dictionary with predicted labels and optional probabilities
+    """
+    executor = get_executor()
+    return executor.fit_predict_classification_with_data(
+        estimator_handle=estimator_handle,
+        train_data_handle=train_data_handle,
+        predict_data_handle=predict_data_handle,
+        return_probabilities=return_probabilities,
+    )
+
+
+def fit_predict_regression_tool(
+    estimator_handle: str,
+    train_data_handle: str,
+    predict_data_handle: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Fit a regressor on supervised data and predict numeric targets.
+
+    Args:
+        estimator_handle: Handle from instantiate_estimator or instantiate_pipeline
+        train_data_handle: Data handle containing target and feature columns
+        predict_data_handle: Optional feature-only or supervised data handle for inference.
+            If omitted, predictions are generated on the training features.
+
+    Returns:
+        Dictionary with predicted numeric values
+    """
+    executor = get_executor()
+    return executor.fit_predict_regression_with_data(
+        estimator_handle=estimator_handle,
+        train_data_handle=train_data_handle,
+        predict_data_handle=predict_data_handle,
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -136,6 +136,127 @@ class TestTools:
         assert result["success"]
         assert "estimators" in result
         assert len(result["estimators"]) <= 5
+        if result["estimators"]:
+            estimator = result["estimators"][0]
+            assert "tags" in estimator
+            assert "tag_count" in estimator
+            assert "hyperparameter_count" in estimator
+            assert "docstring_preview" in estimator
+
+    def test_fit_predict_classification_tool(self):
+        """Classification tool should fit on supervised data and predict on feature-only data."""
+        from sktime.datasets import load_basic_motions
+
+        from sktime_mcp.tools.data_tools import load_data_source_tool, release_data_handle_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool, release_handle_tool
+        from sktime_mcp.tools.supervised import fit_predict_classification_tool
+
+        X_train, y_train = load_basic_motions(split="train")
+        X_test, _ = load_basic_motions(split="test")
+
+        train_df = X_train.copy()
+        train_df["target"] = y_train
+
+        train_result = load_data_source_tool(
+            {
+                "type": "pandas",
+                "data": train_df,
+                "target_column": "target",
+            }
+        )
+        predict_result = load_data_source_tool(
+            {
+                "type": "pandas",
+                "data": X_test.copy(),
+                "feature_only": True,
+            }
+        )
+        estimator_result = instantiate_estimator_tool(
+            "DummyClassifier",
+            {"strategy": "most_frequent"},
+        )
+
+        try:
+            assert train_result["success"]
+            assert predict_result["success"]
+            assert predict_result["metadata"]["feature_only"] is True
+            assert estimator_result["success"]
+
+            result = fit_predict_classification_tool(
+                estimator_result["handle"],
+                train_result["data_handle"],
+                predict_result["data_handle"],
+                return_probabilities=True,
+            )
+
+            assert result["success"]
+            assert result["task"] == "classification"
+            assert len(result["predictions"]) == len(X_test)
+            assert len(result["probabilities"]) == len(X_test)
+            assert "classes" in result
+        finally:
+            if estimator_result.get("success"):
+                release_handle_tool(estimator_result["handle"])
+            if train_result.get("success"):
+                release_data_handle_tool(train_result["data_handle"])
+            if predict_result.get("success"):
+                release_data_handle_tool(predict_result["data_handle"])
+
+    def test_fit_predict_regression_tool(self):
+        """Regression tool should fit on supervised data and predict numeric outputs."""
+        from sktime.datasets import load_tecator
+
+        from sktime_mcp.tools.data_tools import load_data_source_tool, release_data_handle_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool, release_handle_tool
+        from sktime_mcp.tools.supervised import fit_predict_regression_tool
+
+        X_train, y_train = load_tecator(split="train")
+        X_test, _ = load_tecator(split="test")
+
+        train_df = X_train.copy()
+        train_df["target"] = y_train
+
+        train_result = load_data_source_tool(
+            {
+                "type": "pandas",
+                "data": train_df,
+                "target_column": "target",
+            }
+        )
+        predict_result = load_data_source_tool(
+            {
+                "type": "pandas",
+                "data": X_test.copy(),
+                "feature_only": True,
+            }
+        )
+        estimator_result = instantiate_estimator_tool(
+            "DummyRegressor",
+            {"strategy": "mean"},
+        )
+
+        try:
+            assert train_result["success"]
+            assert predict_result["success"]
+            assert estimator_result["success"]
+
+            result = fit_predict_regression_tool(
+                estimator_result["handle"],
+                train_result["data_handle"],
+                predict_result["data_handle"],
+            )
+
+            assert result["success"]
+            assert result["task"] == "regression"
+            assert len(result["predictions"]) == len(X_test)
+            assert all(isinstance(value, (float, int)) for value in result["predictions"])
+        finally:
+            if estimator_result.get("success"):
+                release_handle_tool(estimator_result["handle"])
+            if train_result.get("success"):
+                release_data_handle_tool(train_result["data_handle"])
+            if predict_result.get("success"):
+                release_data_handle_tool(predict_result["data_handle"])
 
     def test_describe_unknown_estimator(self):
         """Test describing an unknown estimator."""


### PR DESCRIPTION
## Summary
- add dedicated it_predict_classification and it_predict_regression MCP tools
- make executor fit/predict task-aware so classifiers/regressors use it(X, y) and predict(X) instead of forecasting-only call shapes
- support eature_only / eature_columns data handles for supervised inference, enrich list_estimators discovery output, and document the new workflow
- cover the new paths with tests and fix the zero-hour job cleanup edge case uncovered during full-suite verification

## Testing
- python -m pytest D:\sktime-mcp\tests -q

## Context
This implements the maintainer-approved directions discussed under RFC issue #34, specifically the dedicated classification/regression execution tools and richer estimator discovery output.