### PR TITLE
fix: propagate coverage param through predict/fit_predict/fit_predict…

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -148,8 +148,9 @@ class Executor:
         handle_id: str,
         fh: Optional[Union[int, list[int]]] = None,
         X: Optional[Any] = None,
+        coverage: Optional[Union[float, list[float]]] = None,
     ) -> dict[str, Any]:
-        """Generate predictions."""
+        """Generate predictions, and optionally prediction intervals."""
         try:
             instance = self._handle_manager.get_instance(handle_id)
         except KeyError:
@@ -176,11 +177,34 @@ class Executor:
             else:
                 result = predictions.tolist() if hasattr(predictions, "tolist") else predictions
 
-            return {
+            response = {
                 "success": True,
                 "predictions": result,
                 "horizon": len(fh) if hasattr(fh, "__len__") else fh,
             }
+
+            if coverage is not None:
+                intervals = (
+                    instance.predict_interval(fh=fh, X=X, coverage=coverage)
+                    if X is not None
+                    else instance.predict_interval(fh=fh, coverage=coverage)
+                )
+                intervals_copy = intervals.copy()
+                if hasattr(intervals_copy, "index"):
+                    intervals_copy.index = intervals_copy.index.astype(str)
+                # Flatten MultiIndex columns to strings for JSON compatibility
+                if hasattr(intervals_copy, "columns"):
+                    intervals_copy.columns = [
+                        "_".join(map(str, col)) if isinstance(col, tuple) else str(col)
+                        for col in intervals_copy.columns
+                    ]
+                response["prediction_intervals"] = (
+                    intervals_copy.to_dict(orient="list")
+                    if isinstance(intervals_copy, pd.DataFrame)
+                    else intervals_copy.to_dict()
+                )
+
+            return response
         except Exception as e:
             return {"success": False, "error": str(e)}
 
@@ -190,6 +214,7 @@ class Executor:
         dataset: str,
         horizon: int = 12,
         data_handle: Optional[str] = None,
+        coverage: Optional[Union[float, list[float]]] = None,
     ) -> dict[str, Any]:
         """Convenience method: load data, fit, and predict."""
         if data_handle is not None:
@@ -217,7 +242,7 @@ class Executor:
         if not fit_result["success"]:
             return fit_result
 
-        return self.predict(handle_id, fh=fh, X=X)
+        return self.predict(handle_id, fh=fh, X=X, coverage=coverage)
 
     async def fit_predict_async(
         self,
@@ -225,6 +250,7 @@ class Executor:
         dataset: str,
         horizon: int = 12,
         job_id: Optional[str] = None,
+        coverage: Optional[Union[float, list[float]]] = None,
     ) -> dict[str, Any]:
         """
         Async version of fit_predict with job tracking.
@@ -313,7 +339,7 @@ class Executor:
 
             # Run predict in executor
             predict_result = await loop.run_in_executor(
-                None, lambda: self.predict(handle_id, fh=fh, X=X)
+                None, lambda: self.predict(handle_id, fh=fh, X=X, coverage=coverage)
             )
 
             if not predict_result["success"]:


### PR DESCRIPTION
## Summary

Fixes #205

`executor.predict()` and `executor.fit_predict()` were missing the `coverage` parameter entirely, and `executor.fit_predict_async()` had no `coverage` in its signature. Calling `fit_predict_async_tool(coverage=0.9)` silently dropped the argument — prediction intervals were never computed for async jobs.

## Changes (single file: `src/sktime_mcp/runtime/executor.py`)

1. Added `coverage` param to `executor.predict()` with prediction interval computation
2. Added `coverage` param to `executor.fit_predict()` and forwarded it to `self.predict()`
3. Added `coverage` param to `executor.fit_predict_async()` and forwarded it to `self.predict()`

## Testing

- `test_async_fit_predict` now passes (was failing with `TypeError: Executor.predict() got an unexpected keyword argument 'coverage'`)
- All 70 other tests continue to pass

## Type of Change
- [x] Bug fix (non-breaking)
