### PR TITLE
feat: add plot_data and plot_forecast MCP tools with ImageContent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "scikit-learn>=1.0.0",
     "statsmodels>=0.13.0",
     "pmdarima>=2.0.0",
+    "matplotlib>=3.5.0",
 ]
 
 [project.optional-dependencies]

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import ImageContent, TextContent, Tool
 
 from sktime_mcp.composition.validator import get_composition_validator
 from sktime_mcp.tools.codegen import export_code_tool
@@ -54,6 +54,7 @@ from sktime_mcp.tools.list_estimators import (
     get_available_tags,
     list_estimators_tool,
 )
+from sktime_mcp.tools.plot_tools import plot_data_tool, plot_forecast_tool
 from sktime_mcp.tools.save_model import save_model_tool
 
 # Configure logging to stderr with detailed format
@@ -555,11 +556,59 @@ async def list_tools() -> list[Tool]:
                 "required": ["estimator_handle", "path"],
             },
         ),
+        Tool(
+            name="plot_data",
+            description=(
+                "Plot a time series as a line chart and return it as an inline image. "
+                "Accepts a loaded data handle (from load_data_source) OR a demo dataset "
+                "name (airline, sunspots, lynx, …). "
+                "Use this to give the LLM visual context before choosing a model."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Handle from load_data_source (optional)",
+                    },
+                    "dataset": {
+                        "type": "string",
+                        "description": "Demo dataset name: airline, sunspots, lynx, etc. (optional)",
+                    },
+                },
+            },
+        ),
+        Tool(
+            name="plot_forecast",
+            description=(
+                "Plot forecast predictions overlaid on historical data and return it as an inline image. "
+                "Pass the predictions dict from fit_predict or predict. "
+                "Optionally supply data_handle or dataset to show the historical series alongside the forecast."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "predictions": {
+                        "type": "object",
+                        "description": "Dict of {timestamp: value} returned by fit_predict or predict",
+                    },
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Handle from load_data_source for historical overlay (optional)",
+                    },
+                    "dataset": {
+                        "type": "string",
+                        "description": "Demo dataset name for historical overlay (optional)",
+                    },
+                },
+                "required": ["predictions"],
+            },
+        ),
     ]
 
 
 @server.call_tool()
-async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent | ImageContent]:
     """Handle tool calls."""
     logger.info(f"=== Tool Call: {name} ===")
     logger.info(f"Arguments: {json.dumps(arguments, indent=2)}")
@@ -667,10 +716,34 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["path"],
                 arguments.get("mlflow_params"),
             )
+        elif name == "plot_data":
+            result = plot_data_tool(
+                data_handle=arguments.get("data_handle"),
+                dataset=arguments.get("dataset"),
+            )
+        elif name == "plot_forecast":
+            result = plot_forecast_tool(
+                predictions=arguments["predictions"],
+                data_handle=arguments.get("data_handle"),
+                dataset=arguments.get("dataset"),
+            )
         else:
             result = {"error": f"Unknown tool: {name}"}
 
         logger.info(f"=== Result for {name} ===")
+
+        # Plot tools return an inline image; all others return JSON text
+        if name in ("plot_data", "plot_forecast"):
+            if result.get("success") and result.get("image"):
+                return [
+                    ImageContent(
+                        type="image",
+                        data=result["image"],
+                        mimeType=result.get("mime_type", "image/png"),
+                    )
+                ]
+            # Fall through to text on error
+            return [TextContent(type="text", text=json.dumps({"error": result.get("error", "Plot failed")}))]
 
         # Sanitize result for JSON serialization
         sanitized_result = sanitize_for_json(result)

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -8,7 +8,7 @@ that exposes sktime's registry and execution capabilities to LLMs.
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import Any, Union
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -608,7 +608,7 @@ async def list_tools() -> list[Tool]:
 
 
 @server.call_tool()
-async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent | ImageContent]:
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[Union[TextContent, ImageContent]]:
     """Handle tool calls."""
     logger.info(f"=== Tool Call: {name} ===")
     logger.info(f"Arguments: {json.dumps(arguments, indent=2)}")

--- a/src/sktime_mcp/tools/plot_tools.py
+++ b/src/sktime_mcp/tools/plot_tools.py
@@ -1,0 +1,210 @@
+"""
+Plot tools for sktime MCP.
+
+Returns base64-encoded PNG images via MCP ImageContent,
+allowing MCP clients (e.g. Claude Desktop) to render
+time series charts directly in the chat interface.
+"""
+
+import base64
+import io
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _fig_to_base64(fig) -> str:
+    """Encode a matplotlib figure as a base64 PNG string."""
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight", dpi=100)
+    buf.seek(0)
+    data = base64.b64encode(buf.read()).decode("utf-8")
+    buf.close()
+    return data
+
+
+def _load_series(data_handle: str | None, dataset: str | None):
+    """
+    Return (y, label) from either a data handle or a demo dataset name.
+
+    Raises ValueError if neither is provided or if the handle/dataset is unknown.
+    """
+    from sktime_mcp.runtime.executor import get_executor
+
+    executor = get_executor()
+
+    if data_handle is not None:
+        if data_handle not in executor._data_handles:
+            raise ValueError(f"Data handle '{data_handle}' not found")
+        info = executor._data_handles[data_handle]
+        y = info["y"]
+        label = y.name or data_handle
+        return y, label
+
+    if dataset is not None:
+        result = executor.load_dataset(dataset)
+        if not result["success"]:
+            raise ValueError(result.get("error", f"Unknown dataset: {dataset}"))
+        y = result["data"]
+        return y, dataset
+
+    raise ValueError("Provide either 'data_handle' or 'dataset'")
+
+
+def plot_data_tool(
+    data_handle: str | None = None,
+    dataset: str | None = None,
+) -> dict[str, Any]:
+    """
+    Plot a time series as a line chart.
+
+    Accepts either a loaded data handle (from load_data_source) or a
+    demo dataset name (airline, sunspots, lynx, …).  Returns a
+    base64-encoded PNG image that MCP clients can render inline.
+
+    Args:
+        data_handle: Handle from load_data_source (optional)
+        dataset:     Demo dataset name (optional)
+
+    Returns:
+        Dict with:
+        - success:   bool
+        - image:     base64-encoded PNG string
+        - mime_type: "image/png"
+        - rows:      number of time steps plotted
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    try:
+        y, label = _load_series(data_handle, dataset)
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.plot(
+        y.index.astype(str),
+        y.values,
+        color="#2196F3",
+        linewidth=1.5,
+        label=label,
+    )
+    ax.set_title(f"Time Series: {label}")
+    ax.set_xlabel("Time")
+    ax.set_ylabel(label)
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    # Show at most 12 x-tick labels to avoid crowding
+    tick_step = max(1, len(y) // 12)
+    ax.set_xticks(range(0, len(y), tick_step))
+    ax.set_xticklabels(
+        [str(y.index[i]) for i in range(0, len(y), tick_step)],
+        rotation=45,
+        ha="right",
+    )
+
+    plt.tight_layout()
+    image_data = _fig_to_base64(fig)
+    plt.close(fig)
+
+    return {
+        "success": True,
+        "image": image_data,
+        "mime_type": "image/png",
+        "rows": len(y),
+    }
+
+
+def plot_forecast_tool(
+    predictions: dict,
+    data_handle: str | None = None,
+    dataset: str | None = None,
+) -> dict[str, Any]:
+    """
+    Plot forecast predictions overlaid on historical time series.
+
+    The historical series is provided via a data handle or demo dataset name.
+    Predictions should be the dict returned by fit_predict or predict
+    (keys are timestamp strings, values are forecast values).
+
+    Args:
+        predictions: Dict of {timestamp_str: value} from fit_predict / predict
+        data_handle: Handle from load_data_source for historical overlay (optional)
+        dataset:     Demo dataset name for historical overlay (optional)
+
+    Returns:
+        Dict with:
+        - success:   bool
+        - image:     base64-encoded PNG string
+        - mime_type: "image/png"
+        - horizon:   number of forecast steps plotted
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+    if not predictions:
+        return {"success": False, "error": "'predictions' must be a non-empty dict"}
+
+    pred_series = pd.Series(
+        list(predictions.values()),
+        index=list(predictions.keys()),
+        name="forecast",
+    )
+
+    fig, ax = plt.subplots(figsize=(12, 4))
+
+    # Historical overlay (last 60 points for readability)
+    if data_handle is not None or dataset is not None:
+        try:
+            y, label = _load_series(data_handle, dataset)
+            y_tail = y.tail(60)
+            ax.plot(
+                y_tail.index.astype(str),
+                y_tail.values,
+                color="#2196F3",
+                linewidth=1.5,
+                label="Historical",
+            )
+        except ValueError as exc:
+            plt.close(fig)
+            return {"success": False, "error": str(exc)}
+    else:
+        label = "series"
+
+    # Forecast line
+    ax.plot(
+        pred_series.index.astype(str),
+        pred_series.values,
+        color="#FF5722",
+        linewidth=1.5,
+        linestyle="--",
+        marker="o",
+        markersize=4,
+        label="Forecast",
+    )
+
+    title = f"Forecast: {label}" if (data_handle or dataset) else "Forecast"
+    ax.set_title(title)
+    ax.set_xlabel("Time")
+    ax.set_ylabel(label)
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+
+    image_data = _fig_to_base64(fig)
+    plt.close(fig)
+
+    return {
+        "success": True,
+        "image": image_data,
+        "mime_type": "image/png",
+        "horizon": len(pred_series),
+    }

--- a/src/sktime_mcp/tools/plot_tools.py
+++ b/src/sktime_mcp/tools/plot_tools.py
@@ -9,7 +9,7 @@ time series charts directly in the chat interface.
 import base64
 import io
 import logging
-from typing import Any
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ def _fig_to_base64(fig) -> str:
     return data
 
 
-def _load_series(data_handle: str | None, dataset: str | None):
+def _load_series(data_handle: Optional[str], dataset: Optional[str]):
     """
     Return (y, label) from either a data handle or a demo dataset name.
 
@@ -53,8 +53,8 @@ def _load_series(data_handle: str | None, dataset: str | None):
 
 
 def plot_data_tool(
-    data_handle: str | None = None,
-    dataset: str | None = None,
+    data_handle: Optional[str] = None,
+    dataset: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Plot a time series as a line chart.
@@ -121,8 +121,8 @@ def plot_data_tool(
 
 def plot_forecast_tool(
     predictions: dict,
-    data_handle: str | None = None,
-    dataset: str | None = None,
+    data_handle: Optional[str] = None,
+    dataset: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Plot forecast predictions overlaid on historical time series.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -215,5 +215,105 @@ class TestTools:
         assert calls["serialization_format"] == "pickle"
 
 
+class TestPlotTools:
+    """Tests for plot_data and plot_forecast tools (Issue #99)."""
+
+    def test_plot_data_demo_dataset(self):
+        """plot_data with a demo dataset returns a valid base64 PNG."""
+        import base64
+
+        from sktime_mcp.tools.plot_tools import plot_data_tool
+
+        result = plot_data_tool(dataset="airline")
+
+        assert result["success"], result.get("error")
+        assert result["mime_type"] == "image/png"
+        assert result["rows"] > 0
+        decoded = base64.b64decode(result["image"])
+        assert decoded[:4] == b"\x89PNG", "Expected PNG magic bytes"
+
+    def test_plot_data_requires_handle_or_dataset(self):
+        """plot_data without arguments should return an error."""
+        from sktime_mcp.tools.plot_tools import plot_data_tool
+
+        result = plot_data_tool()
+
+        assert not result["success"]
+        assert "error" in result
+
+    def test_plot_data_unknown_handle_errors(self):
+        """plot_data with a non-existent data handle should return an error."""
+        from sktime_mcp.tools.plot_tools import plot_data_tool
+
+        result = plot_data_tool(data_handle="data_doesnotexist")
+
+        assert not result["success"]
+        assert "not found" in result["error"].lower()
+
+    def test_plot_forecast_demo_dataset(self):
+        """plot_forecast with demo dataset history returns a valid base64 PNG."""
+        import base64
+
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+        from sktime_mcp.tools.plot_tools import plot_forecast_tool
+
+        inst = instantiate_estimator_tool("NaiveForecaster")
+        assert inst["success"]
+
+        fp = fit_predict_tool(inst["handle"], "airline", horizon=6)
+        assert fp["success"]
+
+        result = plot_forecast_tool(
+            predictions=fp["predictions"],
+            dataset="airline",
+        )
+
+        assert result["success"], result.get("error")
+        assert result["mime_type"] == "image/png"
+        assert result["horizon"] == 6
+        decoded = base64.b64decode(result["image"])
+        assert decoded[:4] == b"\x89PNG", "Expected PNG magic bytes"
+
+    def test_plot_forecast_without_history(self):
+        """plot_forecast works even without a historical source."""
+        import base64
+
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+        from sktime_mcp.tools.plot_tools import plot_forecast_tool
+
+        inst = instantiate_estimator_tool("NaiveForecaster")
+        fp = fit_predict_tool(inst["handle"], "airline", horizon=4)
+        assert fp["success"]
+
+        result = plot_forecast_tool(predictions=fp["predictions"])
+
+        assert result["success"], result.get("error")
+        assert result["horizon"] == 4
+        decoded = base64.b64decode(result["image"])
+        assert decoded[:4] == b"\x89PNG"
+
+    def test_plot_forecast_empty_predictions_errors(self):
+        """plot_forecast with an empty predictions dict should return an error."""
+        from sktime_mcp.tools.plot_tools import plot_forecast_tool
+
+        result = plot_forecast_tool(predictions={})
+
+        assert not result["success"]
+        assert "error" in result
+
+    def test_server_exposes_plot_tools(self):
+        """list_tools should include plot_data and plot_forecast."""
+        import asyncio
+
+        from sktime_mcp.server import list_tools
+
+        tools = asyncio.run(list_tools())
+        names = {t.name for t in tools}
+        assert "plot_data" in names
+        assert "plot_forecast" in names
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add `plot_data` tool: plots a time series from a data handle or demo dataset and returns a base64-encoded PNG via MCP `ImageContent` — rendered inline in Claude Desktop
- Add `plot_forecast` tool: overlays forecast predictions on the historical series and returns an inline image
- Import `ImageContent` from `mcp.types`; update `call_tool` return type to `list[TextContent | ImageContent]`
- Register both tools in `list_tools()` and dispatch in `call_tool()`
- 7 new tests covering success paths, error cases, and server tool exposure

## Context
Closes #99. Time series data is fundamentally visual. LLMs parsing 100+ point dicts are inefficient and prone to hallucination. By returning `ImageContent`, MCP clients like Claude Desktop render the chart directly in the chat — giving the LLM genuine visual context before selecting a model or interpreting results.

Supported workflows:
- `plot_data(dataset="airline")` — visualise a demo dataset before modelling
- `plot_data(data_handle="data_abc123")` — visualise loaded custom data
- `plot_forecast(predictions=..., dataset="airline")` — overlay forecast on history
- `plot_forecast(predictions=...)` — forecast-only view when no history is needed

## Test plan
- [x] `test_plot_data_demo_dataset` — returns valid base64 PNG (PNG magic bytes verified)
- [x] `test_plot_data_requires_handle_or_dataset` — error when no source given
- [x] `test_plot_data_unknown_handle_errors` — error on missing handle
- [x] `test_plot_forecast_demo_dataset` — returns PNG with correct horizon
- [x] `test_plot_forecast_without_history` — works without historical overlay
- [x] `test_plot_forecast_empty_predictions_errors` — error on empty predictions
- [x] `test_server_exposes_plot_tools` — both tools appear in list_tools()
- [x] All 22 tests pass (15 pre-existing + 7 new), 0 regressions
- [x] `ruff check` clean

AI was used for basic drafting assistance and refinement; all changes were verified manually.