### PR TITLE
feat: add detect_seasonality and check_structural_break diagnostic tools (#96)

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -47,6 +47,10 @@ from sktime_mcp.tools.list_estimators import (
     get_available_tags,
     list_estimators_tool,
 )
+from sktime_mcp.tools.diagnostics import (
+    check_structural_break_tool,
+    detect_seasonality_tool,
+)
 from sktime_mcp.tools.save_model import save_model_tool
 
 # ---------------------------------------------------------------------------
@@ -560,6 +564,44 @@ async def list_tools() -> list[Tool]:
                 "required": ["job_id"],
             },
         ),
+        Tool(
+            name="detect_seasonality",
+            description="Detect cyclic patterns in a time series and quantify their strength. Uses FFT-accelerated autocorrelation with adaptive detrending. Returns period, strength, confidence, candidate periods, and a next_action_hint for the agent.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "The time series values as a flat list of floats",
+                    },
+                    "frequency": {
+                        "type": "string",
+                        "description": "Optional frequency hint (e.g. 'D', 'W', 'M') to boost known seasonal periods",
+                    },
+                    "max_lag": {
+                        "type": "integer",
+                        "description": "Maximum lag to check. Defaults to min(len(data)//2, 200)",
+                    },
+                },
+                "required": ["data"],
+            },
+        ),
+        Tool(
+            name="check_structural_break",
+            description="Detect permanent regime changes (level shifts) in a time series using retrospective CUSUM. Returns whether a break was detected, its location, confidence, and a next_action_hint for the agent.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "The time series values as a flat list of floats",
+                    },
+                },
+                "required": ["data"],
+            },
+        ),
     ]
 
 
@@ -739,6 +781,14 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             from sktime_mcp.tools.job_tools import cleanup_old_jobs_tool
             result = cleanup_old_jobs_tool(arguments.get("max_age_hours", 24))
 
+        elif name == "detect_seasonality":
+            result = detect_seasonality_tool(
+                arguments["data"],
+                arguments.get("frequency"),
+                arguments.get("max_lag"),
+            )
+        elif name == "check_structural_break":
+            result = check_structural_break_tool(arguments["data"])
         else:
             result = {"error": f"Unknown tool: {name}"}
 

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -66,6 +66,10 @@ from sktime_mcp.tools.plotting import plot_series_tool
 from sktime_mcp.tools.query_registry import (
     query_registry_tool,
 )
+from sktime_mcp.tools.diagnostics import (
+    check_structural_break_tool,
+    detect_seasonality_tool,
+)
 from sktime_mcp.tools.run_command import run_command_tool
 from sktime_mcp.tools.save_data import save_data_tool
 from sktime_mcp.tools.save_model import save_model_tool
@@ -951,6 +955,44 @@ async def list_tools() -> list[Tool]:
                 "required": ["command"],
             },
         ),
+        Tool(
+            name="detect_seasonality",
+            description="Detect cyclic patterns in a time series and quantify their strength. Uses FFT-accelerated autocorrelation with adaptive detrending. Returns period, strength, confidence, candidate periods, and a next_action_hint for the agent.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "The time series values as a flat list of floats",
+                    },
+                    "frequency": {
+                        "type": "string",
+                        "description": "Optional frequency hint (e.g. 'D', 'W', 'M') to boost known seasonal periods",
+                    },
+                    "max_lag": {
+                        "type": "integer",
+                        "description": "Maximum lag to check. Defaults to min(len(data)//2, 200)",
+                    },
+                },
+                "required": ["data"],
+            },
+        ),
+        Tool(
+            name="check_structural_break",
+            description="Detect permanent regime changes (level shifts) in a time series using retrospective CUSUM. Returns whether a break was detected, its location, confidence, and a next_action_hint for the agent.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "The time series values as a flat list of floats",
+                    },
+                },
+                "required": ["data"],
+            },
+        ),
     ]
 
 
@@ -1167,6 +1209,26 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         # -- System ----------------------------------------------------------
         elif name == "run_command":
             result = run_command_tool(arguments["command"])
+
+        elif name == "delete_job":
+            # Deprecated — kept for backward compatibility
+            logger.warning("delete_job is deprecated; use cancel_job(delete=true)")
+            result = cancel_job_tool(arguments["job_id"], delete=True)
+
+        elif name == "cleanup_old_jobs":
+            # Deprecated — now runs automatically on a periodic timer
+            logger.warning("cleanup_old_jobs is deprecated; jobs are cleaned up automatically")
+            from sktime_mcp.tools.job_tools import cleanup_old_jobs_tool
+            result = cleanup_old_jobs_tool(arguments.get("max_age_hours", 24))
+
+        elif name == "detect_seasonality":
+            result = detect_seasonality_tool(
+                arguments["data"],
+                arguments.get("frequency"),
+                arguments.get("max_lag"),
+            )
+        elif name == "check_structural_break":
+            result = check_structural_break_tool(arguments["data"])
         else:
             result = {"error": f"Unknown tool: {name}"}
 

--- a/src/sktime_mcp/tools/diagnostics.py
+++ b/src/sktime_mcp/tools/diagnostics.py
@@ -70,6 +70,11 @@ def detect_seasonality_tool(
     """
     try:
         x = np.asarray(data, dtype=np.float64)
+        if not np.all(np.isfinite(x)):
+            return {
+                "success": False,
+                "error": "Series contains NaN or Inf values. Remove or interpolate them before analysis.",
+            }
         if len(x) < 6:
             return {
                 "success": False,
@@ -204,6 +209,11 @@ def check_structural_break_tool(
     """
     try:
         x = np.asarray(data, dtype=np.float64)
+        if not np.all(np.isfinite(x)):
+            return {
+                "success": False,
+                "error": "Series contains NaN or Inf values. Remove or interpolate them before analysis.",
+            }
         if len(x) < 10:
             return {
                 "success": False,

--- a/src/sktime_mcp/tools/diagnostics.py
+++ b/src/sktime_mcp/tools/diagnostics.py
@@ -1,0 +1,265 @@
+"""
+Diagnostic MCP tools for sktime-mcp.
+
+Statistical preprocessing tools that give an LLM agent actionable signals
+about the data before it decides on the next modeling step.
+
+Implements:
+- detect_seasonality: Detect cyclic patterns and quantify their strength.
+- check_structural_break: Detect permanent regime changes using CUSUM.
+
+See: https://github.com/sktime/sktime-mcp/issues/96
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+import numpy as np
+
+
+def _autocorrelation_fft(x: np.ndarray, max_lag: int) -> np.ndarray:
+    """Compute autocorrelation using FFT for O(N log N) performance."""
+    n = len(x)
+    x_centered = x - x.mean()
+    # Zero-pad to avoid circular correlation
+    fft_size = 1
+    while fft_size < 2 * n:
+        fft_size *= 2
+    fft_x = np.fft.rfft(x_centered, n=fft_size)
+    acf_full = np.fft.irfft(fft_x * np.conj(fft_x), n=fft_size)[:n]
+    # Normalize by variance
+    if acf_full[0] == 0:
+        return np.zeros(min(max_lag, n - 1))
+    acf_normalized = acf_full / acf_full[0]
+    return acf_normalized[1 : max_lag + 1]
+
+
+# Known seasonal periods for common frequencies
+_FREQ_PERIODS: dict[str, list[int]] = {
+    "D": [7, 14, 28, 30, 365],
+    "W": [4, 13, 26, 52],
+    "M": [3, 6, 12],
+    "Q": [4],
+    "H": [24, 168],
+    "T": [60, 1440],
+    "min": [60, 1440],
+}
+
+
+def detect_seasonality_tool(
+    data: list[float],
+    frequency: Optional[str] = None,
+    max_lag: Optional[int] = None,
+) -> dict[str, Any]:
+    """Detect cyclic patterns in a time series and quantify their strength.
+
+    Uses FFT-accelerated autocorrelation with adaptive detrending and a
+    dynamic significance threshold.
+
+    Args:
+        data: The time series values as a flat list of floats.
+        frequency: Optional frequency hint (e.g. "D", "W", "M") to boost
+            known seasonal periods during candidate scoring.
+        max_lag: Maximum lag to check. Defaults to min(len(data)//2, 200).
+
+    Returns:
+        Dictionary with seasonality analysis results including period,
+        strength, confidence, candidate periods, and a next_action_hint.
+    """
+    try:
+        x = np.asarray(data, dtype=np.float64)
+        if len(x) < 6:
+            return {
+                "success": False,
+                "error": "Series too short for seasonality detection (need >= 6 points)",
+            }
+
+        n = len(x)
+        if max_lag is None:
+            max_lag = min(n // 2, 200)
+
+        # Adaptive detrending: apply first-order differencing only if it
+        # reduces variance (prevents trend from faking seasonality in ACF)
+        x_diff = np.diff(x)
+        if np.var(x_diff) < np.var(x):
+            x_for_acf = x_diff
+            method = "autocorrelation_detrended_fft"
+        else:
+            x_for_acf = x
+            method = "autocorrelation_fft"
+
+        # Compute ACF via FFT
+        effective_max_lag = min(max_lag, len(x_for_acf) - 1)
+        if effective_max_lag < 2:
+            return {
+                "success": True,
+                "period": None,
+                "strength": 0.0,
+                "seasonality_class": "none",
+                "confidence": "low",
+                "candidates": [],
+                "method": method,
+                "next_action_hint": "no_seasonal_pattern",
+            }
+
+        acf = _autocorrelation_fft(x_for_acf, effective_max_lag)
+
+        # Dynamic significance threshold
+        significance = max(1.96 / math.sqrt(n), 0.2)
+
+        # Find candidate peaks above significance threshold
+        candidates = []
+        for lag in range(1, len(acf)):
+            corr = float(acf[lag])
+            if corr > significance:
+                # Check if it's a local peak
+                is_peak = True
+                if lag > 1 and acf[lag - 1] >= corr:
+                    is_peak = False
+                if lag < len(acf) - 1 and acf[lag + 1] >= corr:
+                    is_peak = False
+                if is_peak:
+                    score = corr
+                    # Frequency-aware scoring bonus
+                    if frequency and frequency in _FREQ_PERIODS:
+                        if (lag + 1) in _FREQ_PERIODS[frequency]:
+                            score *= 1.1
+                    candidates.append({
+                        "period": lag + 1,
+                        "correlation": round(corr, 4),
+                        "score": round(score, 4),
+                    })
+
+        # Sort by score descending
+        candidates.sort(key=lambda c: c["score"], reverse=True)
+        # Keep top 5
+        candidates = candidates[:5]
+        # Remove internal score from output
+        for c in candidates:
+            del c["score"]
+
+        if not candidates:
+            return {
+                "success": True,
+                "period": None,
+                "strength": 0.0,
+                "seasonality_class": "none",
+                "confidence": "low",
+                "candidates": [],
+                "method": method,
+                "next_action_hint": "no_seasonal_pattern",
+            }
+
+        best = candidates[0]
+        strength = best["correlation"]
+
+        # Classify strength
+        if strength >= 0.7:
+            seasonality_class = "strong"
+            confidence = "high"
+        elif strength >= 0.4:
+            seasonality_class = "moderate"
+            confidence = "medium"
+        else:
+            seasonality_class = "weak"
+            confidence = "low"
+
+        # Determine next action hint
+        if seasonality_class in ("strong", "moderate"):
+            next_action = "deseasonalize_then_stationarity"
+        else:
+            next_action = "check_stationarity_directly"
+
+        return {
+            "success": True,
+            "period": best["period"],
+            "strength": round(strength, 4),
+            "seasonality_class": seasonality_class,
+            "confidence": confidence,
+            "candidates": candidates,
+            "method": method,
+            "next_action_hint": next_action,
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def check_structural_break_tool(
+    data: list[float],
+) -> dict[str, Any]:
+    """Detect permanent regime changes in a time series using CUSUM.
+
+    Uses retrospective global CUSUM on raw (non-differenced) data with a
+    dynamic threshold based on a Brownian Bridge confidence bound.
+
+    Args:
+        data: The time series values as a flat list of floats.
+
+    Returns:
+        Dictionary with break detection results including location,
+        confidence, test statistic, and a next_action_hint.
+    """
+    try:
+        x = np.asarray(data, dtype=np.float64)
+        if len(x) < 10:
+            return {
+                "success": False,
+                "error": "Series too short for structural break detection (need >= 10 points)",
+            }
+
+        n = len(x)
+        mean = x.mean()
+        std = x.std(ddof=1)
+
+        if std == 0:
+            return {
+                "success": True,
+                "break_detected": False,
+                "location": None,
+                "confidence": 0.0,
+                "test_stat": 0.0,
+                "next_action_hint": "constant_series",
+            }
+
+        # Retrospective global CUSUM: cumulative sum of mean-centered data
+        cusum = np.cumsum(x - mean)
+
+        # Break point = index of maximum absolute divergence
+        abs_cusum = np.abs(cusum)
+        break_idx = int(np.argmax(abs_cusum))
+
+        # Test statistic: max divergence normalized by std * sqrt(N)
+        test_stat = float(abs_cusum[break_idx] / (std * math.sqrt(n)))
+
+        # Dynamic threshold: 1.358 * (1 + 0.1 * ln(N))
+        # 1.358 base = 95% confidence bound of Brownian Bridge
+        # Log-scaled adjustment prevents long series from false positives
+        threshold = 1.358 * (1.0 + 0.1 * math.log(n))
+
+        break_detected = test_stat > threshold
+
+        # Confidence: how far above the threshold (capped at 1.0)
+        if threshold > 0:
+            confidence = min(test_stat / threshold, 2.0) / 2.0
+        else:
+            confidence = 0.0
+
+        if break_detected:
+            next_action = "get_dataset_history"
+        else:
+            next_action = "proceed_with_full_series"
+
+        return {
+            "success": True,
+            "break_detected": break_detected,
+            "location": break_idx if break_detected else None,
+            "confidence": round(confidence, 4),
+            "test_stat": round(test_stat, 4),
+            "next_action_hint": next_action,
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}

--- a/src/sktime_mcp/tools/diagnostics.py
+++ b/src/sktime_mcp/tools/diagnostics.py
@@ -262,10 +262,13 @@ def check_structural_break_tool(
         else:
             next_action = "proceed_with_full_series"
 
+        location_fraction = round(break_idx / n, 4) if break_detected else None
+
         return {
             "success": True,
             "break_detected": break_detected,
             "location": break_idx if break_detected else None,
+            "location_fraction": location_fraction,
             "confidence": round(confidence, 4),
             "test_stat": round(test_stat, 4),
             "next_action_hint": next_action,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,158 @@
+"""Tests for diagnostic MCP tools (detect_seasonality, check_structural_break).
+
+See: https://github.com/sktime/sktime-mcp/issues/96
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from sktime_mcp.tools.diagnostics import (
+    check_structural_break_tool,
+    detect_seasonality_tool,
+)
+
+
+class TestDetectSeasonality:
+    """Tests for the detect_seasonality tool."""
+
+    def test_strong_weekly_seasonality(self):
+        """A clear period-7 sine wave should be detected as strong seasonality."""
+        np.random.seed(42)
+        t = np.arange(200)
+        data = np.sin(2 * np.pi * t / 7) + np.random.randn(200) * 0.1
+        result = detect_seasonality_tool(data.tolist())
+
+        assert result["success"] is True
+        assert result["period"] == 7
+        assert result["seasonality_class"] in ("strong", "moderate")
+        assert result["confidence"] in ("high", "medium")
+        assert len(result["candidates"]) > 0
+        assert result["next_action_hint"] == "deseasonalize_then_stationarity"
+
+    def test_no_seasonality_white_noise(self):
+        """White noise should show no significant seasonality."""
+        np.random.seed(42)
+        data = np.random.randn(200).tolist()
+        result = detect_seasonality_tool(data)
+
+        assert result["success"] is True
+        assert result["seasonality_class"] in ("none", "weak")
+
+    def test_frequency_hint_boosts_known_periods(self):
+        """Passing frequency='D' should boost daily-seasonal periods."""
+        np.random.seed(42)
+        t = np.arange(200)
+        # Period-7 signal (weekly for daily data)
+        data = (np.sin(2 * np.pi * t / 7) + np.random.randn(200) * 0.3).tolist()
+
+        result_no_freq = detect_seasonality_tool(data)
+        result_with_freq = detect_seasonality_tool(data, frequency="D")
+
+        assert result_no_freq["success"] is True
+        assert result_with_freq["success"] is True
+        # Both should detect period 7
+        assert result_with_freq["period"] == 7
+
+    def test_short_series_returns_error(self):
+        """Series with < 6 points should return an error."""
+        result = detect_seasonality_tool([1.0, 2.0, 3.0])
+        assert result["success"] is False
+        assert "too short" in result["error"].lower()
+
+    def test_custom_max_lag(self):
+        """max_lag parameter should limit the search range."""
+        np.random.seed(42)
+        t = np.arange(200)
+        # Period-7 signal with enough lag range to detect it
+        data = (np.sin(2 * np.pi * t / 7) + np.random.randn(200) * 0.1).tolist()
+
+        result_short = detect_seasonality_tool(data, max_lag=3)
+        result_long = detect_seasonality_tool(data, max_lag=50)
+
+        assert result_short["success"] is True
+        assert result_long["success"] is True
+        # Short lag range (max_lag=3) can't detect period-7
+        # Long lag range should detect it
+        assert result_long["period"] == 7
+
+    def test_output_structure(self):
+        """Verify all expected keys are present in the output."""
+        np.random.seed(42)
+        data = np.random.randn(100).tolist()
+        result = detect_seasonality_tool(data)
+
+        assert "success" in result
+        assert "period" in result
+        assert "strength" in result
+        assert "seasonality_class" in result
+        assert "confidence" in result
+        assert "candidates" in result
+        assert "method" in result
+        assert "next_action_hint" in result
+
+
+class TestCheckStructuralBreak:
+    """Tests for the check_structural_break tool."""
+
+    def test_clear_level_shift(self):
+        """A series with a large level shift should be detected."""
+        np.random.seed(42)
+        before = np.random.randn(100) + 0.0
+        after = np.random.randn(100) + 10.0  # Big jump at index 100
+        data = np.concatenate([before, after]).tolist()
+        result = check_structural_break_tool(data)
+
+        assert result["success"] is True
+        assert result["break_detected"] is True
+        assert result["location"] is not None
+        # Break should be near index 100 (±20)
+        assert abs(result["location"] - 100) < 20
+        assert result["next_action_hint"] == "get_dataset_history"
+
+    def test_no_break_stationary(self):
+        """A stationary series should have no structural break."""
+        np.random.seed(42)
+        data = np.random.randn(200).tolist()
+        result = check_structural_break_tool(data)
+
+        assert result["success"] is True
+        assert result["break_detected"] is False
+        assert result["next_action_hint"] == "proceed_with_full_series"
+
+    def test_constant_series(self):
+        """A constant series (zero std) should return no break."""
+        data = [5.0] * 50
+        result = check_structural_break_tool(data)
+
+        assert result["success"] is True
+        assert result["break_detected"] is False
+        assert result["next_action_hint"] == "constant_series"
+
+    def test_short_series_returns_error(self):
+        """Series with < 10 points should return an error."""
+        result = check_structural_break_tool([1.0, 2.0, 3.0])
+        assert result["success"] is False
+        assert "too short" in result["error"].lower()
+
+    def test_output_structure(self):
+        """Verify all expected keys are present in the output."""
+        np.random.seed(42)
+        data = np.random.randn(100).tolist()
+        result = check_structural_break_tool(data)
+
+        assert "success" in result
+        assert "break_detected" in result
+        assert "location" in result
+        assert "confidence" in result
+        assert "test_stat" in result
+        assert "next_action_hint" in result
+
+    def test_confidence_bounded(self):
+        """Confidence should be between 0 and 1."""
+        np.random.seed(42)
+        data = np.random.randn(200).tolist()
+        result = check_structural_break_tool(data)
+
+        assert 0.0 <= result["confidence"] <= 1.0

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -123,7 +123,29 @@ class TestCheckStructuralBreak:
         assert result["location"] is not None
         # Break should be near index 100 (±20)
         assert abs(result["location"] - 100) < 20
+        assert result["location_fraction"] is not None
+        assert 0.0 < result["location_fraction"] < 1.0
         assert result["next_action_hint"] == "get_dataset_history"
+
+    def test_no_break_location_fraction_is_none(self):
+        """No break detected means location_fraction should be None."""
+        np.random.seed(42)
+        data = np.random.randn(200).tolist()
+        result = check_structural_break_tool(data)
+        assert result["location_fraction"] is None
+
+    def test_linear_trend_break_at_midpoint(self):
+        """A pure linear trend triggers CUSUM break near 0.5 fraction.
+
+        This is a known CUSUM limitation — the location_fraction field
+        lets the LLM detect this pattern and treat it as a trend rather
+        than a genuine structural break.
+        """
+        data = list(range(200))  # pure linear trend
+        result = check_structural_break_tool(data)
+        if result["break_detected"]:
+            # If detected, location_fraction should be near 0.5
+            assert abs(result["location_fraction"] - 0.5) < 0.15
 
     def test_no_break_stationary(self):
         """A stationary series should have no structural break."""
@@ -173,6 +195,7 @@ class TestCheckStructuralBreak:
         assert "success" in result
         assert "break_detected" in result
         assert "location" in result
+        assert "location_fraction" in result
         assert "confidence" in result
         assert "test_stat" in result
         assert "next_action_hint" in result

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -61,6 +61,20 @@ class TestDetectSeasonality:
         assert result["success"] is False
         assert "too short" in result["error"].lower()
 
+    def test_nan_in_data_returns_error(self):
+        """Series containing NaN should return an error."""
+        data = [1.0, 2.0, float("nan"), 4.0, 5.0, 6.0, 7.0]
+        result = detect_seasonality_tool(data)
+        assert result["success"] is False
+        assert "nan" in result["error"].lower() or "inf" in result["error"].lower()
+
+    def test_inf_in_data_returns_error(self):
+        """Series containing Inf should return an error."""
+        data = [1.0, 2.0, float("inf"), 4.0, 5.0, 6.0, 7.0]
+        result = detect_seasonality_tool(data)
+        assert result["success"] is False
+        assert "nan" in result["error"].lower() or "inf" in result["error"].lower()
+
     def test_custom_max_lag(self):
         """max_lag parameter should limit the search range."""
         np.random.seed(42)
@@ -135,6 +149,20 @@ class TestCheckStructuralBreak:
         result = check_structural_break_tool([1.0, 2.0, 3.0])
         assert result["success"] is False
         assert "too short" in result["error"].lower()
+
+    def test_nan_in_data_returns_error(self):
+        """Series containing NaN should return an error."""
+        data = [1.0, 2.0, float("nan"), 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        result = check_structural_break_tool(data)
+        assert result["success"] is False
+        assert "nan" in result["error"].lower() or "inf" in result["error"].lower()
+
+    def test_inf_in_data_returns_error(self):
+        """Series containing Inf should return an error."""
+        data = [1.0, 2.0, float("inf"), 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        result = check_structural_break_tool(data)
+        assert result["success"] is False
+        assert "nan" in result["error"].lower() or "inf" in result["error"].lower()
 
     def test_output_structure(self):
         """Verify all expected keys are present in the output."""


### PR DESCRIPTION
Closes #96

## Summary

Two new MCP tools for pre-modeling statistical diagnostics, following @nXtCyberNet's design from #96:

### `detect_seasonality`
- FFT-accelerated autocorrelation (`O(N log N)`) with adaptive detrending
- Dynamic significance threshold: `max(1.96/sqrt(N), 0.2)`
- Optional frequency-aware scoring (boosts known periods for D/W/M data)
- Returns: `period`, `strength`, `seasonality_class`, `confidence`, `candidates`, `next_action_hint`

### `check_structural_break`
- Retrospective global CUSUM on raw (non-differenced) data
- Dynamic threshold: `1.358 * (1 + 0.1 * ln(N))` (Brownian Bridge 95% bound)
- Returns: `break_detected`, `location`, `confidence`, `test_stat`, `next_action_hint`

Both tools provide `next_action_hint` to guide LLM agents in agentic forecasting workflows.

## Changes

- `src/sktime_mcp/tools/diagnostics.py` — tool implementations (265 lines)
- `src/sktime_mcp/server.py` — tool registration in `list_tools` + `call_tool`
- `tests/test_diagnostics.py` — 12 tests covering both tools (seasonality detection, structural breaks, edge cases, output structure)

## Test plan

- [x] 12 new tests pass (`pytest tests/test_diagnostics.py`)
- [x] 42 existing tests still pass (`pytest tests/`)
- [x] No new dependencies (uses only `numpy` which is already a dep)