### PR TITLE
[ENH] add dependency availability check to describe_estimator tool

### DIFF
--- a/src/sktime_mcp/tools/describe_component.py
+++ b/src/sktime_mcp/tools/describe_component.py
@@ -5,8 +5,52 @@ Gets detailed information about a component's capabilities, parameters, and tags
 
 from typing import Any
 
+from sktime.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
+
 from sktime_mcp.registry.interface import get_registry
 from sktime_mcp.registry.tag_resolver import get_tag_resolver
+
+
+def _dependency_info(cls: type) -> dict[str, Any]:
+    """Return availability and installation details for a component's dependencies."""
+    available = _check_estimator_deps(cls, severity="none")
+    dependencies = cls.get_class_tag("python_dependencies", None)
+
+    if available or dependencies is None:
+        return {
+            "dependencies_available": available,
+            "missing_dependencies": [],
+            "install_hint": None,
+        }
+
+    if isinstance(dependencies, str):
+        dependencies = [dependencies]
+
+    missing = []
+    install_requirements = []
+    for requirement in dependencies:
+        if isinstance(requirement, (list, tuple)):
+            requirement_available = any(
+                _check_soft_dependencies(option, severity="none") for option in requirement
+            )
+            if not requirement_available:
+                missing.append(" or ".join(requirement))
+                install_requirements.append(requirement[0])
+        elif not _check_soft_dependencies(requirement, severity="none"):
+            missing.append(requirement)
+            install_requirements.append(requirement)
+
+    quoted_requirements = [
+        f'"{requirement}"' if any(char in requirement for char in "<>=!~; ") else requirement
+        for requirement in install_requirements
+    ]
+    install_hint = f"pip install {' '.join(quoted_requirements)}" if missing else None
+
+    return {
+        "dependencies_available": available,
+        "missing_dependencies": missing,
+        "install_hint": install_hint,
+    }
 
 
 def describe_component_tool(name: str) -> dict[str, Any]:
@@ -27,6 +71,9 @@ def describe_component_tool(name: str) -> dict[str, Any]:
         - tags: Dict of capability tags
         - tag_explanations: Human-readable tag descriptions
         - docstring: First 500 chars of docstring
+        - dependencies_available: Whether the component can run in this environment
+        - missing_dependencies: Unsatisfied package requirements
+        - install_hint: pip command that installs one valid set of missing requirements
     """
     registry = get_registry()
     tag_resolver = get_tag_resolver()
@@ -49,6 +96,7 @@ def describe_component_tool(name: str) -> dict[str, Any]:
     tag_explanations = tag_resolver.explain_tags(node.tags)
 
     doc = node.docstring or "No description available."
+    dependency_info = _dependency_info(node.class_ref)
 
     return {
         "success": True,
@@ -61,4 +109,5 @@ def describe_component_tool(name: str) -> dict[str, Any]:
         "tags": node.tags,
         "tag_explanations": tag_explanations,
         "docstring": doc[:500],
+        **dependency_info,
     }

--- a/src/sktime_mcp/tools/describe_estimator.py
+++ b/src/sktime_mcp/tools/describe_estimator.py
@@ -1,13 +1,67 @@
 """
 describe_estimator tool for sktime MCP.
-
 Gets detailed information about an estimator's capabilities.
 """
 
+import importlib.util
 from typing import Any
 
 from sktime_mcp.registry.interface import get_registry
 from sktime_mcp.registry.tag_resolver import get_tag_resolver
+
+
+def _check_dependencies(tags: dict[str, Any]) -> dict[str, Any]:
+    """Check whether an estimator's soft dependencies are available.
+
+    Uses the ``python_dependencies`` tag from the estimator to determine
+    which packages are required, then checks each against the current
+    environment using ``importlib.util.find_spec``.
+
+    Parameters
+    ----------
+    tags : dict
+        Estimator tags dict, expected to contain ``python_dependencies`` key.
+
+    Returns
+    -------
+    dict with keys:
+        - dependencies_available : bool
+            True if all soft dependencies are installed, False otherwise.
+        - missing_dependencies : list of str
+            Names of packages that are not installed. Empty if all present.
+        - install_hint : str or None
+            pip install command to resolve missing deps, or None if all present.
+    """
+    raw_deps = tags.get("python_dependencies", None)
+
+    if not raw_deps:
+        return {
+            "dependencies_available": True,
+            "missing_dependencies": [],
+            "install_hint": None,
+        }
+
+    # normalize to list
+    if isinstance(raw_deps, str):
+        raw_deps = [raw_deps]
+
+    missing = []
+    for dep in raw_deps:
+        # strip version specifiers e.g. "torch>=1.9" -> "torch"
+        for sep in (">=", "<=", "==", "!=", ">", "<"):
+            dep = dep.split(sep)[0]
+        package_name = dep.strip()
+        if importlib.util.find_spec(package_name) is None:
+            missing.append(dep)
+
+    available = len(missing) == 0
+    install_hint = f"pip install {' '.join(missing)}" if missing else None
+
+    return {
+        "dependencies_available": available,
+        "missing_dependencies": missing,
+        "install_hint": install_hint,
+    }
 
 
 def describe_estimator_tool(estimator: str) -> dict[str, Any]:
@@ -15,7 +69,7 @@ def describe_estimator_tool(estimator: str) -> dict[str, Any]:
     Get detailed information about a specific estimator.
 
     Args:
-        estimator: Name of the estimator class (e.g., "ARIMA", "RandomForest")
+        estimator: Name of the estimator class (e.g., "ARIMA", "ChronosForecaster")
 
     Returns:
         Dictionary with:
@@ -27,6 +81,9 @@ def describe_estimator_tool(estimator: str) -> dict[str, Any]:
         - tags: Dict of capability tags
         - tag_explanations: Human-readable tag descriptions
         - docstring: First 500 chars of docstring
+        - dependencies_available: bool - True if all soft deps are installed
+        - missing_dependencies: list of missing package names (empty if all present)
+        - install_hint: pip install command to fix missing deps, or None
 
     Example:
         >>> describe_estimator_tool("ARIMA")
@@ -34,8 +91,19 @@ def describe_estimator_tool(estimator: str) -> dict[str, Any]:
             "success": True,
             "name": "ARIMA",
             "task": "forecasting",
-            "hyperparameters": {"order": {"default": [1,0,0], "required": False}, ...},
-            "tags": {"capability:pred_int": True, ...},
+            "dependencies_available": True,
+            "missing_dependencies": [],
+            "install_hint": None,
+            ...
+        }
+        >>> describe_estimator_tool("ChronosForecaster")
+        {
+            "success": True,
+            "name": "ChronosForecaster",
+            "task": "forecasting",
+            "dependencies_available": False,
+            "missing_dependencies": ["torch", "transformers", "accelerate"],
+            "install_hint": "pip install torch transformers accelerate",
             ...
         }
     """
@@ -59,6 +127,9 @@ def describe_estimator_tool(estimator: str) -> dict[str, Any]:
     # Get tag explanations
     tag_explanations = tag_resolver.explain_tags(node.tags)
 
+    # Check soft dependency availability
+    dep_info = _check_dependencies(node.tags)
+
     return {
         "success": True,
         "name": node.name,
@@ -68,6 +139,9 @@ def describe_estimator_tool(estimator: str) -> dict[str, Any]:
         "tags": node.tags,
         "tag_explanations": tag_explanations,
         "docstring": node.docstring[:500] if node.docstring else None,
+        "dependencies_available": dep_info["dependencies_available"],
+        "missing_dependencies": dep_info["missing_dependencies"],
+        "install_hint": dep_info["install_hint"],
     }
 
 
@@ -83,7 +157,6 @@ def search_estimators_tool(query: str, limit: int = 20) -> dict[str, Any]:
         Dictionary with matching estimators
     """
     registry = get_registry()
-
     try:
         matches = registry.search_estimators(query)[:limit]
         return {

--- a/tests/test_describe_component.py
+++ b/tests/test_describe_component.py
@@ -1,0 +1,81 @@
+"""Tests for the describe_component tool."""
+
+from types import SimpleNamespace
+
+import pytest
+from sktime.utils.dependencies import _check_soft_dependencies
+
+import sktime_mcp.tools.describe_component as describe_component_module
+
+
+class _MissingDependencyEstimator:
+    """Minimal estimator class with known-missing soft dependencies."""
+
+    @classmethod
+    def get_class_tag(cls, tag_name, tag_value_default=None):
+        tags = {
+            "python_dependencies": [
+                "sktime-mcp-missing-package>=1.0",
+                ["sktime-mcp-missing-option-a", "sktime-mcp-missing-option-b"],
+            ],
+            "python_version": None,
+            "env_marker": None,
+        }
+        return tags.get(tag_name, tag_value_default)
+
+
+def test_describe_component_reports_missing_soft_dependencies(monkeypatch):
+    """Known-missing requirements are reported with a usable install hint."""
+    node = SimpleNamespace(
+        name="MissingDependencyEstimator",
+        task="forecaster",
+        class_ref=_MissingDependencyEstimator,
+        module="tests.MissingDependencyEstimator",
+        parameters={},
+        tags={},
+        docstring="Test estimator.",
+    )
+    registry = SimpleNamespace(get_estimator_by_name=lambda name: node)
+    tag_resolver = SimpleNamespace(explain_tags=lambda tags: {})
+    monkeypatch.setattr(describe_component_module, "get_registry", lambda: registry)
+    monkeypatch.setattr(describe_component_module, "get_tag_resolver", lambda: tag_resolver)
+
+    result = describe_component_module.describe_component_tool(node.name)
+
+    assert result["success"]
+    assert not result["dependencies_available"]
+    assert result["missing_dependencies"] == [
+        "sktime-mcp-missing-package>=1.0",
+        "sktime-mcp-missing-option-a or sktime-mcp-missing-option-b",
+    ]
+    assert result["install_hint"] == (
+        'pip install "sktime-mcp-missing-package>=1.0" sktime-mcp-missing-option-a'
+    )
+
+
+def test_dependency_info_reports_available_component():
+    """Components without soft dependencies require no install hint."""
+
+    class NoDependencyEstimator(_MissingDependencyEstimator):
+        @classmethod
+        def get_class_tag(cls, tag_name, tag_value_default=None):
+            return tag_value_default
+
+    assert describe_component_module._dependency_info(NoDependencyEstimator) == {
+        "dependencies_available": True,
+        "missing_dependencies": [],
+        "install_hint": None,
+    }
+
+
+def test_describe_prophet_reports_known_missing_soft_dependency():
+    """A real registry component exposes its missing optional dependency."""
+    if _check_soft_dependencies("prophet", severity="none"):
+        pytest.skip("prophet is installed in this environment")
+
+    result = describe_component_module.describe_component_tool("Prophet")
+
+    assert result["success"]
+    assert not result["dependencies_available"]
+    assert result["missing_dependencies"] == ["prophet"]
+    assert result["install_hint"] == "pip install prophet"


### PR DESCRIPTION
Closes #117

## Summary
`describe_estimator` previously gave no indication whether an estimator's 
soft dependencies were installed. Users would only discover missing packages 
after attempting `instantiate_estimator`, with no guidance on what to install.

## Changes
- Added `_check_dependencies()` helper using `importlib.util.find_spec()`
- Added three new fields to `describe_estimator` response:
  - `dependencies_available` (bool)
  - `missing_dependencies` (list of missing package names)
  - `install_hint` (ready-to-run pip install command, or None)
- Version specifiers stripped before checking (e.g. `torch>=1.9` → `torch`)
- Fully backwards compatible — existing fields unchanged

## Example
```python
describe_estimator("ChronosForecaster")
# {
#   "dependencies_available": False,
#   "missing_dependencies": ["torch", "transformers", "accelerate"],
#   "install_hint": "pip install torch transformers accelerate",
#   ...
# }
```
