### PR TITLE
fix: update requires-python to >=3.10 to match mcp dependency requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you are new to sktime‑mcp or to MCP‑based workflows, this section provide
 The Model Context Protocol (MCP) allows Large Language Models (LLMs) to discover, reason about, and execute sktime workflows programmatically. This project exposes sktime’s estimator registry and semantics in a structured way so that LLMs can safely compose and run real time‑series pipelines.
 
 ### Prerequisites
-- Python 3.9 or newer
+- Python 3.10 or newer
 - A working Python virtual environment (recommended)
 - `pip` installed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "MCP (Model Context Protocol) layer for sktime - Registry-Driven for LLMs"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "sktime-mcp contributors" }
 ]
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary

Fixes #163

`pyproject.toml` declared `requires-python = ">=3.9"` but the core dependency `mcp>=1.0.0` requires Python >=3.10. This PR aligns the declared requirement with the actual runtime constraint.

## Changes

- `pyproject.toml`: `requires-python` updated from `">=3.9"` to `">=3.10"`
- `pyproject.toml`: Removed `"Programming Language :: Python :: 3.9"` classifier
- `README.md`: Beginner Setup Prerequisites updated from 
  "Python 3.9 or newer" to "Python 3.10 or newer"

## Why all three changes

Fixing only `requires-python` leaves the 3.9 classifier advertising false compatibility to package indexes. Fixing only the classifier leaves the README Beginner Setup misleading new users. All three need to change together for a consistent fix.

## Testing

No functional code changes. Documentation and packaging metadata only.
`make check` passes locally.