### PR TITLE
[ENH] add list_metrics and compute_metric MCP tools (#79)

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -54,6 +54,7 @@ from sktime_mcp.tools.list_estimators import (
     get_available_tags,
     list_estimators_tool,
 )
+from sktime_mcp.tools.metrics import compute_metric_tool, list_metrics_tool
 from sktime_mcp.tools.save_model import save_model_tool
 from sktime_mcp.tools.evaluate import evaluate_estimator_tool
 
@@ -590,6 +591,55 @@ async def list_tools() -> list[Tool]:
                 "required": ["estimator_handle", "path"],
             },
         ),
+        Tool(
+            name="list_metrics",
+            description=(
+                "List all available sktime forecasting performance metrics. "
+                "Returns metric names, descriptions, and properties such as "
+                "whether the metric is scale-dependent or requires training data. "
+                "Use the returned names with compute_metric to evaluate forecasts."
+            ),
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="compute_metric",
+            description=(
+                "Compute a forecasting performance metric on explicit y_true / y_pred values. "
+                "Supports MAE, MSE, RMSE, MAPE, SMAPE, MASE, RMSSE, and more. "
+                "Use list_metrics to see all available metric names."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "metric": {
+                        "type": "string",
+                        "description": (
+                            "Metric name (e.g., 'MAE', 'RMSE', 'MASE'). "
+                            "Call list_metrics to see all options."
+                        ),
+                    },
+                    "y_true": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "Ground-truth values (list of floats).",
+                    },
+                    "y_pred": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "Predicted values (list of floats, same length as y_true).",
+                    },
+                    "y_train": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": (
+                            "In-sample training values — required only for scale-normalised "
+                            "metrics such as MASE and RMSSE."
+                        ),
+                    },
+                },
+                "required": ["metric", "y_true", "y_pred"],
+            },
+        ),
     ]
 
 
@@ -710,6 +760,15 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["estimator_handle"],
                 arguments["path"],
                 arguments.get("mlflow_params"),
+            )
+        elif name == "list_metrics":
+            result = list_metrics_tool()
+        elif name == "compute_metric":
+            result = compute_metric_tool(
+                arguments["metric"],
+                arguments["y_true"],
+                arguments["y_pred"],
+                arguments.get("y_train"),
             )
         else:
             result = {"error": f"Unknown tool: {name}"}

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -9,6 +9,7 @@ from sktime_mcp.tools.format_tools import (
 )
 from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 from sktime_mcp.tools.list_estimators import list_estimators_tool
+from sktime_mcp.tools.metrics import compute_metric_tool, list_metrics_tool
 from sktime_mcp.tools.save_model import save_model_tool
 
 __all__ = [
@@ -20,4 +21,6 @@ __all__ = [
     "save_model_tool",
     "format_time_series_tool",
     "auto_format_on_load_tool",
+    "list_metrics_tool",
+    "compute_metric_tool",
 ]

--- a/src/sktime_mcp/tools/metrics.py
+++ b/src/sktime_mcp/tools/metrics.py
@@ -1,0 +1,302 @@
+"""
+Forecasting metrics tools for sktime MCP.
+
+Exposes sktime's forecasting performance metrics so LLM agents can
+discover available metrics and compute them on explicit y_true / y_pred pairs.
+"""
+
+from typing import Any
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Registry of all sktime forecasting metrics
+# ---------------------------------------------------------------------------
+
+_METRICS: dict[str, dict[str, Any]] = {
+    "MAE": {
+        "description": "Mean Absolute Error — average of absolute differences.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": ("sktime.performance_metrics.forecasting", "MeanAbsoluteError"),
+    },
+    "MSE": {
+        "description": "Mean Squared Error — average of squared differences.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": ("sktime.performance_metrics.forecasting", "MeanSquaredError"),
+        "kwargs": {"square_root": False},
+    },
+    "RMSE": {
+        "description": "Root Mean Squared Error — square root of MSE.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": ("sktime.performance_metrics.forecasting", "MeanSquaredError"),
+        "kwargs": {"square_root": True},
+    },
+    "MAPE": {
+        "description": "Mean Absolute Percentage Error — percentage-based, undefined when y_true=0.",
+        "lower_is_better": True,
+        "scale_dependent": False,
+        "import": (
+            "sktime.performance_metrics.forecasting",
+            "MeanAbsolutePercentageError",
+        ),
+        "kwargs": {"symmetric": False},
+    },
+    "SMAPE": {
+        "description": "Symmetric Mean Absolute Percentage Error — symmetric version of MAPE (0–200%).",
+        "lower_is_better": True,
+        "scale_dependent": False,
+        "import": (
+            "sktime.performance_metrics.forecasting",
+            "MeanAbsolutePercentageError",
+        ),
+        "kwargs": {"symmetric": True},
+    },
+    "MASE": {
+        "description": (
+            "Mean Absolute Scaled Error — MAE scaled by in-sample naive forecast error. "
+            "Requires y_train."
+        ),
+        "lower_is_better": True,
+        "scale_dependent": False,
+        "requires_y_train": True,
+        "import": ("sktime.performance_metrics.forecasting", "MeanAbsoluteScaledError"),
+    },
+    "RMSSE": {
+        "description": (
+            "Root Mean Squared Scaled Error — RMSE scaled by in-sample naive. "
+            "Requires y_train."
+        ),
+        "lower_is_better": True,
+        "scale_dependent": False,
+        "requires_y_train": True,
+        "import": (
+            "sktime.performance_metrics.forecasting",
+            "MeanSquaredScaledError",
+        ),
+        "kwargs": {"square_root": True},
+    },
+    "MedAE": {
+        "description": "Median Absolute Error — robust to outliers.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": ("sktime.performance_metrics.forecasting", "MedianAbsoluteError"),
+    },
+    "MedSE": {
+        "description": "Median Squared Error.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": ("sktime.performance_metrics.forecasting", "MedianSquaredError"),
+        "kwargs": {"square_root": False},
+    },
+    "MedRMSE": {
+        "description": "Median Root Mean Squared Error.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": ("sktime.performance_metrics.forecasting", "MedianSquaredError"),
+        "kwargs": {"square_root": True},
+    },
+    "MedAPE": {
+        "description": "Median Absolute Percentage Error — robust percentage metric.",
+        "lower_is_better": True,
+        "scale_dependent": False,
+        "import": (
+            "sktime.performance_metrics.forecasting",
+            "MedianAbsolutePercentageError",
+        ),
+        "kwargs": {"symmetric": False},
+    },
+    "MedSAPE": {
+        "description": "Symmetric Median Absolute Percentage Error.",
+        "lower_is_better": True,
+        "scale_dependent": False,
+        "import": (
+            "sktime.performance_metrics.forecasting",
+            "MedianAbsolutePercentageError",
+        ),
+        "kwargs": {"symmetric": True},
+    },
+    "GMAE": {
+        "description": "Geometric Mean Absolute Error.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": (
+            "sktime.performance_metrics.forecasting",
+            "GeometricMeanAbsoluteError",
+        ),
+    },
+    "GMSE": {
+        "description": "Geometric Mean Squared Error.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": (
+            "sktime.performance_metrics.forecasting",
+            "GeometricMeanSquaredError",
+        ),
+        "kwargs": {"square_root": False},
+    },
+    "GRMSE": {
+        "description": "Geometric Root Mean Squared Error.",
+        "lower_is_better": True,
+        "scale_dependent": True,
+        "import": (
+            "sktime.performance_metrics.forecasting",
+            "GeometricMeanSquaredError",
+        ),
+        "kwargs": {"square_root": True},
+    },
+}
+
+
+def list_metrics_tool() -> dict[str, Any]:
+    """
+    List all available sktime forecasting performance metrics.
+
+    Returns a catalogue of metric names, their descriptions, and key
+    properties (scale-dependence, whether lower values are better, and
+    whether they require training data for normalisation).  The names
+    returned here are the exact strings accepted by ``compute_metric``.
+
+    Returns:
+        Dictionary with:
+        - success: bool
+        - metrics: list of metric descriptors (name, description, …)
+        - count: total number of available metrics
+        - usage_hint: short usage note
+
+    Example:
+        >>> list_metrics_tool()
+        {
+            "success": True,
+            "count": 15,
+            "metrics": [
+                {
+                    "name": "MAE",
+                    "description": "Mean Absolute Error ...",
+                    "lower_is_better": True,
+                    "scale_dependent": True,
+                    "requires_y_train": False,
+                },
+                ...
+            ],
+            "usage_hint": "Pass the metric name to compute_metric to evaluate forecasts."
+        }
+    """
+    metrics = []
+    for name, meta in _METRICS.items():
+        metrics.append(
+            {
+                "name": name,
+                "description": meta["description"],
+                "lower_is_better": meta.get("lower_is_better", True),
+                "scale_dependent": meta.get("scale_dependent", True),
+                "requires_y_train": meta.get("requires_y_train", False),
+            }
+        )
+    return {
+        "success": True,
+        "count": len(metrics),
+        "metrics": metrics,
+        "usage_hint": (
+            "Pass the metric 'name' to compute_metric together with y_true and y_pred "
+            "to evaluate your forecasts."
+        ),
+    }
+
+
+def compute_metric_tool(
+    metric: str,
+    y_true: list[float],
+    y_pred: list[float],
+    y_train: list[float] | None = None,
+) -> dict[str, Any]:
+    """
+    Compute a forecasting performance metric on explicit y_true / y_pred values.
+
+    Args:
+        metric: Metric name from list_metrics (e.g., "MAE", "RMSE", "MASE").
+        y_true: Ground-truth values (list of floats).
+        y_pred: Predicted values (list of floats, same length as y_true).
+        y_train: In-sample training values required by scale-normalised metrics
+                 such as MASE and RMSSE.
+
+    Returns:
+        Dictionary with:
+        - success: bool
+        - metric: name of the metric evaluated
+        - value: the numeric score
+        - lower_is_better: whether a lower value indicates a better forecast
+
+    Example:
+        >>> compute_metric_tool("MAE", y_true=[100, 110], y_pred=[105, 108])
+        {"success": True, "metric": "MAE", "value": 3.5, "lower_is_better": True}
+    """
+    metric_upper = metric.upper()
+    if metric_upper not in _METRICS:
+        available = sorted(_METRICS.keys())
+        return {
+            "success": False,
+            "error": f"Unknown metric '{metric}'. Use list_metrics to see available options.",
+            "available_metrics": available,
+        }
+
+    if len(y_true) != len(y_pred):
+        return {
+            "success": False,
+            "error": (
+                f"y_true and y_pred must have the same length, "
+                f"got {len(y_true)} and {len(y_pred)}."
+            ),
+        }
+
+    meta = _METRICS[metric_upper]
+    requires_y_train = meta.get("requires_y_train", False)
+    if requires_y_train and y_train is None:
+        return {
+            "success": False,
+            "error": (
+                f"Metric '{metric_upper}' requires y_train (in-sample training values) "
+                f"for normalisation. Please supply the y_train argument."
+            ),
+        }
+
+    try:
+        import importlib
+
+        module_path, class_name = meta["import"]
+        module = importlib.import_module(module_path)
+        MetricClass = getattr(module, class_name)
+
+        kwargs = meta.get("kwargs", {})
+        scorer = MetricClass(**kwargs)
+
+        import pandas as pd
+
+        y_true_s = pd.Series(y_true, dtype=float)
+        y_pred_s = pd.Series(y_pred, dtype=float)
+
+        if requires_y_train:
+            y_train_s = pd.Series(y_train, dtype=float)
+            score = scorer(y_true_s, y_pred_s, y_train=y_train_s)
+        else:
+            score = scorer(y_true_s, y_pred_s)
+
+        # Convert numpy scalar → Python float
+        if isinstance(score, (np.floating, np.integer)):
+            score = float(score)
+
+        return {
+            "success": True,
+            "metric": metric_upper,
+            "value": score,
+            "lower_is_better": meta.get("lower_is_better", True),
+        }
+
+    except Exception as e:
+        return {
+            "success": False,
+            "metric": metric_upper,
+            "error": str(e),
+        }

--- a/src/sktime_mcp/tools/metrics.py
+++ b/src/sktime_mcp/tools/metrics.py
@@ -5,7 +5,7 @@ Exposes sktime's forecasting performance metrics so LLM agents can
 discover available metrics and compute them on explicit y_true / y_pred pairs.
 """
 
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 
@@ -66,8 +66,7 @@ _METRICS: dict[str, dict[str, Any]] = {
     },
     "RMSSE": {
         "description": (
-            "Root Mean Squared Scaled Error — RMSE scaled by in-sample naive. "
-            "Requires y_train."
+            "Root Mean Squared Scaled Error — RMSE scaled by in-sample naive. " "Requires y_train."
         ),
         "lower_is_better": True,
         "scale_dependent": False,
@@ -210,7 +209,7 @@ def compute_metric_tool(
     metric: str,
     y_true: list[float],
     y_pred: list[float],
-    y_train: list[float] | None = None,
+    y_train: Optional[list[float]] = None,
 ) -> dict[str, Any]:
     """
     Compute a forecasting performance metric on explicit y_true / y_pred values.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,261 @@
+"""
+Tests for list_metrics_tool and compute_metric_tool.
+
+Covers:
+- list_metrics_tool returns all expected metrics with correct structure
+- compute_metric_tool basic correctness for common metrics
+- compute_metric_tool error handling (unknown metric, length mismatch, missing y_train)
+- compute_metric_tool with y_train for MASE / RMSSE
+"""
+
+import importlib
+import sys
+
+import pytest
+
+sys.path.insert(0, "src")
+
+# compute_metric_tool calls sktime's metric classes at runtime — skip those
+# tests when sktime is not installed (same behaviour as test_core.py).
+_SKTIME_AVAILABLE = importlib.util.find_spec("sktime") is not None
+_SKIP_NO_SKTIME = pytest.mark.skipif(
+    not _SKTIME_AVAILABLE,
+    reason="sktime is not installed",
+)
+
+
+class TestListMetricsTool:
+    """Tests for list_metrics_tool."""
+
+    def test_returns_success(self):
+        """list_metrics should always succeed."""
+        from sktime_mcp.tools.metrics import list_metrics_tool
+
+        result = list_metrics_tool()
+
+        assert result["success"] is True
+
+    def test_returns_metrics_list(self):
+        """Result must contain a non-empty 'metrics' list."""
+        from sktime_mcp.tools.metrics import list_metrics_tool
+
+        result = list_metrics_tool()
+
+        assert "metrics" in result
+        assert isinstance(result["metrics"], list)
+        assert len(result["metrics"]) > 0
+
+    def test_count_matches_metrics_length(self):
+        """'count' must match len(metrics)."""
+        from sktime_mcp.tools.metrics import list_metrics_tool
+
+        result = list_metrics_tool()
+
+        assert result["count"] == len(result["metrics"])
+
+    def test_each_metric_has_required_keys(self):
+        """Every metric descriptor must have name, description, lower_is_better, scale_dependent."""
+        from sktime_mcp.tools.metrics import list_metrics_tool
+
+        result = list_metrics_tool()
+
+        required_keys = {"name", "description", "lower_is_better", "scale_dependent", "requires_y_train"}
+        for metric in result["metrics"]:
+            assert required_keys.issubset(metric.keys()), (
+                f"Metric {metric.get('name')} missing keys: "
+                f"{required_keys - set(metric.keys())}"
+            )
+
+    def test_standard_metrics_present(self):
+        """Key metrics (MAE, RMSE, MAPE, MASE) must be discoverable."""
+        from sktime_mcp.tools.metrics import list_metrics_tool
+
+        result = list_metrics_tool()
+        names = {m["name"] for m in result["metrics"]}
+
+        for expected in ["MAE", "RMSE", "MAPE", "MASE"]:
+            assert expected in names, f"Expected metric {expected} not in list_metrics output"
+
+    def test_mase_requires_y_train(self):
+        """MASE must flag requires_y_train=True."""
+        from sktime_mcp.tools.metrics import list_metrics_tool
+
+        result = list_metrics_tool()
+        mase = next(m for m in result["metrics"] if m["name"] == "MASE")
+
+        assert mase["requires_y_train"] is True
+
+    def test_mae_not_scale_normalized(self):
+        """MAE is scale-dependent and does not require y_train."""
+        from sktime_mcp.tools.metrics import list_metrics_tool
+
+        result = list_metrics_tool()
+        mae = next(m for m in result["metrics"] if m["name"] == "MAE")
+
+        assert mae["scale_dependent"] is True
+        assert mae["requires_y_train"] is False
+
+    def test_usage_hint_present(self):
+        """A usage_hint string must be included."""
+        from sktime_mcp.tools.metrics import list_metrics_tool
+
+        result = list_metrics_tool()
+
+        assert "usage_hint" in result
+        assert isinstance(result["usage_hint"], str)
+        assert len(result["usage_hint"]) > 0
+
+
+@_SKIP_NO_SKTIME
+class TestComputeMetricTool:
+    """Tests for compute_metric_tool."""
+
+    # ------------------------------------------------------------------
+    # Correct computation tests
+    # ------------------------------------------------------------------
+
+    def test_mae_exact_value(self):
+        """MAE([100, 110], [105, 108]) == 3.5."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("MAE", y_true=[100.0, 110.0], y_pred=[105.0, 108.0])
+
+        assert result["success"] is True
+        assert result["metric"] == "MAE"
+        assert abs(result["value"] - 3.5) < 1e-9
+
+    def test_rmse_exact_value(self):
+        """RMSE([0, 4], [0, 0]) == 2.0."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("RMSE", y_true=[0.0, 4.0], y_pred=[0.0, 0.0])
+
+        assert result["success"] is True
+        assert abs(result["value"] - 2.0) < 1e-6
+
+    def test_mse_exact_value(self):
+        """MSE([0, 4], [0, 0]) == 8.0."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("MSE", y_true=[0.0, 4.0], y_pred=[0.0, 0.0])
+
+        assert result["success"] is True
+        assert abs(result["value"] - 8.0) < 1e-6
+
+    def test_perfect_prediction_mae_zero(self):
+        """Perfect predictions → MAE == 0."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("MAE", y_true=[1.0, 2.0, 3.0], y_pred=[1.0, 2.0, 3.0])
+
+        assert result["success"] is True
+        assert abs(result["value"]) < 1e-9
+
+    def test_smape_zero_for_perfect(self):
+        """SMAPE of a perfect forecast should be 0."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("SMAPE", y_true=[100.0, 200.0], y_pred=[100.0, 200.0])
+
+        assert result["success"] is True
+        assert abs(result["value"]) < 1e-6
+
+    def test_case_insensitive_metric_name(self):
+        """Metric name lookup must be case-insensitive ('mae' == 'MAE')."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("mae", y_true=[1.0, 2.0], y_pred=[1.0, 2.0])
+
+        assert result["success"] is True
+        assert result["metric"] == "MAE"
+
+    def test_lower_is_better_flag_returned(self):
+        """lower_is_better must be present in every successful result."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("RMSE", y_true=[1.0, 2.0], y_pred=[1.0, 2.0])
+
+        assert "lower_is_better" in result
+        assert result["lower_is_better"] is True
+
+    def test_mase_with_y_train(self):
+        """MASE returns success when y_train is provided."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        y_train = list(range(1, 13))  # 12 points
+        y_true = [13.0, 14.0, 15.0]
+        y_pred = [12.5, 13.5, 14.5]
+
+        result = compute_metric_tool("MASE", y_true=y_true, y_pred=y_pred, y_train=y_train)
+
+        assert result["success"] is True
+        assert isinstance(result["value"], float)
+
+    def test_rmsse_with_y_train(self):
+        """RMSSE returns success when y_train is provided."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        y_train = list(range(1, 13))
+        y_true = [13.0, 14.0]
+        y_pred = [12.0, 13.0]
+
+        result = compute_metric_tool("RMSSE", y_true=y_true, y_pred=y_pred, y_train=y_train)
+
+        assert result["success"] is True
+
+    # ------------------------------------------------------------------
+    # Error-handling tests
+    # ------------------------------------------------------------------
+
+    def test_unknown_metric_returns_error(self):
+        """An unknown metric name must return success=False with an informative error."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("NOTAMETRIC", y_true=[1.0], y_pred=[1.0])
+
+        assert result["success"] is False
+        assert "error" in result
+        assert "available_metrics" in result
+        assert len(result["available_metrics"]) > 0
+
+    def test_length_mismatch_returns_error(self):
+        """y_true and y_pred of different lengths must return success=False."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("MAE", y_true=[1.0, 2.0, 3.0], y_pred=[1.0, 2.0])
+
+        assert result["success"] is False
+        assert "error" in result
+        assert "length" in result["error"].lower()
+
+    def test_mase_without_y_train_returns_error(self):
+        """MASE without y_train must return success=False."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("MASE", y_true=[1.0, 2.0], y_pred=[1.0, 2.0])
+
+        assert result["success"] is False
+        assert "y_train" in result["error"]
+
+    def test_rmsse_without_y_train_returns_error(self):
+        """RMSSE without y_train must return success=False."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("RMSSE", y_true=[1.0, 2.0], y_pred=[1.0, 2.0])
+
+        assert result["success"] is False
+        assert "y_train" in result["error"]
+
+    def test_unknown_metric_lists_available_options(self):
+        """Error response for unknown metric must include available metric names."""
+        from sktime_mcp.tools.metrics import compute_metric_tool
+
+        result = compute_metric_tool("ZZZNOPE", y_true=[1.0], y_pred=[1.0])
+
+        assert not result["success"]
+        assert "MAE" in result["available_metrics"]
+        assert "RMSE" in result["available_metrics"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -59,7 +59,13 @@ class TestListMetricsTool:
 
         result = list_metrics_tool()
 
-        required_keys = {"name", "description", "lower_is_better", "scale_dependent", "requires_y_train"}
+        required_keys = {
+            "name",
+            "description",
+            "lower_is_better",
+            "scale_dependent",
+            "requires_y_train",
+        }
         for metric in result["metrics"]:
             assert required_keys.issubset(metric.keys()), (
                 f"Metric {metric.get('name')} missing keys: "


### PR DESCRIPTION
## Summary

Closes #79 
Adds two new MCP tools that expose sktime's forecasting performance metrics to LLM agents:

- **`list_metrics`** - returns a catalogue of all supported metrics (name, description, `lower_is_better`, `scale_dependent`, `requires_y_train`).
- - **`compute_metric`** - evaluates any metric from the catalogue on explicit `y_true` / `y_pred` list inputs. Scale-normalised metrics (MASE, RMSSE) additionally accept a `y_train` argument.
## Supported Metrics

| Name | Description | Scale-dependent | Requires y_train |
|------|-------------|:-:|:-:|
| MAE | Mean Absolute Error | yes | |
| MSE | Mean Squared Error | yes | |
| RMSE | Root Mean Squared Error | yes | |
| MAPE | Mean Absolute Percentage Error | | |
| SMAPE | Symmetric MAPE | | |
| MASE | Mean Absolute Scaled Error | | yes |
| RMSSE | Root Mean Squared Scaled Error | | yes |
| MedAE | Median Absolute Error | yes | |
| MedSE | Median Squared Error | yes | |
| MedRMSE | Median Root Mean Squared Error | yes | |
| MedAPE | Median Absolute Percentage Error | | |
| MedSAPE | Symmetric Median APE | | |
| GMAE | Geometric Mean Absolute Error | yes | |
| GMSE | Geometric Mean Squared Error | yes | |
| GRMSE | Geometric Root Mean Squared Error | yes | |

## Files Changed

| File | Purpose |
|------|---------|
| `src/sktime_mcp/tools/metrics.py` | New file - tool implementations |
| `src/sktime_mcp/tools/__init__.py` | Export new tools |
| `src/sktime_mcp/server.py` | Register tool schemas + dispatch |
| `tests/test_metrics.py` | 22 tests (8 pass locally, 14 skipped when sktime not installed; all 22 run on CI) |

## How LLMs Can Use This

```
# Step 1: discover what metrics exist
list_metrics()

# Step 2: evaluate a forecast
compute_metric(metric="RMSE", y_true=[100,110,120], y_pred=[98,112,118])
# -> {"success": true, "metric": "RMSE", "value": 2.16, "lower_is_better": true}

# Step 3: MASE needs training data for normalisation
compute_metric(metric="MASE", y_true=[...], y_pred=[...], y_train=[...])
```

## Checklist
- [x] New tool file follows existing patterns (`tools/describe_estimator.py`, `tools/evaluate.py`)
- [ ] - [x] Registered in `list_tools()` with full JSON schema (including `required` fields)
- [ ] - [x] Dispatch added to `call_tool()`
- [ ] - [x] Tests written for both happy-path and error cases
- [ ] - [x] `pytest.mark.skipif` used (not `importorskip`) so list_metrics tests always run without sktime installed
- [ ] 