### PR TITLE
Expose fit/predict and handle tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,29 @@ Execute a complete workflow: load dataset, fit estimator, and generate predictio
 
 ---
 
-#### 9. `save_model`
+#### 9. `fit`
+Fit an estimator on a dataset without generating predictions.
+
+**Arguments:**
+- `estimator_handle` (required): Handle from `instantiate_estimator` or `instantiate_pipeline`
+- `dataset` (required): Dataset name (e.g., `"airline"`, `"sunspots"`, `"lynx"`)
+
+**Returns:** `{"success": true, ...}`
+
+---
+
+#### 10. `predict`
+Generate predictions from a previously fitted estimator.
+
+**Arguments:**
+- `estimator_handle` (required): Handle of a fitted estimator
+- `horizon` (optional): Forecast horizon (default: 12)
+
+**Returns:** `{"success": true, "predictions": {...}, "horizon": 12}`
+
+---
+
+#### 11. `save_model`
 Persist a fitted estimator or pipeline handle to a local filesystem path using `sktime.utils.mlflow_sktime.save_model`.
 
 **Arguments:**

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -30,6 +30,8 @@ from sktime_mcp.tools.describe_estimator import (
 from sktime_mcp.tools.fit_predict import (
     fit_predict_async_tool,
     fit_predict_tool,
+    fit_tool,
+    predict_tool,
 )
 from sktime_mcp.tools.format_tools import (
     auto_format_on_load_tool,
@@ -161,12 +163,12 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_handles",
-            description="List all active estimator handles in memory",
+            description="List all active estimator handles and their metadata",
             inputSchema={"type": "object", "properties": {}},
         ),
         Tool(
             name="release_handle",
-            description="Release an estimator handle and free it from memory",
+            description="Release an estimator handle and free memory",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -218,6 +220,43 @@ async def list_tools() -> list[Tool]:
                     "data_handle": {
                         "type": "string",
                         "description": "Handle from load_data_source (use this instead of dataset for custom data)",
+                    },
+                    "horizon": {
+                        "type": "integer",
+                        "description": "Forecast horizon (default: 12)",
+                        "default": 12,
+                    },
+                },
+                "required": ["estimator_handle"],
+            },
+        ),
+        Tool(
+            name="fit",
+            description="Fit an estimator on a dataset",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle from instantiate_estimator",
+                    },
+                    "dataset": {
+                        "type": "string",
+                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                    },
+                },
+                "required": ["estimator_handle", "dataset"],
+            },
+        ),
+        Tool(
+            name="predict",
+            description="Generate predictions from a fitted estimator",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {
+                        "type": "string",
+                        "description": "Handle of a fitted estimator",
                     },
                     "horizon": {
                         "type": "integer",
@@ -622,7 +661,6 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             result = list_handles_tool()
         elif name == "release_handle":
             result = release_handle_tool(arguments["handle"])
-
         elif name == "fit_predict":
             result = fit_predict_tool(
                 arguments["estimator_handle"],
@@ -637,6 +675,16 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["estimator_handle"],
                 arguments["dataset"],
                 arguments.get("cv_folds", 3),
+            )
+        elif name == "fit":
+            result = fit_tool(
+                arguments["estimator_handle"],
+                arguments["dataset"],
+            )
+        elif name == "predict":
+            result = predict_tool(
+                arguments["estimator_handle"],
+                arguments.get("horizon", 12),
             )
             result = sanitize_for_json(result)
         elif name == "validate_pipeline":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 Tests for sktime-mcp core functionality.
 """
 
+import asyncio
 import sys
 
 import pytest
@@ -213,6 +214,38 @@ class TestTools:
         assert result["saved_path"] == str(tmp_path / "model_dir")
         assert calls["path"] == str(tmp_path / "model_dir")
         assert calls["serialization_format"] == "pickle"
+
+    def test_list_handles_and_release_handle_tools(self):
+        """Test handle listing and release tool flow."""
+        from sktime_mcp.tools.instantiate import (
+            instantiate_estimator_tool,
+            list_handles_tool,
+            release_handle_tool,
+        )
+
+        create_result = instantiate_estimator_tool("NaiveForecaster")
+        assert create_result["success"]
+        handle = create_result["handle"]
+
+        handles_result = list_handles_tool()
+        assert handles_result["success"]
+        handle_ids = {h["handle_id"] for h in handles_result["handles"]}
+        assert handle in handle_ids
+
+        release_result = release_handle_tool(handle)
+        assert release_result["success"]
+
+    def test_server_exposes_quick_win_tools(self):
+        """Test MCP server lists the newly exposed tools."""
+        from sktime_mcp.server import list_tools
+
+        tools = asyncio.run(list_tools())
+        tool_names = {tool.name for tool in tools}
+
+        assert "list_handles" in tool_names
+        assert "release_handle" in tool_names
+        assert "fit" in tool_names
+        assert "predict" in tool_names
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #92

## Problem

`fit_tool` and `predict_tool` are implemented in `src/sktime_mcp/tools/fit_predict.py` but not registered as MCP server tools. Clients can only use the combined `fit_predict` ,  there's no way to fit an estimator and predict separately.

Separated fit/predict is useful when:
- The user wants to fit once and predict multiple times with different horizons
- Fit is expensive and shouldn't be repeated unnecessarily
- The workflow needs inspection between fitting and predicting

Note: `list_handles` and `release_handle` (also mentioned in #92) were already exposed by #66.

## Changes

1. **`src/sktime_mcp/server.py`**:
   - Import `fit_tool` and `predict_tool`
   - Add `fit` and `predict` tool schemas in `list_tools()`
   - Add dispatch branches in `call_tool()`
   - Minor description improvements for `list_handles` and `release_handle`

2. **`tests/test_core.py`**:
   - Add test verifying `fit`, `predict`, `list_handles`, `release_handle` are exposed in the server tool list
   - Add test for handle listing and release flow

3. **`README.md`**:
   - Document `fit` (tool 9) and `predict` (tool 10)
   - Renumber subsequent tools

## Context

Previous PR was closed with a request to open an issue first:
https://github.com/sktime/sktime-mcp/pull/50#issuecomment-4187392776