### PR TITLE
fix: failing py-test in main 

### DIFF
--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any
 
 from sktime.forecasting.model_evaluation import evaluate
-from sktime.forecasting.model_selection import ExpandingWindowSplitter
+from sktime.split import ExpandingWindowSplitter
 
 from sktime_mcp.runtime.executor import get_executor
 
@@ -46,11 +46,21 @@ def evaluate_estimator_tool(
     X = data_result.get("exog")
 
     try:
+        if isinstance(cv_folds, bool) or not isinstance(cv_folds, int) or cv_folds < 1:
+            return {
+                "success": False,
+                "error": "'cv_folds' must be a positive integer",
+            }
+
         n = len(y)
-        # Handle small datasets gracefully
-        initial_window = max(int(n * 0.5), n - cv_folds * 2)
-        if initial_window < 1:
-            initial_window = 1
+        if n < 2:
+            return {
+                "success": False,
+                "error": "Dataset must contain at least 2 observations for evaluation",
+            }
+
+        folds_to_run = min(cv_folds, n - 1)
+        initial_window = n - folds_to_run
 
         cv = ExpandingWindowSplitter(initial_window=initial_window, step_length=1, fh=[1])
 
@@ -63,11 +73,7 @@ def evaluate_estimator_tool(
 
         metrics = results.to_dict(orient="records")
 
-        return {
-            "success": True,
-            "results": metrics,
-            "cv_folds_run": len(metrics)
-        }
+        return {"success": True, "results": metrics, "cv_folds_run": len(metrics)}
     except Exception as e:
         logger.exception("Error during evaluate")
         return {"success": False, "error": str(e)}


### PR DESCRIPTION
fixes  #132

#### What does this implement/fix? Explain your changes.
in main branch on test was failing 
<img width="1882" height="176" alt="Screenshot 2026-04-11 231842" src="https://github.com/user-attachments/assets/fd642cb1-79e0-4c43-802f-c493e3b6e858" />

after fixing the test 
<img width="1917" height="185" alt="Screenshot 2026-04-11 231922" src="https://github.com/user-attachments/assets/c476a21c-2ef3-45a5-99da-6c05f32aceff" />


- The test in `test_evaluate.py` expected `cv_folds=2`to produce exactly 2 evaluation results.
- In the old code in `evaluate.py` , `cv_folds` was not used to set an exact number of folds. It was only used inside a heuristic for initial_window .
- ExpandingWindowSplitter then generated as many valid splits as the dataset allowed, which happened to be 4 for the airline data.
- So the test failed on assert `len(result["results"]) == 2` because the actual result length was 4 .
What We Fixed

- In `evaluate.py` , we changed the fold logic so `cv_folds` directly controls how many splits are run.
- We now compute:
1. `folds_to_run = min(cv_folds, n - 1)`
2. `initial_window = n - folds_to_run`
3. With `fh=[1]` and `step_length=1` , that makes the splitter return exactly the requested number of folds when possible.