### PR TITLE
[ENH] add offset pagination to list_estimators tool

### DIFF
--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -1,6 +1,5 @@
 """
 list_estimators tool for sktime MCP.
-
 Discovers estimators by task type and capability tags.
 """
 
@@ -13,6 +12,7 @@ def list_estimators_tool(
     task: Optional[str] = None,
     tags: Optional[dict[str, Any]] = None,
     limit: int = 50,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """
     Discover sktime estimators by task type and capability tags.
@@ -22,40 +22,68 @@ def list_estimators_tool(
               "regression", "transformation", "clustering"
         tags: Filter by capability tags. Example: {"capability:pred_int": True}
         limit: Maximum number of results to return (default: 50)
+        offset: Number of results to skip for pagination (default: 0).
+                Use with limit to paginate through all estimators.
+                Example: offset=50 returns results 51-100.
 
     Returns:
         Dictionary with:
         - success: bool
         - estimators: List of estimator summaries
-        - count: Number of results
-        - total: Total matching (before limit)
+        - count: Number of results returned in this page
+        - total: Total matching estimators (before limit/offset)
+        - offset: Current offset (for pagination)
+        - limit: Current limit (for pagination)
+        - has_more: True if more results exist beyond this page
 
     Example:
-        >>> list_estimators_tool(task="forecasting", tags={"capability:pred_int": True})
+        >>> list_estimators_tool(task="forecasting", limit=50, offset=0)
         {
             "success": True,
             "estimators": [{"name": "ARIMA", "task": "forecasting", ...}, ...],
-            "count": 15,
-            "total": 15
+            "count": 50,
+            "total": 128,
+            "offset": 0,
+            "limit": 50,
+            "has_more": True
+        }
+        >>> list_estimators_tool(task="forecasting", limit=50, offset=50)
+        {
+            "success": True,
+            "estimators": [...],
+            "count": 50,
+            "total": 128,
+            "offset": 50,
+            "limit": 50,
+            "has_more": True
         }
     """
     registry = get_registry()
-
     try:
         estimators = registry.get_all_estimators(task=task, tags=tags)
         total = len(estimators)
 
-        # Apply limit
-        estimators = estimators[:limit]
+        # Validate offset
+        if offset < 0:
+            return {
+                "success": False,
+                "error": "offset must be a non-negative integer.",
+            }
+
+        # Apply offset and limit for pagination
+        page = estimators[offset : offset + limit]
 
         # Convert to summaries
-        results = [est.to_summary() for est in estimators]
+        results = [est.to_summary() for est in page]
 
         return {
             "success": True,
             "estimators": results,
             "count": len(results),
             "total": total,
+            "offset": offset,
+            "limit": limit,
+            "has_more": (offset + limit) < total,
             "task_filter": task,
             "tag_filter": tags,
         }


### PR DESCRIPTION
Closes #112

## Summary
`list_estimators` previously returned only 50 results with no way to 
access the remaining estimators. For forecasting alone, sktime 0.40.1 
has 128 estimators but only 50 were reachable.

## Changes
- Added `offset` parameter (default: 0) to `list_estimators_tool`
- Added `has_more` field to response so clients know more results exist
- `offset` and `limit` are echoed back in every response
- Added offset validation (rejects negative values)
- Existing calls with no `offset` are fully backwards compatible

## Example
```python
# Page 1
list_estimators(task="forecasting", limit=50, offset=0)
# Returns: {total: 128, count: 50, has_more: True, offset: 0}

# Page 2  
list_estimators(task="forecasting", limit=50, offset=50)
# Returns: {total: 128, count: 50, has_more: True, offset: 50}
```