### PR TITLE
Sync docs with current MCP tool surface and strengthen CI (Python 3.9 + docs build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -50,3 +50,21 @@ jobs:
 
       - name: Run tests
         run: pytest tests/
+
+  docs:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Build docs
+        run: mkdocs build

--- a/README.md
+++ b/README.md
@@ -260,14 +260,18 @@ Persist a fitted estimator or pipeline handle to a local filesystem path using `
 
 ---
 
-### Datasets
+### Data Availability
 
-#### 10. `list_datasets`
-List all available demo datasets for testing and experimentation.
+#### 10. `list_available_data`
+List available data in one unified response: built-in demo datasets and active loaded data handles.
 
-**Arguments:** None
+**Arguments:**
+- `is_demo` (optional):
+  - `true` → return only demo datasets
+  - `false` → return only active data handles
+  - omitted → return both
 
-**Returns:** `{"success": true, "datasets": ["airline", "sunspots", "lynx", "shampoo", ...]}`
+**Returns:** `{"success": true, "system_demos": ["airline", "sunspots", ...], "active_handles": [...], "total": 12}`
 
 ---
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -96,13 +96,20 @@ List all available data source types.
 - `sources` (list): Available source types
 - `descriptions` (dict): Description for each source
 
-### `list_data_handles`
+### `list_available_data`
 
-List all currently loaded data handles.
+List available data in a single response, including demo datasets and active handles.
+
+**Arguments (optional):**
+- `is_demo` (bool):
+    - `true` → only demo datasets
+    - `false` → only active data handles
+    - omitted → both
 
 **Returns:**
-- `count` (int): Number of loaded data handles
-- `handles` (list): List of data handle information
+- `system_demos` (list): Built-in demo dataset names
+- `active_handles` (list): Active data handle information
+- `total` (int): Combined count of returned entries
 
 ### `release_data_handle`
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -4,7 +4,7 @@ This guide explains how the project is structured, how to develop new features, 
 
 ## Development Prerequisites
 
-- Python 3.10+
+- Python 3.9+
 - pip
 - Optional: `mkdocs` if you want to build the documentation site
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -10,7 +10,7 @@ Welcome to the **sktime-mcp** User Guide. This comprehensive manual will help yo
 
 Before you begin, ensure you have:
 
-- **Python 3.10+** installed.
+- **Python 3.9+** installed.
 - **pip** package manager.
 - A compatible MCP Client (like **Claude Desktop**).
 
@@ -52,7 +52,7 @@ The `sktime-mcp` server exposes a suite of tools designed for Large Language Mod
 |----------|-------|-------------|
 | **Discovery** | `list_estimators`, `search_estimators`, `describe_estimator` | Find the right model for your task (Forecasting, Classification, etc.). |
 | **Instantiation** | `instantiate_estimator`, `instantiate_pipeline` | Create model instances or complex pipelines. |
-| **Execution** | `fit_predict`, `fit`, `predict` | Train models and generate forecasts. |
+| **Execution** | `fit_predict`, `fit_predict_async`, `fit_predict_with_data` | Train models and generate forecasts on demo or user data. |
 | **Data** | `load_data_source`, `list_available_data` | Load data from Pandas, CSV/Parquet, or SQL, and inspect demo datasets plus active handles. |
 | **Export** | `export_code`, `save_model` | Generate Python code or persist fitted estimators to a local path. |
 
@@ -203,9 +203,9 @@ While `sktime-mcp` is a powerful tool for prototyping, please be aware of the cu
 The server stores active handles in standard Python dictionaries.
 > **Impact**: If the server restarts or connection drops, in-memory handles are lost. Use `save_model` to persist fitted estimators to a local filesystem path when needed.
 
-#### 2. Synchronous Execution (GIL Blocking)
-Heavy operations (like `AutoARIMA` fitting) run on the main thread.
-> **Impact**: The server will not respond to other requests (like "hello") until the fitting operation completes.
+#### 2. Mixed Sync/Async Execution
+Heavy operations can still block when using synchronous tools (like `fit_predict`).
+> **Impact**: For long-running jobs, use async tools (`fit_predict_async`, `load_data_source_async`) so the server remains responsive.
 
 #### 3. "The Data Wall" (Memory Limits)
 Data Adapters read the entire dataset into RAM.


### PR DESCRIPTION
### Summary
This PR aligns project documentation with the current MCP API and updates CI to better match declared support and docs quality checks.

### What changed
- Updated docs to use `list_available_data` instead of older dataset/handle naming.
- Updated execution capability docs to reflect async/background options (`fit_predict_async`, `fit_predict_with_data`).
- Updated documented Python requirement from 3.10+ to 3.9+ to match package metadata.
- Added Python 3.9 to the CI test matrix.
- Added a CI docs build job (`mkdocs build`) to catch documentation regressions.

### Files updated
- `README.md`
- `user-guide.md`
- `data-sources.md`
- `dev-guide.md`
- `ci.yml`