### PR TITLE
[BUG]  fix sunspots dataset loader calling load_sunspot instead of load_sunspots

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -27,7 +27,7 @@ DEMO_DATASETS = {
     "longley": "sktime.datasets.load_longley",
     "lynx": "sktime.datasets.load_lynx",
     "shampoo": "sktime.datasets.load_shampoo_sales",
-    "sunspots": "sktime.datasets.load_sunspot",
+    "sunspots": "sktime.datasets.load_sunspots",
     "uschange": "sktime.datasets.load_uschange",
 }
 


### PR DESCRIPTION
Closes #115

## Summary
One-character typo in `DEMO_DATASETS` dict caused the built-in sunspots 
dataset to fail with `AttributeError` on every call.

## Root Cause
`executor.py` mapped `"sunspots"` to `"sktime.datasets.load_sunspot"` 
(missing trailing `s`). The correct function is `load_sunspots`.

## Change
Single-line fix in `src/sktime_mcp/runtime/executor.py`:

```python
# before
"sunspots": "sktime.datasets.load_sunspot",

# after  
"sunspots": "sktime.datasets.load_sunspots",
```

## Testing
Verified that `load_sunspots` exists in `sktime.datasets` and loads 
correctly. All other 5 demo datasets were unaffected.