### PR TITLE
 [ENH] feat: add data_handle support to evaluate_estimator for custom data cross-validation

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -301,7 +301,11 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="evaluate_estimator",
-            description="Evaluate an estimator using cross-validation on a dataset",
+            description=(
+                "Evaluate an estimator using cross-validation. "
+                "Accepts either a demo dataset name or a data_handle from load_data_source. "
+                "data_handle takes priority over dataset when both are provided."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -311,7 +315,14 @@ async def list_tools() -> list[Tool]:
                     },
                     "dataset": {
                         "type": "string",
-                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                        "description": "Demo dataset name: airline, sunspots, lynx, etc.",
+                    },
+                    "data_handle": {
+                        "type": "string",
+                        "description": (
+                            "Handle from load_data_source for custom data "
+                            "(use instead of dataset for user-loaded data)"
+                        ),
                     },
                     "cv_folds": {
                         "type": "integer",
@@ -319,7 +330,7 @@ async def list_tools() -> list[Tool]:
                         "default": 3,
                     },
                 },
-                "required": ["estimator_handle", "dataset"],
+                "required": ["estimator_handle"],
             },
         ),
         # -- Data ------------------------------------------------------------
@@ -653,8 +664,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         elif name == "evaluate_estimator":
             result = evaluate_estimator_tool(
                 arguments["estimator_handle"],
-                arguments["dataset"],
-                arguments.get("cv_folds", 3),
+                dataset=arguments.get("dataset", ""),
+                cv_folds=arguments.get("cv_folds", 3),
+                data_handle=arguments.get("data_handle"),
             )
             result = sanitize_for_json(result)
 

--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -5,7 +5,7 @@ Executes cross-validation on an estimator.
 """
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from sktime.forecasting.model_evaluation import evaluate
 from sktime.forecasting.model_selection import ExpandingWindowSplitter
@@ -17,16 +17,18 @@ logger = logging.getLogger(__name__)
 
 def evaluate_estimator_tool(
     estimator_handle: str,
-    dataset: str,
+    dataset: str = "",
     cv_folds: int = 3,
+    data_handle: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Evaluate an estimator using cross-validation.
 
     Args:
         estimator_handle: Handle from instantiate_estimator
-        dataset: Name of demo dataset
+        dataset: Name of demo dataset (e.g. 'airline'). Ignored if data_handle is provided.
         cv_folds: Number of folds for Splitter
+        data_handle: Handle from load_data_source for custom data. Takes priority over dataset.
 
     Returns:
         Dictionary with cross-validation results
@@ -38,12 +40,20 @@ def evaluate_estimator_tool(
     except KeyError:
         return {"success": False, "error": f"Handle not found: {estimator_handle}"}
 
-    data_result = executor.load_dataset(dataset)
-    if not data_result["success"]:
-        return data_result
-
-    y = data_result["data"]
-    X = data_result.get("exog")
+    if data_handle is not None:
+        if data_handle not in executor._data_handles:
+            return {"success": False, "error": f"Unknown data handle: {data_handle}"}
+        data_info = executor._data_handles[data_handle]
+        y = data_info["y"]
+        X = data_info.get("X")
+    else:
+        if not dataset:
+            return {"success": False, "error": "Provide either 'dataset' (demo name) or 'data_handle'"}
+        data_result = executor.load_dataset(dataset)
+        if not data_result["success"]:
+            return data_result
+        y = data_result["data"]
+        X = data_result.get("exog")
 
     try:
         n = len(y)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The `evaluate_estimator` only accepted a demo dataset name (airline, sunspots, etc.), making it difficult to cross validate on custom data loaded via `load_data_source`.                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                       
 Added an optional `data_handle` parameter to `evaluate_estimator`. When provided, it pulls `y`/`X` directly from the handle store instead of loading a demo dataset. `data_handle` takes priority over `dataset` when both are supplied. `dataset` is now optional in the schema so the tool can be called with either input.                                                                                                                                    
  

#### Does your contribution introduce a new dependency? If yes, which one?
 No

#### What should a reviewer concentrate their feedback on?
1. `tools/evaluate.py` — the `data_handle` branch that reads from  `executor._data_handles[data_handle]` and the guard for unknown handles                                                                                           
2. `server.py` — schema change making `dataset` no longer required and   the `call_tool` update passing `data_handle` through                                                                                                              
3. Confirm the fallback path (no `data_handle`, `dataset` provided) still works as before                                                                                                       
                                                                                                                           
                                           
#### Any other comments?
If neither `data_handle` nor `dataset` is given, the tool now returns a clear error instead of silently passing an empty string to `load_dataset`.  
                                                                                                                   
#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
