### PR TITLE
fix: include job_id in all failure paths of fit_predict_async

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -333,7 +333,7 @@ class Executor:
                         status=JobStatus.FAILED,
                         errors=[f"Failed to load dataset: {data_result.get('error')}"],
                     )
-                    return data_result
+                    return {**data_result, "job_id": job_id}
 
                 y = data_result["data"]
                 X = data_result.get("exog")
@@ -359,7 +359,7 @@ class Executor:
                     status=JobStatus.FAILED,
                     errors=[f"Fit failed: {fit_result.get('error')}"],
                 )
-                return fit_result
+                return {**fit_result, "job_id": job_id}
 
             # Step 3: Generate predictions
             self._job_manager.update_job(
@@ -379,7 +379,7 @@ class Executor:
                     status=JobStatus.FAILED,
                     errors=[f"Prediction failed: {predict_result.get('error')}"],
                 )
-                return predict_result
+                return {**predict_result, "job_id": job_id}
 
             # Mark as completed
             self._job_manager.update_job(
@@ -390,7 +390,7 @@ class Executor:
                 result=predict_result,
             )
 
-            return predict_result
+            return {**predict_result, "job_id": job_id}
 
         except Exception as e:
             logger.exception(f"Error in async fit_predict for job {job_id}")


### PR DESCRIPTION
## Reference Issues/PRs
None.

---

## What does this implement/fix?

`fit_predict_async` now always includes `job_id` in the returned response across all paths:
- dataset load failure
- fit failure
- predict failure
- success

Previously, some early failure paths returned only an error dict without `job_id`, even though the job had already been created. This made it impossible for clients to track or inspect failed async jobs.

This change ensures consistency in the async job lifecycle - every response now includes `job_id`.

---

## Does your contribution introduce a new dependency?
No.

---

## What should a reviewer concentrate their feedback on?
- Return shapes from `Executor.fit_predict_async`
- Consistency of `job_id` across all execution paths

---

## Any other comments?
None.

---

## PR checklist

### For all contributions
- [x] I've added myself to the list of contributors (if applicable)
- [x] I've added unit tests and made sure they pass locally

---

### Title