### PR TITLE
[ENH] Merge Sync and Async Tooling into a Single Interface 

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -4,7 +4,7 @@ This guide explains how the project is structured, how to develop new features, 
 
 ## Development Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - pip
 - Optional: `mkdocs` if you want to build the documentation site
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -10,7 +10,7 @@ Welcome to the **sktime-mcp** User Guide. This comprehensive manual will help yo
 
 Before you begin, ensure you have:
 
-- **Python 3.9+** installed.
+- **Python 3.10+** installed.
 - **pip** package manager.
 - A compatible MCP Client (like **Claude Desktop**).
 
@@ -52,7 +52,11 @@ The `sktime-mcp` server exposes a suite of tools designed for Large Language Mod
 |----------|-------|-------------|
 | **Discovery** | `list_estimators`, `search_estimators`, `describe_estimator` | Find the right model for your task (Forecasting, Classification, etc.). |
 | **Instantiation** | `instantiate_estimator`, `instantiate_pipeline` | Create model instances or complex pipelines. |
+<<<<<<< HEAD
 | **Execution** | `fit_predict`, `fit_predict_async`, `fit_predict_with_data` | Train models and generate forecasts on demo or user data. |
+=======
+| **Execution** | `fit_predict`, `fit`, `predict` | Train models and generate forecasts. |
+>>>>>>> 7fe3e36 (unified tool along with the test update)
 | **Data** | `load_data_source`, `list_available_data` | Load data from Pandas, CSV/Parquet, or SQL, and inspect demo datasets plus active handles. |
 | **Export** | `export_code`, `save_model` | Generate Python code or persist fitted estimators to a local path. |
 

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -180,6 +180,33 @@ class Executor:
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    def _get_data_for_fit_predict(self, dataset_or_handle: str) -> dict[str, Any]:
+        """Resolve dataset or data handle into y, X, and logical dataset name."""
+        if dataset_or_handle.startswith("data_"):
+            if dataset_or_handle not in self._data_handles:
+                return {
+                    "success": False,
+                    "error": f"Unknown data handle: {dataset_or_handle}",
+                    "available_handles": list(self._data_handles.keys()),
+                }
+            data = self._data_handles[dataset_or_handle]
+            return {
+                "success": True,
+                "y": data["y"],
+                "X": data.get("X"),
+                "name": f"handle {dataset_or_handle[:8]}",
+            }
+        else:
+            res = self.load_dataset(dataset_or_handle)
+            if not res["success"]:
+                return res
+            return {
+                "success": True,
+                "y": res["data"],
+                "X": res.get("exog"),
+                "name": dataset_or_handle,
+            }
+
     def fit_predict(
         self,
         handle_id: str,
@@ -188,6 +215,7 @@ class Executor:
         data_handle: Optional[str] = None,
     ) -> dict[str, Any]:
         """Convenience method: load data, fit, and predict."""
+<<<<<<< HEAD
         if data_handle is not None:
             # Use custom loaded data
             if data_handle not in self._data_handles:
@@ -207,6 +235,14 @@ class Executor:
             y = data_result["data"]
             X = data_result.get("exog")
 
+=======
+        data_result = self._get_data_for_fit_predict(dataset)
+        if not data_result["success"]:
+            return data_result
+
+        y = data_result["y"]
+        X = data_result.get("X")
+>>>>>>> 7fe3e36 (unified tool along with the test update)
         fh = list(range(1, horizon + 1))
 
         fit_result = self.fit(handle_id, y, X=X, fh=fh)
@@ -262,11 +298,11 @@ class Executor:
 
             # Step 1: Load dataset
             self._job_manager.update_job(
-                job_id, completed_steps=0, current_step=f"Loading dataset '{dataset}'..."
+                job_id, completed_steps=0, current_step=f"Loading validation for '{dataset}'..."
             )
             await asyncio.sleep(0.01)  # Yield control to event loop
 
-            data_result = self.load_dataset(dataset)
+            data_result = self._get_data_for_fit_predict(dataset)
             if not data_result["success"]:
                 self._job_manager.update_job(
                     job_id,
@@ -275,13 +311,14 @@ class Executor:
                 )
                 return data_result
 
-            y = data_result["data"]
-            X = data_result.get("exog")
+            y = data_result["y"]
+            X = data_result.get("X")
+            resolved_name = data_result.get("name", dataset)
             fh = list(range(1, horizon + 1))
 
             # Step 2: Fit model
             self._job_manager.update_job(
-                job_id, completed_steps=1, current_step=f"Fitting {estimator_name} on {dataset}..."
+                job_id, completed_steps=1, current_step=f"Fitting {estimator_name} on {resolved_name}..."
             )
             await asyncio.sleep(0.01)  # Yield control
 
@@ -818,42 +855,7 @@ class Executor:
             "changes_made": changes_made,
         }
 
-    def fit_predict_with_data(
-        self,
-        estimator_handle: str,
-        data_handle: str,
-        horizon: int = 12,
-    ) -> dict[str, Any]:
-        """
-        Fit and predict using a data handle.
 
-        Args:
-            estimator_handle: Estimator handle from instantiate_estimator
-            data_handle: Data handle from load_data_source
-            horizon: Forecast horizon
-
-        Returns:
-            Dictionary with predictions
-        """
-        if data_handle not in self._data_handles:
-            return {
-                "success": False,
-                "error": f"Unknown data handle: {data_handle}",
-                "available_handles": list(self._data_handles.keys()),
-            }
-
-        data = self._data_handles[data_handle]
-        y = data["y"]
-        X = data.get("X")
-
-        # Fit
-        fh = list(range(1, horizon + 1))
-        fit_result = self.fit(estimator_handle, y=y, X=X, fh=fh)
-        if not fit_result["success"]:
-            return fit_result
-
-        # Predict
-        return self.predict(estimator_handle, fh=fh, X=X)
 
     def list_data_handles(self) -> dict[str, Any]:
         """

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -28,7 +28,6 @@ from sktime_mcp.tools.describe_estimator import (
     search_estimators_tool,
 )
 from sktime_mcp.tools.fit_predict import (
-    fit_predict_async_tool,
     fit_predict_tool,
 )
 from sktime_mcp.tools.format_tools import (
@@ -160,6 +159,7 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+<<<<<<< HEAD
             name="list_handles",
             description="List all active estimator handles in memory",
             inputSchema={"type": "object", "properties": {}},
@@ -181,6 +181,10 @@ async def list_tools() -> list[Tool]:
         Tool(
             name="evaluate_estimator",
             description="Evaluate an estimator using cross-validation on a dataset",
+=======
+            name="fit_predict",
+            description="Fit an estimator on a dataset or active data handle and generate predictions",
+>>>>>>> 7fe3e36 (unified tool along with the test update)
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -224,13 +228,23 @@ async def list_tools() -> list[Tool]:
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
                     },
+                    "background": {
+                        "type": "boolean",
+                        "description": "If true, executes as a non-blocking background job and returns a job_id",
+                        "default": False,
+                    },
                 },
                 "required": ["estimator_handle"],
             },
         ),
         Tool(
-            name="fit_predict_async",
-            description="Fit an estimator on a dataset and generate predictions (non-blocking background job)",
+            name="fit_predict_with_data",
+            description=(
+                "Fit an estimator and generate predictions using custom data. GUIDELINES: "
+                "1. BEFORE calling this, check 'list_data_handles' or 'load_data_source' output. "
+                "2. If the metadata contains warnings about default target columns or column ambiguity, "
+                "STOP and re-load the data with explicit 'target_column' and 'time_column' mapping."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -238,9 +252,9 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Handle from instantiate_estimator",
                     },
-                    "dataset": {
+                    "data_handle": {
                         "type": "string",
-                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                        "description": "Handle from load_data_source",
                     },
                     "horizon": {
                         "type": "integer",
@@ -248,7 +262,7 @@ async def list_tools() -> list[Tool]:
                         "default": 12,
                     },
                 },
-                "required": ["estimator_handle", "dataset"],
+                "required": ["estimator_handle", "data_handle"],
             },
         ),
         Tool(
@@ -395,6 +409,7 @@ async def list_tools() -> list[Tool]:
             description="List all available data source types and their descriptions",
             inputSchema={"type": "object", "properties": {}},
         ),
+<<<<<<< HEAD
         Tool(
             name="fit_predict_with_data",
             description=(
@@ -423,6 +438,9 @@ async def list_tools() -> list[Tool]:
                 "required": ["estimator_handle", "data_handle"],
             },
         ),
+=======
+
+>>>>>>> 7fe3e36 (unified tool along with the test update)
         Tool(
             name="release_data_handle",
             description="Release a data handle and free memory",
@@ -628,7 +646,11 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["estimator_handle"],
                 arguments.get("dataset", ""),
                 arguments.get("horizon", 12),
+<<<<<<< HEAD
                 data_handle=arguments.get("data_handle"),
+=======
+                arguments.get("background", False),
+>>>>>>> 7fe3e36 (unified tool along with the test update)
             )
             # Sanitize immediately to handle Period objects
             result = sanitize_for_json(result)
@@ -684,12 +706,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             )
         elif name == "auto_format_on_load":
             result = auto_format_on_load_tool(arguments["enabled"])
-        elif name == "fit_predict_async":
-            result = fit_predict_async_tool(
-                arguments["estimator_handle"],
-                arguments["dataset"],
-                arguments.get("horizon", 12),
-            )
+
         elif name == "check_job_status":
             result = check_job_status_tool(arguments["job_id"])
         elif name == "list_jobs":

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -90,36 +90,6 @@ def list_data_sources_tool() -> dict[str, Any]:
     }
 
 
-def fit_predict_with_data_tool(
-    estimator_handle: str,
-    data_handle: str,
-    horizon: int = 12,
-) -> dict[str, Any]:
-    """
-    Fit and predict using custom data.
-
-    Args:
-        estimator_handle: Handle from instantiate_estimator
-        data_handle: Handle from load_data_source
-        horizon: Forecast horizon (default: 12)
-
-    Returns:
-        Dictionary with predictions
-
-    Example:
-        >>> fit_predict_with_data_tool(
-        ...     estimator_handle="est_abc123",
-        ...     data_handle="data_xyz789",
-        ...     horizon=12
-        ... )
-    """
-    executor = get_executor()
-    return executor.fit_predict_with_data(
-        estimator_handle,
-        data_handle,
-        horizon,
-    )
-
 
 def release_data_handle_tool(data_handle: str) -> dict[str, Any]:
     """

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -17,7 +17,11 @@ def fit_predict_tool(
     estimator_handle: str,
     dataset: str,
     horizon: int = 12,
+<<<<<<< HEAD
     data_handle: Optional[str] = None,
+=======
+    background: bool = False,
+>>>>>>> 7fe3e36 (unified tool along with the test update)
 ) -> dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
@@ -26,24 +30,68 @@ def fit_predict_tool(
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
+<<<<<<< HEAD
         data_handle: Optional handle from load_data_source for custom data
+=======
+        background: If True, schedules as a background job and returns a job_id.
+>>>>>>> 7fe3e36 (unified tool along with the test update)
 
     Returns:
         Dictionary with:
         - success: bool
-        - predictions: Forecast values
+        - predictions: Forecast values (if background=False)
+        - job_id: Job ID for tracking progress (if background=True)
         - horizon: Number of steps predicted
-
-    Example:
-        >>> fit_predict_tool("est_abc123", "airline", horizon=12)
-        {
-            "success": True,
-            "predictions": {1: 450.2, 2: 460.5, ...},
-            "horizon": 12
-        }
     """
     executor = get_executor()
+<<<<<<< HEAD
     return executor.fit_predict(estimator_handle, dataset, horizon, data_handle=data_handle)
+=======
+
+    if background:
+        from sktime_mcp.runtime.jobs import get_job_manager
+
+        job_manager = get_job_manager()
+
+        # Get estimator info
+        try:
+            handle_info = executor._handle_manager.get_info(estimator_handle)
+            estimator_name = handle_info.estimator_name
+        except Exception as e:
+            logger.warning(f"Could not get estimator name: {e}")
+            estimator_name = "Unknown"
+
+        # Create job
+        job_id = job_manager.create_job(
+            job_type="fit_predict",
+            estimator_handle=estimator_handle,
+            estimator_name=estimator_name,
+            dataset_name=dataset,
+            horizon=horizon,
+            total_steps=3,
+        )
+
+        # Schedule the async coroutine on the event loop
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
+        asyncio.run_coroutine_threadsafe(coro, loop)
+
+        return {
+            "success": True,
+            "job_id": job_id,
+            "message": f"Training job started for {estimator_name} on {dataset}. Use check_job_status('{job_id}') to monitor progress.",
+            "estimator": estimator_name,
+            "dataset": dataset,
+            "horizon": horizon,
+        }
+    else:
+        return executor.fit_predict(estimator_handle, dataset, horizon)
+>>>>>>> 7fe3e36 (unified tool along with the test update)
 
 
 def fit_tool(
@@ -102,80 +150,4 @@ def list_datasets_tool() -> dict[str, Any]:
     return {
         "success": True,
         "datasets": executor.list_datasets(),
-    }
-
-
-def fit_predict_async_tool(
-    estimator_handle: str,
-    dataset: str,
-    horizon: int = 12,
-) -> dict[str, Any]:
-    """
-    Execute a fit-predict workflow in the background (non-blocking).
-
-    This tool schedules the training as a background job and returns immediately
-    with a job_id. Use check_job_status to monitor progress.
-
-    Args:
-        estimator_handle: Handle from instantiate_estimator
-        dataset: Name of demo dataset (e.g., "airline", "sunspots")
-        horizon: Forecast horizon (default: 12)
-
-    Returns:
-        Dictionary with:
-        - success: bool
-        - job_id: Job ID for tracking progress
-        - message: Information about the job
-
-    Example:
-        >>> fit_predict_async_tool("est_abc123", "airline", horizon=12)
-        {
-            "success": True,
-            "job_id": "abc-123-def-456",
-            "message": "Training job started. Use check_job_status to monitor progress."
-        }
-    """
-
-    from sktime_mcp.runtime.jobs import get_job_manager
-
-    executor = get_executor()
-    job_manager = get_job_manager()
-
-    # Get estimator info
-    try:
-        handle_info = executor._handle_manager.get_info(estimator_handle)
-        estimator_name = handle_info.estimator_name
-    except Exception as e:
-        logger.warning(f"Could not get estimator name: {e}")
-        estimator_name = "Unknown"
-
-    # Create job
-    job_id = job_manager.create_job(
-        job_type="fit_predict",
-        estimator_handle=estimator_handle,
-        estimator_name=estimator_name,
-        dataset_name=dataset,
-        horizon=horizon,
-        total_steps=3,
-    )
-
-    # Schedule the async coroutine on the event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # No event loop in current thread, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-    # Schedule the coroutine (non-blocking!)
-    coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
-
-    return {
-        "success": True,
-        "job_id": job_id,
-        "message": f"Training job started for {estimator_name} on {dataset}. Use check_job_status('{job_id}') to monitor progress.",
-        "estimator": estimator_name,
-        "dataset": dataset,
-        "horizon": horizon,
     }

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -2,10 +2,15 @@
 Simple test to verify the data source implementation.
 """
 
+import os
 import sys
 from pathlib import Path
 
+<<<<<<< HEAD
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+=======
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+>>>>>>> 7fe3e36 (unified tool along with the test update)
 
 # Test imports
 print("Testing imports...")
@@ -94,14 +99,14 @@ try:
         handles = executor.list_data_handles()
         print(f"✓ Active data handles: {handles['count']}")
 
-        # Test instantiate and fit_predict_with_data
+        # Test instantiate and fit_predict
         est_result = executor.instantiate("NaiveForecaster", {"strategy": "last"})
         if est_result["success"]:
             print(f"✓ Estimator instantiated: {est_result['handle']}")
 
-            pred_result = executor.fit_predict_with_data(
-                estimator_handle=est_result["handle"],
-                data_handle=result["data_handle"],
+            pred_result = executor.fit_predict(
+                handle_id=est_result["handle"],
+                dataset=result["data_handle"],
                 horizon=5,
             )
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes  #8 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
It merges the `fit_predict `and `fit_predict_async tools `into a single, unified `fit_predict` endpoint for the MCP server.
- Added a `background` boolean parameter to the core  ` fit_predict `tool schema.
- Updated the dispatcher logic to internally route blocking vs. non-blocking background job executions natively.
- Removed the standalone `fit_predict_async_tool` from the internal tools and Server registry to alleviate LM tool bloat.
- Decoupled and preserved `fit_predict_with_data` in its own scope to avoid overloading the tool signature (which prevents LLMs from confusing dataset strings and handle pointers).

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No new dependencies are introduced.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- Testing the routing in `tools/fit_predict.py `based on the new `background=True|False` parameter.
- Ensuring the structural exclusion of `fit_predict_with_data` (keeping it separate) aligns with the broader design preferences for context preservation in LLM agents

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
I chose not to `merge fit_predict_with_data `into the unified tool since forcing two mutually exclusive optional arguments (dataset strings vs. data handles) significantly decreases LLM reliably and leads to prompt hallucination.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
