### PR TITLE
fix(#222): Add BackgroundLoop for async job execution

### DIFF
--- a/src/sktime_mcp/runtime/_background_loop.py
+++ b/src/sktime_mcp/runtime/_background_loop.py
@@ -1,0 +1,80 @@
+"""
+Background event loop for async job execution.
+
+Problem: asyncio.run_coroutine_threadsafe() only works if event loop is
+already running in another thread. Without this, coroutines submitted
+via run_coroutine_threadsafe() sit in the queue forever.
+
+Solution: Start a daemon thread that runs an event loop forever, and
+submit coroutines to that shared loop.
+"""
+
+import asyncio
+import logging
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundLoop:
+    """A shared background event loop running in a dedicated thread."""
+    
+    def __init__(self):
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._started = False
+        self._lock = threading.Lock()
+        self._start()
+    
+    def _start(self):
+        """Start the background thread with a running event loop."""
+        with self._lock:
+            if self._started:
+                return
+            self._loop = asyncio.new_event_loop()
+            self._thread = threading.Thread(
+                target=self._run_loop,
+                name="sktime-mcp-background-loop",
+                daemon=True
+            )
+            self._thread.start()
+            self._started = True
+            logger.debug("Background event loop started")
+    
+    def _run_loop(self):
+        """Run the event loop forever (called in background thread)."""
+        try:
+            self._loop.run_forever()
+        except Exception as e:
+            logger.error(f"Background loop error: {e}")
+    
+    def submit(self, coro):
+        """Submit a coroutine to the background event loop."""
+        if not self._started or self._loop is None:
+            raise RuntimeError("Background loop not started")
+        return asyncio.run_coroutine_threadsafe(coro, self._loop)
+    
+    def is_running(self) -> bool:
+        """Check if the background loop is running."""
+        return self._started and self._loop is not None and self._loop.is_running()
+
+
+# Singleton instance
+_bg_loop: Optional[BackgroundLoop] = None
+_init_lock = threading.Lock()
+
+
+def get_background_loop() -> BackgroundLoop:
+    """Get the singleton BackgroundLoop instance."""
+    global _bg_loop
+    if _bg_loop is None:
+        with _init_lock:
+            if _bg_loop is None:
+                _bg_loop = BackgroundLoop()
+    return _bg_loop
+
+
+def submit_async(coro):
+    """Convenience function to submit a coroutine to the background loop."""
+    return get_background_loop().submit(coro)

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -184,15 +184,10 @@ def load_data_source_async_tool(
         total_steps=3,  # load, validate, format
     )
 
-    # schedule on event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+    from sktime_mcp.runtime._background_loop import submit_async
 
     coro = executor.load_data_source_async(config, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
+    submit_async(coro)
 
     return {
         "success": True,

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -159,17 +159,10 @@ def fit_predict_async_tool(
         total_steps=3,
     )
 
-    # Schedule the async coroutine on the event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        # No event loop in current thread, create one
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+    from sktime_mcp.runtime._background_loop import submit_async
 
-    # Schedule the coroutine (non-blocking!)
     coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
-    asyncio.run_coroutine_threadsafe(coro, loop)
+    submit_async(coro)
 
     return {
         "success": True,


### PR DESCRIPTION
## Summary
Created BackgroundLoop class for shared async event loop running in daemon thread.
Fixes fit_predict_async and load_data_source_async jobs staying 'pending' forever.

## Problem
asyncio.run_coroutine_threadsafe() was called on an event loop that was never started in any thread. Coroutines sat in queue forever.

## Solution
1. Created _background_loop.py with BackgroundLoop class
   - Runs a daemon thread with event loop that runs forever
   - Provides submit_async() for thread-safe coroutine submission

2. Updated fit_predict.py and data_tools.py to use submit_async()

## Changes
- NEW: src/sktime_mcp/runtime/_background_loop.py
- src/sktime_mcp/tools/fit_predict.py
- src/sktime_mcp/tools/data_tools.py