### PR TITLE
docs: improve error feedback in LLM query simulation example

### DIFF
--- a/examples/02_llm_query_simulation.py
+++ b/examples/02_llm_query_simulation.py
@@ -143,12 +143,26 @@ def simulate_query_2():
             pred1 = fit_predict_tool(h1, "sunspots", 6)
             print_result({"success": pred1["success"], "horizon": pred1.get("horizon")})
 
+            if not pred1["success"]:
+                print("⚠️ Prediction failed for NaiveForecaster.")
+                print("Possible reasons:")
+                print("- Dataset may not be compatible")
+                print("- Horizon value may be incorrect")
+                print("- Model may require additional parameters")
+
         if h2:
             print_tool_call(
                 "fit_predict", {"estimator_handle": h2, "dataset": "sunspots", "horizon": 6}
             )
             pred2 = fit_predict_tool(h2, "sunspots", 6)
             print_result({"success": pred2["success"], "horizon": pred2.get("horizon")})
+
+            if not pred2["success"]:
+                print("⚠️ Prediction failed for ThetaForecaster.")
+                print("Possible reasons:")
+                print("- Dataset may not be compatible")
+                print("- Horizon value may be incorrect")
+                print("- Model may require additional parameters")
 
         # Step 6: Generate comparison
         print("\n🤖 LLM Response:")

--- a/examples/02_llm_query_simulation.py
+++ b/examples/02_llm_query_simulation.py
@@ -141,28 +141,30 @@ def simulate_query_2():
                 "fit_predict", {"estimator_handle": h1, "dataset": "sunspots", "horizon": 6}
             )
             pred1 = fit_predict_tool(h1, "sunspots", 6)
-            print_result({"success": pred1["success"], "horizon": pred1.get("horizon")})
+            result1 = {
+                "success": pred1["success"],
+                "horizon": pred1.get("horizon"),
+            }
 
             if not pred1["success"]:
-                print("⚠️ Prediction failed for NaiveForecaster.")
-                print("Possible reasons:")
-                print("- Dataset may not be compatible")
-                print("- Horizon value may be incorrect")
-                print("- Model may require additional parameters")
+                result1["note"] = "Prediction failed. Check dataset compatibility or parameters."
+
+            print_result(result1)
 
         if h2:
             print_tool_call(
                 "fit_predict", {"estimator_handle": h2, "dataset": "sunspots", "horizon": 6}
             )
             pred2 = fit_predict_tool(h2, "sunspots", 6)
-            print_result({"success": pred2["success"], "horizon": pred2.get("horizon")})
+            result2 = {
+                "success": pred2["success"],
+                "horizon": pred2.get("horizon"),
+            }
 
             if not pred2["success"]:
-                print("⚠️ Prediction failed for ThetaForecaster.")
-                print("Possible reasons:")
-                print("- Dataset may not be compatible")
-                print("- Horizon value may be incorrect")
-                print("- Model may require additional parameters")
+                result2["note"] = "Prediction failed. Check dataset compatibility or parameters."
+
+            print_result(result2)
 
         # Step 6: Generate comparison
         print("\n🤖 LLM Response:")


### PR DESCRIPTION
This PR improves the clarity of the LLM query simulation example by adding feedback when predictions fail.

Currently, failed predictions only return `success: false` without explanation, which can be confusing for new users.

Changes:
- Added user-friendly messages when prediction fails
- Provided possible reasons for failure

This improves usability and helps beginners understand expected behavior.