### PR TITLE
[BUG] fix: remove traceback field from instantiate_pipeline error response

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -471,13 +471,8 @@ class Executor:
             }
 
         except Exception as e:
-            import traceback
-
-            return {
-                "success": False,
-                "error": str(e),
-                "traceback": traceback.format_exc(),
-            }
+            logger.exception("Error during instantiate_pipeline")
+            return {"success": False, "error": str(e)}
 
     def list_datasets(self) -> list[str]:
         """List available demo datasets."""


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
The instantiate_pipeline returned a raw `traceback.format_exc()` string in its error response. Every exception sent a full Python stack trace to the MCP client, leaking internal file paths, line numbers, and library internals directly to the LLM. 

I have routed the exception through `logger.exception()` (which keeps it server-side in logs) and returning only {"success": False, "error": str(e)}.
   

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new hard dependency, weay suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
1. `executor.py` — the single hunk replacing the `import traceback` + `"traceback": traceback.format_exc()` block with `logger.exception()`                                                                                             
 2. Confirm the error message (`str(e)`) is still surfaced to callers unchanged    
#### Any other comments?
Have removed `traceback` import , as it was only used on this one spot

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
