### PR TITLE
feat: expose separate fit and predict tools as MCP endpoints

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -30,6 +30,8 @@ from sktime_mcp.tools.describe_estimator import (
 from sktime_mcp.tools.fit_predict import (
     fit_predict_async_tool,
     fit_predict_tool,
+    fit_tool,
+    predict_tool,
 )
 from sktime_mcp.tools.format_tools import (
     auto_format_on_load_tool,
@@ -175,6 +177,53 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["handle"],
+            },
+        ),
+        Tool(
+            name="fit",
+            description=(
+                "Fit an estimator on a dataset WITHOUT predicting. "
+                "Use this when you want to train a model first and predict later "
+                "(possibly multiple times with different horizons). "
+                "The estimator_handle is marked as fitted after success."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle from instantiate_estimator or instantiate_pipeline",
+                    },
+                    "dataset": {
+                        "type": "string",
+                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                    },
+                },
+                "required": ["estimator_handle", "dataset"],
+            },
+        ),
+        Tool(
+            name="predict",
+            description=(
+                "Generate predictions from an already-fitted estimator. "
+                "The estimator must have been fitted first via the 'fit' or "
+                "'fit_predict' tool. Use this to re-predict with a different "
+                "horizon without re-fitting."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle of a fitted estimator",
+                    },
+                    "horizon": {
+                        "type": "integer",
+                        "description": "Forecast horizon — number of steps ahead (default: 12)",
+                        "default": 12,
+                    },
+                },
+                "required": ["estimator_handle"],
             },
         ),
         Tool(
@@ -588,6 +637,18 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         elif name == "release_handle":
             result = release_handle_tool(arguments["handle"])
 
+        elif name == "fit":
+            result = fit_tool(
+                arguments["estimator_handle"],
+                arguments["dataset"],
+            )
+        elif name == "predict":
+            result = predict_tool(
+                arguments["estimator_handle"],
+                arguments.get("horizon", 12),
+            )
+            # Sanitize to handle Period objects in prediction index
+            result = sanitize_for_json(result)
         elif name == "fit_predict":
             result = fit_predict_tool(
                 arguments["estimator_handle"],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -215,5 +215,82 @@ class TestTools:
         assert calls["serialization_format"] == "pickle"
 
 
+class TestFitPredictSeparate:
+    """Tests for separate fit and predict tools (Issue #92)."""
+
+    def test_fit_then_predict(self):
+        """fit + predict should produce the same result as fit_predict."""
+        from sktime_mcp.tools.fit_predict import fit_tool, predict_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+
+        # Instantiate
+        inst = instantiate_estimator_tool("NaiveForecaster")
+        assert inst["success"]
+        handle = inst["handle"]
+
+        # Fit
+        fit_result = fit_tool(handle, "airline")
+        assert fit_result["success"]
+        assert fit_result["fitted"] is True
+
+        # Predict
+        pred_result = predict_tool(handle, horizon=6)
+        assert pred_result["success"]
+        assert len(pred_result["predictions"]) == 6
+
+    def test_predict_without_fit_fails(self):
+        """predict on an unfitted estimator should fail."""
+        from sktime_mcp.tools.fit_predict import predict_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+
+        inst = instantiate_estimator_tool("NaiveForecaster")
+        assert inst["success"]
+
+        pred = predict_tool(inst["handle"], horizon=3)
+        assert not pred["success"]
+        assert "not fitted" in pred["error"].lower() or "error" in pred
+
+    def test_fit_then_predict_different_horizons(self):
+        """After fitting once, predict should work with different horizons."""
+        from sktime_mcp.tools.fit_predict import fit_tool, predict_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+
+        inst = instantiate_estimator_tool("NaiveForecaster")
+        handle = inst["handle"]
+
+        fit_tool(handle, "airline")
+
+        pred_3 = predict_tool(handle, horizon=3)
+        pred_12 = predict_tool(handle, horizon=12)
+
+        assert pred_3["success"]
+        assert pred_12["success"]
+        assert len(pred_3["predictions"]) == 3
+        assert len(pred_12["predictions"]) == 12
+
+    def test_list_handles_shows_fitted_status(self):
+        """list_handles should reflect fitted status after fit."""
+        from sktime_mcp.tools.fit_predict import fit_tool
+        from sktime_mcp.tools.instantiate import (
+            instantiate_estimator_tool,
+            list_handles_tool,
+        )
+
+        inst = instantiate_estimator_tool("NaiveForecaster")
+        handle = inst["handle"]
+
+        # Before fit
+        handles = list_handles_tool()
+        match = [h for h in handles["handles"] if h["handle_id"] == handle]
+        assert len(match) == 1
+        assert match[0]["fitted"] is False
+
+        # After fit
+        fit_tool(handle, "airline")
+        handles = list_handles_tool()
+        match = [h for h in handles["handles"] if h["handle_id"] == handle]
+        assert match[0]["fitted"] is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Register `fit` and `predict` as independent MCP tools in `server.py`
- Enables LLMs to **fit once, predict many times** with different horizons without re-training
- Adds clear tool descriptions guiding LLMs on when to use `fit`/`predict` vs `fit_predict`
- Prediction output is JSON-sanitized (handles Period index objects)

## Why this matters
Currently, `fit_predict` couples training and inference into a single call. If an LLM wants to try 3 different forecast horizons, it must re-fit the model 3 times. With separate `fit` + `predict`, the model trains once and the LLM can predict with `horizon=3`, `horizon=12`, `horizon=24` instantly.

This also enables inspection workflows — fit a model, check `list_handles` to confirm fitted status, then predict.

## Changes
| File | Change |
|------|--------|
| `server.py` | Import `fit_tool`, `predict_tool`; add Tool schemas + dispatch |
| `tests/test_core.py` | 4 new tests covering fit→predict flow, error cases, multi-horizon |

## Test plan
- [x] `test_fit_then_predict` — fit + predict produces results
- [x] `test_predict_without_fit_fails` — unfitted estimator returns error
- [x] `test_fit_then_predict_different_horizons` — one fit, two predicts with horizon=3 and horizon=12
- [x] `test_list_handles_shows_fitted_status` — fitted flag updates correctly
- [x] All 19 existing tests pass (0 regressions)
- [x] `ruff check` clean

Partially addresses #92

AI was used for basic drafting assistance and refinement; all changes were verified manually.