### PR TITLE
fix(validator): disallow forecaster-to-forecaster chains in pipeline validation

### DIFF
--- a/src/sktime_mcp/composition/validator.py
+++ b/src/sktime_mcp/composition/validator.py
@@ -213,6 +213,16 @@ class CompositionValidator:
             current_name, current_node = nodes[i]
             next_name, next_node = nodes[i + 1]
 
+            # In linear pipelines, forecaster -> forecaster is invalid.
+            # The forecasting->forecasting rule is for ensemble composition,
+            # not sequential pipeline chaining.
+            if current_node.task == next_node.task == "forecasting":
+                errors.append(
+                    f"Cannot chain forecasters '{current_node.name}' → '{next_node.name}' directly. "
+                    "Use an ensemble or multiplexer instead."
+                )
+                continue
+
             # Check if this composition is valid
             valid_pair, pair_errors, pair_warnings = self._check_pair_compatibility(
                 current_node, next_node

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -123,6 +123,26 @@ class TestCompositionValidator:
 
         assert not result.valid
 
+    def test_forecaster_chain_invalid(self):
+        """Forecaster -> forecaster should be invalid in linear pipeline validation."""
+        from sktime_mcp.composition.validator import CompositionValidator
+
+        validator = CompositionValidator()
+        result = validator.validate_pipeline(["NaiveForecaster", "ExponentialSmoothing"])
+
+        assert not result.valid
+        assert any("Cannot chain forecasters" in err for err in result.errors)
+
+    def test_transformer_to_forecaster_valid(self):
+        """Transformer -> forecaster remains valid."""
+        from sktime_mcp.composition.validator import CompositionValidator
+
+        validator = CompositionValidator()
+        result = validator.validate_pipeline(["Imputer", "NaiveForecaster"])
+
+        assert result.valid
+        assert len(result.errors) == 0
+
 
 class TestTools:
     """Tests for MCP tools."""


### PR DESCRIPTION
Closes #201 

This PR attempts to resolve the issue by correcting pipeline validation behavior. Happy to make any changes if needed.

## Summary
This PR fixes an issue where `validate_pipeline` incorrectly allowed chaining one forecaster after another in a linear pipeline.

## What was wrong
The validation logic treated forecasting → forecasting as valid because it matched a rule intended for ensemble usage. However, this rule should not apply to sequential pipelines.

## What was changed
- Added a check in `validate_pipeline` to prevent forecaster → forecaster chaining in linear pipelines
- Kept the existing error message unchanged
- Left ensemble-related rules untouched

## Tests
- Added a regression test to ensure forecaster chaining is correctly rejected
- Added a test to confirm valid transformer → forecaster pipelines still work as expected

## Why this matters
`validate_pipeline` is used in agentic workflows to construct valid pipelines. Allowing invalid combinations can lead to incorrect pipeline construction and runtime issues. This change ensures such cases are properly caught.