### PR TITLE
fix: cancel_job() now actually stops running background jobs (#136)

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -266,6 +266,11 @@ class Executor:
             )
             await asyncio.sleep(0.01)  # Yield control to event loop
 
+            # Check if job was cancelled before proceeding
+            job = self._job_manager.get_job(job_id)
+            if job and job.status == JobStatus.CANCELLED:
+                return {"success": False, "error": "Job cancelled", "job_id": job_id}
+
             data_result = self.load_dataset(dataset)
             if not data_result["success"]:
                 self._job_manager.update_job(
@@ -284,6 +289,11 @@ class Executor:
                 job_id, completed_steps=1, current_step=f"Fitting {estimator_name} on {dataset}..."
             )
             await asyncio.sleep(0.01)  # Yield control
+
+            # Check if job was cancelled before proceeding
+            job = self._job_manager.get_job(job_id)
+            if job and job.status == JobStatus.CANCELLED:
+                return {"success": False, "error": "Job cancelled", "job_id": job_id}
 
             # Run fit in executor to avoid blocking
             loop = asyncio.get_event_loop()
@@ -306,6 +316,11 @@ class Executor:
                 current_step=f"Generating predictions (horizon={horizon})...",
             )
             await asyncio.sleep(0.01)  # Yield control
+
+            # Check if job was cancelled before proceeding
+            job = self._job_manager.get_job(job_id)
+            if job and job.status == JobStatus.CANCELLED:
+                return {"success": False, "error": "Job cancelled", "job_id": job_id}
 
             # Run predict in executor
             predict_result = await loop.run_in_executor(
@@ -611,6 +626,11 @@ class Executor:
             )
             await asyncio.sleep(0.01)
 
+            # Check if job was cancelled
+            job = self._job_manager.get_job(job_id)
+            if job and job.status == JobStatus.CANCELLED:
+                return {"success": False, "error": "Job cancelled", "job_id": job_id}
+
             from sktime_mcp.data import DataSourceRegistry
 
             loop = asyncio.get_event_loop()
@@ -622,6 +642,11 @@ class Executor:
                 job_id, completed_steps=1, current_step="Validating data..."
             )
             await asyncio.sleep(0.01)
+
+            # Check if job was cancelled
+            job = self._job_manager.get_job(job_id)
+            if job and job.status == JobStatus.CANCELLED:
+                return {"success": False, "error": "Job cancelled", "job_id": job_id}
 
             is_valid, validation_report = adapter.validate(data)
             if not is_valid:
@@ -639,6 +664,11 @@ class Executor:
                 job_id, completed_steps=2, current_step="Converting to sktime format..."
             )
             await asyncio.sleep(0.01)
+
+            # Check if job was cancelled
+            job = self._job_manager.get_job(job_id)
+            if job and job.status == JobStatus.CANCELLED:
+                return {"success": False, "error": "Job cancelled", "job_id": job_id}
 
             y, X = adapter.to_sktime_format(data)
 

--- a/src/sktime_mcp/runtime/jobs.py
+++ b/src/sktime_mcp/runtime/jobs.py
@@ -4,6 +4,7 @@ Job management for long-running operations in sktime MCP.
 Handles background training jobs with progress tracking and status updates.
 """
 
+import concurrent.futures
 import threading
 import uuid
 from dataclasses import dataclass, field
@@ -127,6 +128,7 @@ class JobManager:
 
     def __init__(self):
         self.jobs: dict[str, JobInfo] = {}
+        self._futures: dict[str, concurrent.futures.Future] = {}
         self.lock = threading.Lock()
 
     def create_job(
@@ -198,6 +200,10 @@ class JobManager:
 
             # Update status
             if status is not None:
+                # Guard: do not allow overwriting a CANCELLED job
+                if job.status == JobStatus.CANCELLED and status != JobStatus.CANCELLED:
+                    return False
+
                 old_status = job.status
                 job.status = status
 
@@ -268,9 +274,25 @@ class JobManager:
 
             return jobs
 
+    def register_future(self, job_id: str, future: concurrent.futures.Future) -> None:
+        """
+        Store the Future returned by asyncio.run_coroutine_threadsafe.
+
+        This allows cancel_job() to actually cancel the running coroutine.
+
+        Args:
+            job_id: Job ID
+            future: The concurrent.futures.Future for the background coroutine
+        """
+        with self.lock:
+            self._futures[job_id] = future
+
     def cancel_job(self, job_id: str) -> bool:
         """
         Cancel a job.
+
+        If a Future was registered for this job, it will be cancelled to
+        stop the actual background coroutine.
 
         Args:
             job_id: Job ID to cancel
@@ -288,6 +310,12 @@ class JobManager:
             if job.status in (JobStatus.PENDING, JobStatus.RUNNING):
                 job.status = JobStatus.CANCELLED
                 job.end_time = datetime.now()
+
+                # Cancel the actual coroutine if a future was stored
+                future = self._futures.pop(job_id, None)
+                if future is not None:
+                    future.cancel()
+
                 return True
 
             return False

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -192,7 +192,8 @@ def load_data_source_async_tool(
         asyncio.set_event_loop(loop)
 
     coro = executor.load_data_source_async(config, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    job_manager.register_future(job_id, future)
 
     return {
         "success": True,

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -169,7 +169,8 @@ def fit_predict_async_tool(
 
     # Schedule the coroutine (non-blocking!)
     coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    job_manager.register_future(job_id, future)
 
     return {
         "success": True,

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -204,6 +204,114 @@ def test_cleanup_old_jobs():
     assert job is None
 
 
+def test_cancel_prevents_overwrite():
+    """Test that a CANCELLED job cannot be overwritten to COMPLETED."""
+    job_manager = get_job_manager()
+
+    job_id = job_manager.create_job(
+        job_type="fit_predict",
+        estimator_handle="test_handle",
+        estimator_name="ARIMA",
+        dataset_name="airline",
+        total_steps=3,
+    )
+
+    # Move to RUNNING, then cancel
+    job_manager.update_job(job_id, status=JobStatus.RUNNING)
+    success = job_manager.cancel_job(job_id)
+    assert success
+
+    job = job_manager.get_job(job_id)
+    assert job.status == JobStatus.CANCELLED
+
+    # Simulate the background coroutine trying to overwrite status
+    result = job_manager.update_job(
+        job_id,
+        status=JobStatus.COMPLETED,
+        completed_steps=3,
+        current_step="Completed",
+        result={"predictions": {1: 450.2, 2: 460.5}},
+    )
+    assert result is False
+
+    # Status must still be CANCELLED
+    job = job_manager.get_job(job_id)
+    assert job.status == JobStatus.CANCELLED
+
+    print("✓ Cancelled status cannot be overwritten to completed")
+
+    # Cleanup
+    job_manager.delete_job(job_id)
+
+
+def test_cancel_job_stores_and_cancels_future():
+    """Test that register_future stores a future and cancel_job cancels it."""
+    from unittest.mock import MagicMock
+
+    job_manager = get_job_manager()
+
+    job_id = job_manager.create_job(
+        job_type="fit_predict",
+        estimator_handle="test_handle",
+        estimator_name="ARIMA",
+        total_steps=3,
+    )
+    job_manager.update_job(job_id, status=JobStatus.RUNNING)
+
+    # Register a mock future
+    mock_future = MagicMock()
+    job_manager.register_future(job_id, mock_future)
+
+    # Cancel the job — should call future.cancel()
+    success = job_manager.cancel_job(job_id)
+    assert success
+    mock_future.cancel.assert_called_once()
+
+    print("✓ cancel_job() calls future.cancel()")
+
+    # Cleanup
+    job_manager.delete_job(job_id)
+
+
+@pytest.mark.asyncio
+async def test_async_fit_predict_respects_cancellation():
+    """Test that fit_predict_async exits early when the job is cancelled."""
+    executor = get_executor()
+    job_manager = get_job_manager()
+
+    # Instantiate a simple forecaster
+    result = executor.instantiate("NaiveForecaster")
+    assert result["success"]
+    handle = result["handle"]
+
+    # Create and immediately cancel the job
+    job_id = job_manager.create_job(
+        job_type="fit_predict",
+        estimator_handle=handle,
+        estimator_name="NaiveForecaster",
+        dataset_name="airline",
+        horizon=12,
+        total_steps=3,
+    )
+    job_manager.update_job(job_id, status=JobStatus.RUNNING)
+    job_manager.cancel_job(job_id)
+
+    # Run the async coroutine — it should detect the cancellation and exit early
+    result = await executor.fit_predict_async(handle, "airline", 12, job_id)
+
+    assert result["success"] is False
+    assert "cancelled" in result["error"].lower()
+
+    # Status must remain CANCELLED
+    job = job_manager.get_job(job_id)
+    assert job.status == JobStatus.CANCELLED
+
+    print("✓ Async fit_predict respects cancellation")
+
+    # Cleanup
+    job_manager.delete_job(job_id)
+
+
 def run_all_tests():
     """Run all tests."""
     print("=" * 60)


### PR DESCRIPTION
### Reference Issues/PRs

Fixes #136

### What does this implement/fix? Explain your changes.

`cancel_job()` was only changing the status label to CANCELLED but wasn't actually stopping the background coroutine. The coroutine would keep running and silently overwrite the CANCELLED status back to COMPLETED when it finished.

There were three things causing this:

1. The `Future` returned by `asyncio.run_coroutine_threadsafe()` was being thrown away in both `fit_predict_async_tool()` and `load_data_source_async_tool()`, so there was no way to actually cancel it.

2. The async coroutines (`fit_predict_async` and `load_data_source_async`) never checked if the job had been cancelled between their steps they just ran straight through load → fit → predict regardless.

3. `update_job()` had no guard against overwriting a CANCELLED status, so the still-running coroutine could silently set it back to COMPLETED.

This PR fixes all three:
- Stores the `Future` via a new `register_future()` method and calls `future.cancel()` in `cancel_job()`
- Adds cancellation checks between each step in both async coroutines so they exit early
- Adds a guard in `update_job()` that rejects status changes from CANCELLED

### Does your contribution introduce a new dependency? If yes, which one?

No.

### What should a reviewer concentrate their feedback on?

- The guard logic in `update_job()` it currently blocks any status change away from CANCELLED. This felt like the right approach since a cancelled job should stay cancelled, but open to feedback if FAILED should still be allowed to overwrite CANCELLED.
- The cancellation check pattern in the async coroutines checks happen at the yield points between steps. During a blocking `run_in_executor` call (e.g., while fitting a model), the cancellation won't take effect until that step finishes. This is a limitation of cooperative cancellation but seemed like a reasonable tradeoff.

### Any other comments?

The same issue also affected `load_data_source_async_tool()` in `data_tools.py` as noted in the issue, so I applied the fix there too.

Three new tests added:
- `test_cancel_prevents_overwrite` - verifies the exact reproduction scenario from the issue
- `test_cancel_job_stores_and_cancels_future` - verifies `future.cancel()` is called
- `test_async_fit_predict_respects_cancellation` - end-to-end test for early exit

### PR checklist

#### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTORS.md).
- [x] I've added unit tests and made sure they pass locally.