### PR TITLE
[BUG] fix: release orphaned  data handle after auto-format in load_data_source

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -548,11 +548,12 @@ class Executor:
                         data_handle, auto_infer_freq=True, fill_missing=True, remove_duplicates=True
                     )
                     if format_result["success"]:
-                        # Return the NEW handle (formatted)
+                        # Release the intermediate (unformatted) handle — it is superseded by
+                        # the formatted one and must not accumulate in memory across calls.
+                        del self._data_handles[data_handle]
                         return {
                             "success": True,
                             "data_handle": format_result["data_handle"],
-                            "original_handle": data_handle,
                             "metadata": format_result["metadata"],
                             "validation": validation_report,
                             "formatted": True,
@@ -669,6 +670,8 @@ class Executor:
                         data_handle, auto_infer_freq=True, fill_missing=True, remove_duplicates=True
                     )
                     if format_result["success"]:
+                        # Release the intermediate (unformatted) handle before reassigning.
+                        del self._data_handles[data_handle]
                         data_handle = format_result["data_handle"]
                         metadata = format_result["metadata"]
                 except Exception as e:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
When load_data_source runs with auto-format enabled (the default), it creates a raw data handle, then calls `format_data_handle()` which creates a second formatted handle. Only the formatted handle is returned to the caller, but the raw intermediate handle was never deleted from _data_handles. This caused the internal dict to grow by 2 per call instead of 1, with no cap or eviction on data handles.       

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
1. executor.py — the two `del self._data_handles[data_handle]` lines, one in each code path                                                                             
2. Confirm the fallback path (where auto-format fails) is untouched and still returns the raw handle correctly
#### Any other comments?
 
I removed the original_handle from the sync response, it pointed to the deleted handle and would cause a "handle not found" error if used.          
#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
