### PR TITLE
fix: correct handling of exogenous variables in fit_predict workflows

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -190,7 +190,17 @@ class Executor:
         if not fit_result["success"]:
             return fit_result
 
-        return self.predict(handle_id, fh=fh, X=X)
+        predict_result = self.predict(handle_id, fh=fh)
+
+        if X is not None and predict_result.get("success"):
+            predict_result.setdefault("warnings", []).append(
+                "Exogenous variables (X) were used during fitting but are not "
+                "available for the forecast horizon. Predictions use endogenous "
+                "data only. For exogenous-aware predictions, call fit and predict "
+                "separately with future X values."
+            )
+
+        return predict_result
 
     async def fit_predict_async(
         self,
@@ -284,9 +294,10 @@ class Executor:
             )
             await asyncio.sleep(0.01)  # Yield control
 
-            # Run predict in executor
+            # Run predict in executor (do not pass training X — it has the
+            # wrong shape/index for the forecast horizon)
             predict_result = await loop.run_in_executor(
-                None, lambda: self.predict(handle_id, fh=fh, X=X)
+                None, lambda: self.predict(handle_id, fh=fh)
             )
 
             if not predict_result["success"]:
@@ -296,6 +307,14 @@ class Executor:
                     errors=[f"Prediction failed: {predict_result.get('error')}"],
                 )
                 return predict_result
+
+            if X is not None:
+                predict_result.setdefault("warnings", []).append(
+                    "Exogenous variables (X) were used during fitting but are not "
+                    "available for the forecast horizon. Predictions use endogenous "
+                    "data only. For exogenous-aware predictions, call fit and predict "
+                    "separately with future X values."
+                )
 
             # Mark as completed
             self._job_manager.update_job(
@@ -795,11 +814,50 @@ class Executor:
             "changes_made": changes_made,
         }
 
+    def _align_future_exog(
+        self,
+        future_X: Any,
+        training_y: pd.Series,
+        training_X: Any,
+        horizon: int,
+    ) -> pd.DataFrame:
+        """Align future exogenous data so its index continues from training."""
+        # Convert Series → DataFrame matching training X column structure
+        if isinstance(future_X, pd.Series):
+            col_name = "exog"
+            if training_X is not None and hasattr(training_X, "columns") and len(training_X.columns) > 0:
+                col_name = training_X.columns[0]
+            future_X = future_X.to_frame(name=col_name)
+
+        future_X = future_X.iloc[:horizon].copy()
+
+        # Build an index that continues from the training data's last index
+        last_idx = training_y.index[-1]
+
+        if isinstance(training_y.index, pd.DatetimeIndex):
+            freq = training_y.index.freq
+            if freq is None and len(training_y.index) > 1:
+                freq = training_y.index[-1] - training_y.index[-2]
+            new_index = pd.date_range(
+                start=last_idx, periods=horizon + 1, freq=freq
+            )[1:]
+        elif isinstance(training_y.index, pd.PeriodIndex):
+            new_index = pd.period_range(
+                start=last_idx + 1, periods=horizon, freq=training_y.index.freq
+            )
+        else:
+            step = int(training_y.index[-1] - training_y.index[-2]) if len(training_y.index) > 1 else 1
+            new_index = pd.Index([int(last_idx) + step * (i + 1) for i in range(horizon)])
+
+        future_X.index = new_index[: len(future_X)]
+        return future_X
+
     def fit_predict_with_data(
         self,
         estimator_handle: str,
         data_handle: str,
         horizon: int = 12,
+        future_data_handle: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Fit and predict using a data handle.
@@ -808,6 +866,10 @@ class Executor:
             estimator_handle: Estimator handle from instantiate_estimator
             data_handle: Data handle from load_data_source
             horizon: Forecast horizon
+            future_data_handle: Optional data handle containing future exogenous
+                variables (X) for the forecast horizon. If the training data
+                includes exogenous variables and this is not provided, predictions
+                will be generated without exogenous inputs.
 
         Returns:
             Dictionary with predictions
@@ -829,8 +891,34 @@ class Executor:
         if not fit_result["success"]:
             return fit_result
 
+        # Resolve future exogenous data for prediction
+        future_X = None
+        if future_data_handle is not None:
+            if future_data_handle not in self._data_handles:
+                return {
+                    "success": False,
+                    "error": f"Unknown future data handle: {future_data_handle}",
+                    "available_handles": list(self._data_handles.keys()),
+                }
+            future_X = self._data_handles[future_data_handle].get("X")
+            if future_X is None:
+                future_X = self._data_handles[future_data_handle].get("y")
+
+            future_X = self._align_future_exog(future_X, y, X, horizon)
+
         # Predict
-        return self.predict(estimator_handle, fh=fh, X=X)
+        predict_result = self.predict(estimator_handle, fh=fh, X=future_X)
+
+        if X is not None and future_X is None and predict_result.get("success"):
+            predict_result.setdefault("warnings", []).append(
+                "Exogenous variables (X) were used during fitting but no "
+                "future_data_handle was provided for the forecast horizon. "
+                "Predictions use endogenous data only. To include future "
+                "exogenous values, load them as a separate data source and "
+                "pass the handle via 'future_data_handle'."
+            )
+
+        return predict_result
 
     def list_data_handles(self) -> dict[str, Any]:
         """

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -365,7 +365,10 @@ async def list_tools() -> list[Tool]:
                 "Fit an estimator and generate predictions using custom data. GUIDELINES: "
                 "1. BEFORE calling this, check 'list_data_handles' or 'load_data_source' output. "
                 "2. If the metadata contains warnings about default target columns or column ambiguity, "
-                "STOP and re-load the data with explicit 'target_column' and 'time_column' mapping."
+                "STOP and re-load the data with explicit 'target_column' and 'time_column' mapping. "
+                "3. If your training data has exogenous columns and you have future values for them, "
+                "load the future values as a separate data source and pass the handle via "
+                "'future_data_handle' for accurate predictions."
             ),
             inputSchema={
                 "type": "object",
@@ -382,6 +385,14 @@ async def list_tools() -> list[Tool]:
                         "type": "integer",
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
+                    },
+                    "future_data_handle": {
+                        "type": "string",
+                        "description": (
+                            "Optional handle containing future exogenous variables "
+                            "for the forecast horizon. Load future X values as a "
+                            "separate data source first, then pass that handle here."
+                        ),
                     },
                 },
                 "required": ["estimator_handle", "data_handle"],
@@ -626,6 +637,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["estimator_handle"],
                 arguments["data_handle"],
                 arguments.get("horizon", 12),
+                future_data_handle=arguments.get("future_data_handle"),
             )
             # Sanitize immediately to handle Period objects
             result = sanitize_for_json(result)

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -94,6 +94,7 @@ def fit_predict_with_data_tool(
     estimator_handle: str,
     data_handle: str,
     horizon: int = 12,
+    future_data_handle: str | None = None,
 ) -> dict[str, Any]:
     """
     Fit and predict using custom data.
@@ -102,6 +103,9 @@ def fit_predict_with_data_tool(
         estimator_handle: Handle from instantiate_estimator
         data_handle: Handle from load_data_source
         horizon: Forecast horizon (default: 12)
+        future_data_handle: Optional handle containing future exogenous
+            variables for the forecast horizon. Required for accurate
+            predictions when training data includes exogenous columns.
 
     Returns:
         Dictionary with predictions
@@ -118,6 +122,7 @@ def fit_predict_with_data_tool(
         estimator_handle,
         data_handle,
         horizon,
+        future_data_handle=future_data_handle,
     )
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes a critical bug where `fit_predict`, `fit_predict_with_data`, and `fit_predict_async` pass training exogenous data (`X`) to `predict()`, causing dimension mismatch errors on any multi-column dataset. Also adds a new `future_data_handle` parameter to `fit_predict_with_data` to enable exogenous-aware forecasting.

---

#### What does this implement/fix?

This PR fixes a bug in `fit_predict`, `fit_predict_with_data`, and `fit_predict_async`.

Previously, the training exogenous data (`X`) was passed directly into `predict()`.  
However, in sktime, `predict(fh, X)` expects **future exogenous values** matching the forecast horizon — not the training data.

This caused:
- errors for models that rely on exogenous variables (e.g. SARIMAX)
- confusing behavior when exogenous data was present but not properly used

---

#### What’s changed?

- Training `X` is no longer passed to `predict()`
- A warning is returned when exogenous data was used during training but not available for prediction
- Added optional `future_data_handle` to `fit_predict_with_data` to support forecasting with future exogenous values
- Added a small helper to align future exogenous data with the forecast horizon

---

#### Why this matters

This fixes a broken workflow for multi-column datasets and enables proper use of exogenous variables in forecasting.

---

#### What should reviewers focus on?

- Logic for handling exogenous data during prediction
- The `future_data_handle` flow
- Index alignment for future exogenous inputs

---
#### Any other comments?

**Verified via MCP Inspector with 4 test cases:**

| Test | Result |
|------|--------|
| SARIMAX + longley (before fix) | ❌ `"Provided exogenous values are not of the appropriate shape"` |
| SARIMAX + custom data + `future_data_handle` (after fix) | ✅ `success: true`, predictions returned |
| NaiveForecaster + longley (after fix) | ✅ `success: true` + `warnings` field present |
| Invalid `future_data_handle` | ✅ `success: false` with clear error + available handles |



#### Reproduction and Fix Demonstration


##### Before fix:
https://github.com/user-attachments/assets/8d167ca4-fa9b-48c2-9def-ca3f187a968d


##### After fix:
https://github.com/user-attachments/assets/7c0640a5-3d6a-4d7c-8c1b-543f4b24055b



#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.