### PR TITLE
fix(#221): Add limit validation to prevent negative limit returning all results

### DIFF
--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -58,6 +58,12 @@ def list_estimators_tool(
                 "error": "offset must be a non-negative integer.",
             }
 
+        if limit is not None and limit < 0:
+            return {
+                "success": False,
+                "error": "limit must be a non-negative integer.",
+            }
+
         page = estimators[offset : offset + limit]
         results = [est.to_summary() for est in page]
 


### PR DESCRIPTION
## Summary
- Added validation for negative limit values in list_estimators_tool
- When limit < 0 is passed, returns error instead of Python slice behavior returning all results
- Fixes Issue #221

## Problem Analysis
When limit=-5 is passed, Python's list slice semantics return all estimators EXCEPT the last 5. This floods the LLM context window with ~400+ results instead of returning a validation error.

## Fix Applied
Added validation after offset check in src/sktime_mcp/tools/list_estimators.py:
if limit is not None and limit < 0:
    return { "success": False, "error": "limit must be a non-negative integer." }

## Changes
- src/sktime_mcp/tools/list_estimators.py: Added limit < 0 validation after offset validation

## Testing
- limit=-5 returns error
- limit=-1 returns error
- limit=0 returns empty list (valid)
- limit=50 works normally