### PR TITLE
fix(examples): replace hardcoded /tmp paths with cross-platform temp directory

### DIFF
--- a/examples/csv_example.py
+++ b/examples/csv_example.py
@@ -5,6 +5,7 @@ This example demonstrates how to use the sktime-mcp data loading
 functionality with CSV files.
 """
 
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -20,7 +21,7 @@ sample_data = pd.DataFrame(
     }
 )
 
-csv_path = Path("/tmp/sample_sales_data.csv")
+csv_path = Path(tempfile.gettempdir()) / "sample_sales_data.csv"
 sample_data.to_csv(csv_path, index=False)
 print(f"Created sample CSV file: {csv_path}")
 print(f"File size: {csv_path.stat().st_size} bytes")
@@ -90,7 +91,7 @@ print("\n" + "=" * 60)
 print("Loading data from TSV file")
 print("=" * 60)
 
-tsv_path = Path("/tmp/sample_sales_data.tsv")
+tsv_path = Path(tempfile.gettempdir()) / "sample_sales_data.tsv"
 sample_data.to_csv(tsv_path, sep="\t", index=False)
 print(f"Created sample TSV file: {tsv_path}")
 

--- a/examples/sql_example.py
+++ b/examples/sql_example.py
@@ -6,6 +6,7 @@ functionality with SQL databases (SQLite in this example).
 """
 
 import sqlite3
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -13,7 +14,7 @@ import pandas as pd
 from sktime_mcp.runtime.executor import get_executor
 
 # Create a sample SQLite database
-db_path = Path("/tmp/sample_sales.db")
+db_path = Path(tempfile.gettempdir()) / "sample_sales.db"
 
 # Create sample data
 sample_data = pd.DataFrame(


### PR DESCRIPTION
Closes #224 

This PR attempts to resolve the issue by making example file paths cross-platform. Happy to make any changes if needed.

## Summary
Replaces hardcoded `/tmp` paths in example scripts with a cross-platform temporary directory.

## What was wrong
Example scripts used `/tmp`, which is Unix-specific and causes failures on Windows when attempting to write or open files.

## What was changed
- Replaced `/tmp` paths with `tempfile.gettempdir()`
- Kept changes minimal and limited to path construction
- No changes to logic or behavior

## Why this matters
Ensures example scripts run correctly across supported platforms, including Windows.