### PR TITLE
feat: add `extract_ts_metadata` tool for `LLM`-driven model selection

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -48,6 +48,7 @@ from sktime_mcp.tools.list_estimators import (
     list_estimators_tool,
 )
 from sktime_mcp.tools.save_model import save_model_tool
+from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
 
 # ---------------------------------------------------------------------------
 # Server configuration via environment variables
@@ -560,6 +561,29 @@ async def list_tools() -> list[Tool]:
                 "required": ["job_id"],
             },
         ),
+        Tool(
+            name="extract_ts_metadata",
+            description=(
+                "Extract rich statistical metadata from a time series for LLM-driven model selection. "
+                "Returns trend direction, stationarity (ADF test), seasonality detection, "
+                "autocorrelation, registry-matched recommended models, and actionable agent hints. "
+                "ALWAYS call this after load_data_source and before instantiate_estimator to guide "
+                "model selection — this closes the prompt → model → evaluation agentic loop."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Handle from load_data_source (for custom data)",
+                    },
+                    "dataset": {
+                        "type": "string",
+                        "description": "Demo dataset name (e.g. 'airline', 'sunspots', 'lynx')",
+                    },
+                },
+            },
+        ),
     ]
 
 
@@ -737,7 +761,14 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             # Deprecated — now runs automatically on a periodic timer
             logger.warning("cleanup_old_jobs is deprecated; jobs are cleaned up automatically")
             from sktime_mcp.tools.job_tools import cleanup_old_jobs_tool
+
             result = cleanup_old_jobs_tool(arguments.get("max_age_hours", 24))
+
+        elif name == "extract_ts_metadata":
+            result = extract_ts_metadata_tool(
+                data_handle=arguments.get("data_handle"),
+                dataset=arguments.get("dataset"),
+            )
 
         else:
             result = {"error": f"Unknown tool: {name}"}

--- a/src/sktime_mcp/tools/ts_metadata.py
+++ b/src/sktime_mcp/tools/ts_metadata.py
@@ -1,0 +1,365 @@
+"""
+extract_ts_metadata tool for sktime MCP.
+
+Provides rich statistical profiling of time series data for
+LLM agents to reason about data characteristics before model selection.
+"""
+
+import logging
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+
+from sktime_mcp.runtime.executor import get_executor
+
+logger = logging.getLogger(__name__)
+
+
+def _detect_trend(y: pd.Series) -> str:
+    """Detect trend direction using linear regression slope."""
+    try:
+        x = np.arange(len(y))
+        slope = np.polyfit(x, y.values.astype(float), 1)[0]
+        # Normalize slope relative to mean to determine significance
+        relative_slope = abs(slope) / (abs(float(y.mean())) + 1e-10)
+        if relative_slope < 0.001:
+            return "none"
+        return "upward" if slope > 0 else "downward"
+    except Exception:
+        return "unknown"
+
+
+def _check_stationarity(y: pd.Series) -> dict[str, Any]:
+    """Run Augmented Dickey-Fuller test for stationarity."""
+    try:
+        from statsmodels.tsa.stattools import adfuller
+
+        result = adfuller(y.dropna(), autolag="AIC")
+        adf_stat = float(result[0])
+        p_value = float(result[1])
+        return {
+            "adf_statistic": round(adf_stat, 4),
+            "adf_pvalue": round(p_value, 4),
+            "is_stationary": p_value < 0.05,
+        }
+    except Exception as e:
+        logger.debug(f"Stationarity test failed: {e}")
+        return {"error": str(e), "is_stationary": None}
+
+
+def _detect_seasonality(y: pd.Series, freq: Optional[str]) -> dict[str, Any]:
+    """Detect seasonality using ACF analysis."""
+    try:
+        from statsmodels.tsa.stattools import acf
+
+        n = len(y)
+        if n < 10:
+            return {"detected": False, "dominant_period": None, "strength": "none"}
+
+        # Map known frequencies to their natural seasonal period
+        freq_period_map = {
+            "MS": [12],
+            "M": [12],
+            "ME": [12],
+            "QS": [4],
+            "Q": [4],
+            "QE": [4],
+            "D": [7, 365],
+            "h": [24, 168],
+            "H": [24, 168],
+            "W": [52],
+            "A": [1],
+            "Y": [1],
+            "YE": [1],
+            "min": [60, 1440],
+            "T": [60, 1440],
+        }
+        candidates = freq_period_map.get(freq, [4, 7, 12, 24, 52]) if freq else [4, 7, 12, 24, 52]
+
+        max_lag = min(n // 2 - 1, max(candidates) + 5) if candidates else min(n // 2 - 1, 50)
+        if max_lag < 2:
+            return {"detected": False, "dominant_period": None, "strength": "none"}
+
+        acf_values = acf(y.dropna(), nlags=max_lag, fft=True)
+
+        # Find peak ACF at candidate periods first
+        best_period = None
+        best_acf = 0.0
+        for period in candidates:
+            if period < len(acf_values):
+                val = abs(acf_values[period])
+                if val > best_acf:
+                    best_acf = val
+                    best_period = period
+
+        # If no strong candidate found, scan all lags for any peak
+        if best_acf < 0.3:
+            for lag in range(2, len(acf_values)):
+                val = abs(acf_values[lag])
+                if val > best_acf:
+                    best_acf = val
+                    best_period = lag
+
+        detected = best_acf > 0.3
+        if best_acf > 0.7:
+            strength = "strong"
+        elif best_acf > 0.4:
+            strength = "moderate"
+        elif best_acf > 0.3:
+            strength = "weak"
+        else:
+            strength = "none"
+
+        return {
+            "detected": detected,
+            "dominant_period": best_period if detected else None,
+            "strength": strength,
+        }
+    except Exception as e:
+        logger.debug(f"Seasonality detection failed: {e}")
+        return {"detected": False, "dominant_period": None, "strength": "none", "error": str(e)}
+
+
+def _get_autocorrelation(y: pd.Series, seasonal_period: Optional[int]) -> dict[str, Any]:
+    """Compute autocorrelation at lag 1 and the seasonal lag."""
+    try:
+        from statsmodels.tsa.stattools import acf
+
+        max_lag = max(2, (seasonal_period or 1) + 1)
+        max_lag = min(max_lag, len(y) // 2 - 1)
+        if max_lag < 1:
+            return {"lag_1": None, "lag_seasonal": None}
+
+        acf_vals = acf(y.dropna(), nlags=max_lag, fft=True)
+        lag1 = round(float(acf_vals[1]), 4) if len(acf_vals) > 1 else None
+        lag_s = (
+            round(float(acf_vals[seasonal_period]), 4)
+            if seasonal_period and seasonal_period < len(acf_vals)
+            else None
+        )
+        return {"lag_1": lag1, "lag_seasonal": lag_s}
+    except Exception as e:
+        logger.debug(f"Autocorrelation calculation failed: {e}")
+        return {"lag_1": None, "lag_seasonal": None}
+
+
+def _recommend_models(
+    is_stationary: Optional[bool],
+    seasonality: dict,
+    trend: str,
+) -> list[str]:
+    """
+    Suggest estimators from the sktime registry based on data characteristics.
+    Returns up to 5 model names that are actually present in the registry.
+    """
+    try:
+        from sktime_mcp.registry.interface import get_registry
+
+        registry = get_registry()
+        all_forecasters = registry.get_all_estimators(task="forecasting")
+        registry_names = {node.name for node in all_forecasters}
+
+        # Priority-ordered candidates per characteristic
+        if seasonality.get("detected"):
+            candidates = [
+                "AutoARIMA",
+                "ExponentialSmoothing",
+                "TBATS",
+                "Prophet",
+                "ARIMA",
+                "AutoETS",
+            ]
+        elif is_stationary is False:
+            candidates = [
+                "ARIMA",
+                "AutoARIMA",
+                "ExponentialSmoothing",
+                "ThetaForecaster",
+                "AutoETS",
+            ]
+        else:
+            candidates = [
+                "NaiveForecaster",
+                "ExponentialSmoothing",
+                "ARIMA",
+                "AutoARIMA",
+                "ThetaForecaster",
+            ]
+
+        recommended = [m for m in candidates if m in registry_names]
+
+        # Always include NaiveForecaster as a baseline if not already present
+        if "NaiveForecaster" not in recommended and "NaiveForecaster" in registry_names:
+            recommended.append("NaiveForecaster")
+
+        return recommended[:5]
+    except Exception as e:
+        logger.debug(f"Model recommendation failed: {e}")
+        return ["NaiveForecaster", "ARIMA", "ExponentialSmoothing"]
+
+
+def _build_agent_hints(
+    trend: str,
+    stationarity: dict,
+    seasonality: dict,
+    missing_pct: float,
+) -> list[str]:
+    """Generate actionable natural-language hints for LLM agents."""
+    hints = []
+
+    if missing_pct > 0:
+        hints.append(
+            f"{missing_pct:.1f}% missing values detected — "
+            "run format_time_series to fill gaps before fitting"
+        )
+
+    if trend in ("upward", "downward"):
+        hints.append(
+            f"{trend.capitalize()} trend detected — "
+            "consider adding a Detrender transformer in a pipeline"
+        )
+
+    if seasonality.get("detected"):
+        period = seasonality.get("dominant_period")
+        strength = seasonality.get("strength", "")
+        hints.append(
+            f"{strength.capitalize()} seasonality at period {period} — "
+            f"use ConditionalDeseasonalizer or seasonal ARIMA (s={period})"
+        )
+
+    is_stationary = stationarity.get("is_stationary")
+    p_value = stationarity.get("adf_pvalue")
+    if is_stationary is False:
+        hints.append(
+            f"Non-stationary series (ADF p-value={p_value}) — "
+            "ARIMA with d≥1, ExponentialSmoothing, or AutoARIMA recommended"
+        )
+    elif is_stationary is True:
+        hints.append(
+            f"Stationary series (ADF p-value={p_value}) — "
+            "wide model choice; ARIMA with d=0 or ThetaForecaster work well"
+        )
+
+    if not hints:
+        hints.append("No strong patterns detected — NaiveForecaster is a solid baseline")
+
+    return hints
+
+
+def extract_ts_metadata_tool(
+    data_handle: Optional[str] = None,
+    dataset: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Extract rich statistical metadata from a time series.
+
+    Enables LLM agents to reason about data characteristics (trend,
+    stationarity, seasonality, autocorrelation) before choosing a model —
+    closing the gap in the prompt → model → evaluation agentic loop.
+
+    Args:
+        data_handle: Handle from load_data_source (custom data)
+        dataset: Demo dataset name (e.g. 'airline', 'sunspots')
+
+    Returns:
+        Dictionary with statistical profile, stationarity test results,
+        seasonality detection, autocorrelation, recommended models,
+        and actionable agent hints.
+    """
+    if data_handle is None and dataset is None:
+        return {"success": False, "error": "Provide either 'data_handle' or 'dataset'"}
+
+    executor = get_executor()
+
+    # --- Load the series ---
+    if data_handle is not None:
+        if data_handle not in executor._data_handles:
+            return {
+                "success": False,
+                "error": f"Unknown data handle: {data_handle}",
+                "available_handles": list(executor._data_handles.keys()),
+            }
+        data_info = executor._data_handles[data_handle]
+        y = data_info["y"]
+        freq_str = (
+            str(y.index.freq)
+            if getattr(y.index, "freq", None)
+            else (data_info.get("metadata", {}).get("frequency"))
+        )
+    else:
+        data_result = executor.load_dataset(dataset)
+        if not data_result["success"]:
+            return data_result
+        y = data_result["data"]
+        freq_str = (
+            str(y.index.freq) if hasattr(y, "index") and getattr(y.index, "freq", None) else None
+        )
+
+    if not isinstance(y, pd.Series):
+        return {
+            "success": False,
+            "error": "extract_ts_metadata supports univariate pd.Series only",
+        }
+
+    y_clean = y.dropna()
+    n = len(y)
+    missing_count = int(y.isna().sum())
+    missing_pct = round(missing_count / n * 100, 2) if n > 0 else 0.0
+
+    # --- Basic descriptive stats ---
+    basic = {
+        "series_length": n,
+        "frequency": freq_str,
+        "start_date": str(y.index.min()),
+        "end_date": str(y.index.max()),
+        "missing_count": missing_count,
+        "missing_pct": missing_pct,
+        "mean": round(float(y_clean.mean()), 4) if len(y_clean) > 0 else None,
+        "std": round(float(y_clean.std()), 4) if len(y_clean) > 0 else None,
+        "min": round(float(y_clean.min()), 4) if len(y_clean) > 0 else None,
+        "max": round(float(y_clean.max()), 4) if len(y_clean) > 0 else None,
+    }
+
+    too_short = len(y_clean) < 10
+
+    # --- Trend ---
+    trend = _detect_trend(y_clean) if not too_short else "unknown"
+
+    # --- Stationarity ---
+    stationarity = (
+        _check_stationarity(y_clean)
+        if not too_short
+        else {"is_stationary": None, "note": "Too few observations for ADF test"}
+    )
+
+    # --- Seasonality ---
+    seasonality = (
+        _detect_seasonality(y_clean, freq_str)
+        if not too_short
+        else {"detected": False, "dominant_period": None, "strength": "none"}
+    )
+
+    # --- Autocorrelation ---
+    autocorrelation = _get_autocorrelation(y_clean, seasonality.get("dominant_period"))
+
+    # --- Recommended models ---
+    recommended_models = _recommend_models(
+        stationarity.get("is_stationary"),
+        seasonality,
+        trend,
+    )
+
+    # --- Agent hints ---
+    agent_hints = _build_agent_hints(trend, stationarity, seasonality, missing_pct)
+
+    return {
+        "success": True,
+        **basic,
+        "trend": trend,
+        "stationarity": stationarity,
+        "seasonality": seasonality,
+        "autocorrelation": autocorrelation,
+        "recommended_models": recommended_models,
+        "agent_hints": agent_hints,
+    }

--- a/src/sktime_mcp/tools/ts_metadata.py
+++ b/src/sktime_mcp/tools/ts_metadata.py
@@ -41,7 +41,7 @@ def _check_stationarity(y: pd.Series) -> dict[str, Any]:
         return {
             "adf_statistic": round(adf_stat, 4),
             "adf_pvalue": round(p_value, 4),
-            "is_stationary": p_value < 0.05,
+            "is_stationary": bool(p_value < 0.05),
         }
     except Exception as e:
         logger.debug(f"Stationarity test failed: {e}")
@@ -101,7 +101,7 @@ def _detect_seasonality(y: pd.Series, freq: Optional[str]) -> dict[str, Any]:
                     best_acf = val
                     best_period = lag
 
-        detected = best_acf > 0.3
+        detected = bool(best_acf > 0.3)
         if best_acf > 0.7:
             strength = "strong"
         elif best_acf > 0.4:

--- a/tests/test_ts_metadata.py
+++ b/tests/test_ts_metadata.py
@@ -1,0 +1,170 @@
+"""
+Tests for extract_ts_metadata tool.
+"""
+
+import sys
+
+import pytest
+
+sys.path.insert(0, "src")
+
+
+def test_extract_ts_metadata_demo_dataset():
+    """Test extract_ts_metadata with a demo dataset (airline)."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(dataset="airline")
+
+    assert result["success"], f"Tool failed: {result.get('error')}"
+    assert result["series_length"] == 144
+    assert result["missing_count"] == 0
+    assert result["missing_pct"] == 0.0
+    assert result["mean"] is not None
+    assert result["std"] is not None
+    assert result["min"] is not None
+    assert result["max"] is not None
+
+
+def test_extract_ts_metadata_trend_detected():
+    """Airline dataset has a known upward trend."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(dataset="airline")
+
+    assert result["success"]
+    assert result["trend"] == "upward"
+
+
+def test_extract_ts_metadata_stationarity():
+    """Airline dataset is known to be non-stationary."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(dataset="airline")
+
+    assert result["success"]
+    stationarity = result["stationarity"]
+    assert "is_stationary" in stationarity
+    assert stationarity["is_stationary"] is False
+    assert "adf_statistic" in stationarity
+    assert "adf_pvalue" in stationarity
+
+
+def test_extract_ts_metadata_seasonality():
+    """Airline dataset has strong monthly seasonality (period=12)."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(dataset="airline")
+
+    assert result["success"]
+    seasonality = result["seasonality"]
+    assert seasonality["detected"]
+    assert seasonality["dominant_period"] == 12
+    assert seasonality["strength"] in ("strong", "moderate")
+
+
+def test_extract_ts_metadata_autocorrelation():
+    """Autocorrelation keys are present."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(dataset="airline")
+
+    assert result["success"]
+    acf = result["autocorrelation"]
+    assert "lag_1" in acf
+    assert "lag_seasonal" in acf
+    assert acf["lag_1"] is not None
+
+
+def test_extract_ts_metadata_recommended_models():
+    """Recommended models list is non-empty and contains known models."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(dataset="airline")
+
+    assert result["success"]
+    models = result["recommended_models"]
+    assert isinstance(models, list)
+    assert len(models) > 0
+    # All recommendations should be strings (estimator names)
+    assert all(isinstance(m, str) for m in models)
+
+
+def test_extract_ts_metadata_agent_hints():
+    """Agent hints list is non-empty and contains strings."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(dataset="airline")
+
+    assert result["success"]
+    hints = result["agent_hints"]
+    assert isinstance(hints, list)
+    assert len(hints) > 0
+    assert all(isinstance(h, str) for h in hints)
+
+
+def test_extract_ts_metadata_with_data_handle():
+    """Test extract_ts_metadata using a loaded data_handle."""
+    from sktime.datasets import load_airline
+
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    executor = get_executor()
+    y = load_airline()
+
+    # Manually store a data handle
+    handle_id = "data_test_meta"
+    executor._data_handles[handle_id] = {
+        "y": y,
+        "X": None,
+        "metadata": {"frequency": "MS"},
+        "validation": {},
+        "config": {},
+    }
+
+    try:
+        result = extract_ts_metadata_tool(data_handle=handle_id)
+        assert result["success"], f"Tool failed: {result.get('error')}"
+        assert result["series_length"] == 144
+        assert result["trend"] == "upward"
+    finally:
+        executor._data_handles.pop(handle_id, None)
+
+
+def test_extract_ts_metadata_missing_both_args():
+    """Should return error when neither data_handle nor dataset is provided."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool()
+
+    assert result["success"] is False
+    assert "error" in result
+
+
+def test_extract_ts_metadata_unknown_handle():
+    """Should return error for unknown data handle."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(data_handle="data_nonexistent")
+
+    assert result["success"] is False
+    assert "error" in result
+
+
+def test_extract_ts_metadata_lynx():
+    """Test with lynx dataset — different characteristics from airline."""
+    from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
+
+    result = extract_ts_metadata_tool(dataset="lynx")
+
+    assert result["success"], f"Tool failed: {result.get('error')}"
+    assert result["series_length"] > 0
+    assert "trend" in result
+    assert "stationarity" in result
+    assert "seasonality" in result
+    assert "recommended_models" in result
+    assert "agent_hints" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
fixes #156
**What does this implement/fix? Explain your changes.**
Adds a new MCP tool `extract_ts_metadata` that statistically profiles a time series and returns structured insights to help LLM agents make informed model selection decisions.
  
**task of `extract_ts_metadata`**
It analyzes the data and tells the LLM what pipeline to build. It does not build or run any pipeline itself.

**impact on LLM**
Using our tool's output, the LLM can now go and build the pipeline 

** Any other comments?**
Also fixed a numpy boolean serialization bug (np.bool_ → bool) that caused json.dumps to crash on the tool output.

**Does your contribution introduce a new dependency? If yes, which one?**
No new dependencies

** how testing was done**
step 1
```python
(venv) direk@dkakkar:/mnt/f/sktime-mcp$ cat > /tmp/test_feature.py << 'EOF'                                                                                                          

import sys, json
sys.path.insert(0, 'src')
from sktime_mcp.tools.ts_metadata import extract_ts_metadata_tool
result = extract_ts_metadata_tool(dataset='airline')
print(json.dumps(result, indent=2))
EOF
```
step 2
```python
(venv) direk@dkakkar:/mnt/f/sktime-mcp$ python /tmp/test_feature.py
{
  "success": true,
  "series_length": 144,
  "frequency": "<MonthEnd>",
  "start_date": "1949-01",
  "end_date": "1960-12",
  "missing_count": 0,
  "missing_pct": 0.0,
  "mean": 280.2986,
  "std": 119.9663,
  "min": 104.0,
  "max": 622.0,
  "trend": "upward",
  "stationarity": {
    "adf_statistic": 0.8154,
    "adf_pvalue": 0.9919,
    "is_stationary": false
  },
  "seasonality": {
    "detected": true,
    "dominant_period": 12,
    "strength": "strong"
  },
  "autocorrelation": {
    "lag_1": 0.948,
    "lag_seasonal": 0.7604
  },
  "recommended_models": [
    "AutoARIMA",
    "ExponentialSmoothing",
    "TBATS",
    "Prophet",
    "ARIMA"
  ],
  "agent_hints": [
    "Upward trend detected \u2014 consider adding a Detrender transformer in a pipeline",
    "Strong seasonality at period 12 \u2014 use ConditionalDeseasonalizer or seasonal ARIMA (s=12)",
    "Non-stationary series (ADF p-value=0.9919) \u2014 ARIMA with d\u22651, ExponentialSmoothing, or AutoARIMA recommended"
  ]
}
(venv) direk@dkakkar:/mnt/f/sktime-mcp$ 
```
**pytests** - passing
`python -m pytest tests/test_ts_metadata.py -v`
<img width="1919" height="153" alt="Image" src="https://github.com/user-attachments/assets/bf6803cc-6e51-43e8-9ab6-08bf1d221480" />