### PR TITLE
fix: exclude loaders with required args from demo dataset registry

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # load_* function in sktime.datasets to the MCP server.
 def _discover_demo_datasets() -> dict:
     """Return a mapping of dataset name -> dotted module path for every
-    ``load_*`` function exported by ``sktime.datasets``."""
+    zero-argument ``load_*`` function exported by ``sktime.datasets``."""
     try:
         import sktime.datasets as _ds_module
 
@@ -34,6 +34,11 @@ def _discover_demo_datasets() -> dict:
             name.removeprefix("load_"): f"sktime.datasets.{name}"
             for name, obj in inspect.getmembers(_ds_module, inspect.isfunction)
             if name.startswith("load_")
+            and all(
+                p.default is not inspect.Parameter.empty
+                for p in inspect.signature(obj).parameters.values()
+                if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+            )
         }
     except Exception:  # pragma: no cover
         return {}  # fallback: empty dict if sktime not installed


### PR DESCRIPTION
## Summary
- Filter `_discover_demo_datasets` to only include zero-argument `load_*` functions
- Reduces the exposed dataset list from 33 to 24 (removes 9 file/path utilities that were never valid demo datasets)

## Why
`_discover_demo_datasets` picked up every `load_*` function from `sktime.datasets`, including
ones like `load_from_tsfile(full_file_path_and_name)` that require mandatory arguments. These
appeared in `list_datasets()` as valid options but always failed with a raw `TypeError` when
called. The fix uses `inspect.signature` to include only zero-argument loaders.

Closes #226 

## Test plan
- [ ] `list_datasets()` no longer includes `from_tsfile`, `UCR_UEA_dataset`, `fpp3`, `forecastingdata`, and the other 5 file-path loaders
- [ ] All previously working datasets (e.g. `airline`, `lynx`) still load successfully

Looking forward to your approval, thanks ! 
@Shashankss1205 
