### PR TITLE
fix: route startup message to stderr via logger

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -783,7 +783,7 @@ async def run_server():
 
 def main():
     """Main entry point."""
-    print("Starting sktime-mcp server...")
+    logger.info("Starting sktime-mcp server...")
     asyncio.run(run_server())
 
 


### PR DESCRIPTION
## Summary
- Replace `print("Starting sktime-mcp server...")` in `main()` with `logger.info(...)` which routes to stderr instead of stdout

## Why
The stdio transport uses stdout exclusively as the JSON-RPC channel. A plain-text line on stdout before the protocol handshake is not valid JSON-RPC and will cause strict MCP clients to fail to connect. `logger` is already defined in `server.py` and correctly routes to stderr.

Closes #214

## Test plan
- [ ] Confirm no stdout output on server start: `python -c "from sktime_mcp.server import main; main()" > out.txt`  , then  `out.txt` should be empty
