### PR TITLE
[ENH] Merge Sync and Async Tooling into a Single Interface

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -222,9 +222,10 @@ class Executor:
     async def fit_predict_async(
         self,
         handle_id: str,
-        dataset: str,
+        dataset: str = "",
         horizon: int = 12,
         job_id: Optional[str] = None,
+        data_handle: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Async version of fit_predict with job tracking.
@@ -234,9 +235,10 @@ class Executor:
 
         Args:
             handle_id: Estimator handle
-            dataset: Dataset name
+            dataset: Dataset name (demo)
             horizon: Forecast horizon
             job_id: Optional job ID for tracking (created if not provided)
+            data_handle: Optional data handle from load_data_source
 
         Returns:
             Dictionary with success status and job_id
@@ -249,13 +251,15 @@ class Executor:
             logger.warning(f"Could not get estimator name: {e}")
             estimator_name = "Unknown"
 
+        data_source_name = data_handle if data_handle else dataset
+
         # Create job if not provided
         if job_id is None:
             job_id = self._job_manager.create_job(
                 job_type="fit_predict",
                 estimator_handle=handle_id,
                 estimator_name=estimator_name,
-                dataset_name=dataset,
+                dataset_name=data_source_name,
                 horizon=horizon,
                 total_steps=3,  # load data, fit, predict
             )
@@ -264,28 +268,43 @@ class Executor:
             # Update status to RUNNING
             self._job_manager.update_job(job_id, status=JobStatus.RUNNING)
 
-            # Step 1: Load dataset
-            self._job_manager.update_job(
-                job_id, completed_steps=0, current_step=f"Loading dataset '{dataset}'..."
-            )
-            await asyncio.sleep(0.01)  # Yield control to event loop
-
-            data_result = self.load_dataset(dataset)
-            if not data_result["success"]:
+            # Step 1: Get data
+            if data_handle:
                 self._job_manager.update_job(
-                    job_id,
-                    status=JobStatus.FAILED,
-                    errors=[f"Failed to load dataset: {data_result.get('error')}"],
+                    job_id, completed_steps=0, current_step=f"Retrieving data handle '{data_handle}'..."
                 )
-                return data_result
+                if data_handle not in self._data_handles:
+                    err = f"Unknown data handle: {data_handle}"
+                    self._job_manager.update_job(
+                        job_id, status=JobStatus.FAILED, errors=[err]
+                    )
+                    return {"success": False, "error": err}
+                
+                data_info = self._data_handles[data_handle]
+                y = data_info["y"]
+                X = data_info.get("X")
+            else:
+                self._job_manager.update_job(
+                    job_id, completed_steps=0, current_step=f"Loading demo dataset '{dataset}'..."
+                )
+                await asyncio.sleep(0.01)  # Yield control to event loop
 
-            y = data_result["data"]
-            X = data_result.get("exog")
+                data_result = self.load_dataset(dataset)
+                if not data_result["success"]:
+                    self._job_manager.update_job(
+                        job_id,
+                        status=JobStatus.FAILED,
+                        errors=[f"Failed to load dataset: {data_result.get('error')}"],
+                    )
+                    return data_result
+                y = data_result["data"]
+                X = data_result.get("exog")
+
             fh = list(range(1, horizon + 1))
 
             # Step 2: Fit model
             self._job_manager.update_job(
-                job_id, completed_steps=1, current_step=f"Fitting {estimator_name} on {dataset}..."
+                job_id, completed_steps=1, current_step=f"Fitting {estimator_name} on {data_source_name}..."
             )
             await asyncio.sleep(0.01)  # Yield control
 

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -18,7 +18,6 @@ from mcp.types import TextContent, Tool
 from sktime_mcp.composition.validator import get_composition_validator
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.data_tools import (
-    fit_predict_with_data_tool,
     load_data_source_async_tool,
     load_data_source_tool,
     release_data_handle_tool,
@@ -26,7 +25,6 @@ from sktime_mcp.tools.data_tools import (
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.evaluate import evaluate_estimator_tool
 from sktime_mcp.tools.fit_predict import (
-    fit_predict_async_tool,
     fit_predict_tool,
 )
 from sktime_mcp.tools.format_tools import format_time_series_tool
@@ -244,7 +242,8 @@ async def list_tools() -> list[Tool]:
             name="fit_predict",
             description=(
                 "Fit an estimator on a dataset and generate predictions. "
-                "Accepts either a demo dataset name or a data_handle from load_data_source."
+                "Accepts either a demo dataset name or a data_handle. "
+                "Set background=true to run as a non-blocking background job."
             ),
             inputSchema={
                 "type": "object",
@@ -255,48 +254,24 @@ async def list_tools() -> list[Tool]:
                     },
                     "dataset": {
                         "type": "string",
-                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                        "description": "Dataset name (e.g. airline, sunspots).",
                     },
                     "data_handle": {
                         "type": "string",
-                        "description": (
-                            "Handle from load_data_source (use this instead "
-                            "of dataset for custom data)"
-                        ),
+                        "description": "Handle from load_data_source (takes priority over dataset)",
                     },
                     "horizon": {
                         "type": "integer",
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
+                    },
+                    "background": {
+                        "type": "boolean",
+                        "description": "Run in background and return a job_id (default: false)",
+                        "default": False,
                     },
                 },
                 "required": ["estimator_handle"],
-            },
-        ),
-        Tool(
-            name="fit_predict_async",
-            description=(
-                "Fit an estimator on a dataset and generate predictions "
-                "(non-blocking background job). Returns a job_id."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "estimator_handle": {
-                        "type": "string",
-                        "description": "Handle from instantiate_estimator",
-                    },
-                    "dataset": {
-                        "type": "string",
-                        "description": "Dataset name: airline, sunspots, lynx, etc.",
-                    },
-                    "horizon": {
-                        "type": "integer",
-                        "description": "Forecast horizon (default: 12)",
-                        "default": 12,
-                    },
-                },
-                "required": ["estimator_handle", "dataset"],
             },
         ),
         Tool(
@@ -627,26 +602,22 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         elif name == "fit_predict":
             result = fit_predict_tool(
                 arguments["estimator_handle"],
-                arguments.get("dataset", ""),
-                arguments.get("horizon", 12),
+                dataset=arguments.get("dataset", ""),
+                horizon=arguments.get("horizon", 12),
                 data_handle=arguments.get("data_handle"),
+                background=arguments.get("background", False),
             )
             result = sanitize_for_json(result)
 
-        elif name == "fit_predict_async":
-            result = fit_predict_async_tool(
+        elif name in ("fit_predict_async", "fit_predict_with_data"):
+            # Deprecated — unified into fit_predict
+            logger.warning(f"{name} is deprecated; use fit_predict with appropriate flags")
+            result = fit_predict_tool(
                 arguments["estimator_handle"],
-                arguments["dataset"],
-                arguments.get("horizon", 12),
-            )
-
-        elif name == "fit_predict_with_data":
-            # Deprecated — kept for backward compatibility
-            logger.warning("fit_predict_with_data is deprecated; use fit_predict(data_handle=...)")
-            result = fit_predict_with_data_tool(
-                arguments["estimator_handle"],
-                arguments["data_handle"],
-                arguments.get("horizon", 12),
+                dataset=arguments.get("dataset", ""),
+                horizon=arguments.get("horizon", 12),
+                data_handle=arguments.get("data_handle"),
+                background=(name == "fit_predict_async"),
             )
             result = sanitize_for_json(result)
 

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -90,35 +90,7 @@ def list_data_sources_tool() -> dict[str, Any]:
     }
 
 
-def fit_predict_with_data_tool(
-    estimator_handle: str,
-    data_handle: str,
-    horizon: int = 12,
-) -> dict[str, Any]:
-    """
-    Fit and predict using custom data.
 
-    Args:
-        estimator_handle: Handle from instantiate_estimator
-        data_handle: Handle from load_data_source
-        horizon: Forecast horizon (default: 12)
-
-    Returns:
-        Dictionary with predictions
-
-    Example:
-        >>> fit_predict_with_data_tool(
-        ...     estimator_handle="est_abc123",
-        ...     data_handle="data_xyz789",
-        ...     horizon=12
-        ... )
-    """
-    executor = get_executor()
-    return executor.fit_predict_with_data(
-        estimator_handle,
-        data_handle,
-        horizon,
-    )
 
 
 def release_data_handle_tool(data_handle: str) -> dict[str, Any]:

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -15,9 +15,10 @@ logger = logging.getLogger(__name__)
 
 def fit_predict_tool(
     estimator_handle: str,
-    dataset: str,
+    dataset: str = "",
     horizon: int = 12,
     data_handle: Optional[str] = None,
+    background: bool = False,
 ) -> dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
@@ -27,12 +28,10 @@ def fit_predict_tool(
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
         data_handle: Optional handle from load_data_source for custom data
+        background: If True, run in background and return a job_id
 
     Returns:
-        Dictionary with:
-        - success: bool
-        - predictions: Forecast values
-        - horizon: Number of steps predicted
+        Dictionary with results (sync) or job_id (async)
 
     Example:
         >>> fit_predict_tool("est_abc123", "airline", horizon=12)
@@ -43,7 +42,57 @@ def fit_predict_tool(
         }
     """
     executor = get_executor()
-    return executor.fit_predict(estimator_handle, dataset, horizon, data_handle=data_handle)
+
+    if not background:
+        return executor.fit_predict(
+            estimator_handle, dataset, horizon, data_handle=data_handle
+        )
+
+    # Handle background execution
+    from sktime_mcp.runtime.jobs import get_job_manager
+
+    job_manager = get_job_manager()
+
+    # Get estimator info for job name
+    try:
+        handle_info = executor._handle_manager.get_info(estimator_handle)
+        estimator_name = handle_info.estimator_name
+    except Exception as e:
+        logger.warning(f"Could not get estimator name: {e}")
+        estimator_name = "Unknown"
+
+    data_source_name = data_handle if data_handle else dataset
+
+    # Create job
+    job_id = job_manager.create_job(
+        job_type="fit_predict",
+        estimator_handle=estimator_handle,
+        estimator_name=estimator_name,
+        dataset_name=data_source_name,
+        horizon=horizon,
+        total_steps=3,
+    )
+
+    # Schedule the async coroutine
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    coro = executor.fit_predict_async(
+        estimator_handle, dataset, horizon, job_id=job_id, data_handle=data_handle
+    )
+    asyncio.run_coroutine_threadsafe(coro, loop)
+
+    return {
+        "success": True,
+        "job_id": job_id,
+        "message": f"Training job started for {estimator_name} on {data_source_name}. Use check_job_status('{job_id}') to monitor progress.",
+        "estimator": estimator_name,
+        "dataset": data_source_name,
+        "horizon": horizon,
+    }
 
 
 def fit_tool(
@@ -105,77 +154,4 @@ def list_datasets_tool() -> dict[str, Any]:
     }
 
 
-def fit_predict_async_tool(
-    estimator_handle: str,
-    dataset: str,
-    horizon: int = 12,
-) -> dict[str, Any]:
-    """
-    Execute a fit-predict workflow in the background (non-blocking).
 
-    This tool schedules the training as a background job and returns immediately
-    with a job_id. Use check_job_status to monitor progress.
-
-    Args:
-        estimator_handle: Handle from instantiate_estimator
-        dataset: Name of demo dataset (e.g., "airline", "sunspots")
-        horizon: Forecast horizon (default: 12)
-
-    Returns:
-        Dictionary with:
-        - success: bool
-        - job_id: Job ID for tracking progress
-        - message: Information about the job
-
-    Example:
-        >>> fit_predict_async_tool("est_abc123", "airline", horizon=12)
-        {
-            "success": True,
-            "job_id": "abc-123-def-456",
-            "message": "Training job started. Use check_job_status to monitor progress."
-        }
-    """
-
-    from sktime_mcp.runtime.jobs import get_job_manager
-
-    executor = get_executor()
-    job_manager = get_job_manager()
-
-    # Get estimator info
-    try:
-        handle_info = executor._handle_manager.get_info(estimator_handle)
-        estimator_name = handle_info.estimator_name
-    except Exception as e:
-        logger.warning(f"Could not get estimator name: {e}")
-        estimator_name = "Unknown"
-
-    # Create job
-    job_id = job_manager.create_job(
-        job_type="fit_predict",
-        estimator_handle=estimator_handle,
-        estimator_name=estimator_name,
-        dataset_name=dataset,
-        horizon=horizon,
-        total_steps=3,
-    )
-
-    # Schedule the async coroutine on the event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # No event loop in current thread, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-    # Schedule the coroutine (non-blocking!)
-    coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
-
-    return {
-        "success": True,
-        "job_id": job_id,
-        "message": f"Training job started for {estimator_name} on {dataset}. Use check_job_status('{job_id}') to monitor progress.",
-        "estimator": estimator_name,
-        "dataset": dataset,
-        "horizon": horizon,
-    }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #8 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
It merges the `fit_predict `and `fit_predict_async tools `into a single, unified `fit_predict` endpoint for the MCP server.
- Added a `background` boolean parameter to the core  ` fit_predict `tool schema.
- Updated the dispatcher logic to internally route blocking vs. non-blocking background job executions natively.
- Removed the standalone `fit_predict_async_tool` from the internal tools and Server registry to alleviate LM tool bloat.
- Decoupled and preserved `fit_predict_with_data` in its own scope to avoid overloading the tool signature (which prevents LLMs from confusing dataset strings and handle pointers).


#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies are introduced.


<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
- Testing the routing in `tools/fit_predict.py `based on the new `background=True|False` parameter.
- Ensuring the structural exclusion of `fit_predict_with_data` (keeping it separate) aligns with the broader design preferences for context preservation in LLM agents

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
Merged `fit_predict_async` and `fit_predict_with_data` into the single `fit_predict` entry point to reduce tool bloat for the LLM client while maintaining support for all data types in both sync and background modes.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
