### PR TITLE
fix: add coverage parameter to fit_predict and fit_predict_async

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -184,14 +184,94 @@ class Executor:
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    def predict_interval(
+        self,
+        handle_id: str,
+        fh: Optional[Union[int, list[int]]] = None,
+        X: Optional[Any] = None,
+        coverage: Union[float, list[float]] = 0.9,
+    ) -> dict[str, Any]:
+        """Generate predictions with prediction intervals.
+
+        Args:
+            handle_id: Estimator handle
+            fh: Forecast horizon
+            X: Optional exogenous variables
+            coverage: Confidence level(s) for prediction intervals.
+                      Can be a single float (e.g., 0.9 for 90% interval) or
+                      a list of floats for multiple intervals.
+
+        Returns:
+            Dictionary with success status, predictions, and intervals
+        """
+        try:
+            instance = self._handle_manager.get_instance(handle_id)
+        except KeyError:
+            return {"success": False, "error": f"Handle not found: {handle_id}"}
+
+        if not self._handle_manager.is_fitted(handle_id):
+            return {"success": False, "error": "Estimator not fitted"}
+
+        try:
+            if fh is None:
+                fh = list(range(1, 13))
+
+            # Check if estimator supports prediction intervals
+            if not hasattr(instance, "predict_interval"):
+                return {
+                    "success": False,
+                    "error": "Estimator does not support prediction intervals. "
+                    "Use a probabilistic forecaster (check capability:pred_int tag).",
+                }
+
+            pred_intervals = instance.predict_interval(fh=fh, X=X, coverage=coverage)
+
+            # Convert to JSON-serializable format
+            # The result is a DataFrame with MultiIndex columns: (variable, coverage, lower/upper)
+            pred_intervals_copy = pred_intervals.copy()
+            pred_intervals_copy.index = pred_intervals_copy.index.astype(str)
+
+            # Extract intervals into a structured format
+            intervals_dict = {}
+            for col in pred_intervals_copy.columns:
+                var_name = col[0] if isinstance(col, tuple) else "predictions"
+                cov_level = col[1] if isinstance(col, tuple) else coverage
+                bound_type = col[2] if isinstance(col, tuple) else "bound"
+
+                key = f"{var_name}_{cov_level}"
+                if key not in intervals_dict:
+                    intervals_dict[key] = {"coverage": cov_level}
+                intervals_dict[key][bound_type] = pred_intervals_copy[col].to_dict()
+
+            return {
+                "success": True,
+                "predictions": pred_intervals_copy.to_dict(),
+                "intervals": intervals_dict,
+                "horizon": len(fh) if hasattr(fh, "__len__") else fh,
+                "coverage": coverage,
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
     def fit_predict(
         self,
         handle_id: str,
         dataset: str,
         horizon: int = 12,
         data_handle: Optional[str] = None,
+        coverage: Optional[Union[float, list[float]]] = None,
     ) -> dict[str, Any]:
-        """Convenience method: load data, fit, and predict."""
+        """Convenience method: load data, fit, and predict.
+
+        Args:
+            handle_id: Estimator handle
+            dataset: Dataset name
+            horizon: Forecast horizon
+            data_handle: Optional data handle for custom data
+            coverage: Optional confidence level(s) for prediction intervals.
+                      If provided, uses predict_interval() instead of predict().
+                      Can be a single float (e.g., 0.9) or list of floats.
+        """
         if data_handle is not None:
             # Use custom loaded data
             if data_handle not in self._data_handles:
@@ -217,6 +297,9 @@ class Executor:
         if not fit_result["success"]:
             return fit_result
 
+        # Use predict_interval if coverage is provided, otherwise use predict
+        if coverage is not None:
+            return self.predict_interval(handle_id, fh=fh, X=X, coverage=coverage)
         return self.predict(handle_id, fh=fh, X=X)
 
     async def fit_predict_async(
@@ -225,6 +308,7 @@ class Executor:
         dataset: str,
         horizon: int = 12,
         job_id: Optional[str] = None,
+        coverage: Optional[Union[float, list[float]]] = None,
     ) -> dict[str, Any]:
         """
         Async version of fit_predict with job tracking.
@@ -237,6 +321,8 @@ class Executor:
             dataset: Dataset name
             horizon: Forecast horizon
             job_id: Optional job ID for tracking (created if not provided)
+            coverage: Optional confidence level(s) for prediction intervals.
+                      If provided, uses predict_interval() instead of predict().
 
         Returns:
             Dictionary with success status and job_id
@@ -304,17 +390,25 @@ class Executor:
                 return fit_result
 
             # Step 3: Generate predictions
+            step_msg = f"Generating predictions (horizon={horizon})"
+            if coverage is not None:
+                step_msg += f" with coverage={coverage}"
             self._job_manager.update_job(
                 job_id,
                 completed_steps=2,
-                current_step=f"Generating predictions (horizon={horizon})...",
+                current_step=step_msg,
             )
             await asyncio.sleep(0.01)  # Yield control
 
-            # Run predict in executor
-            predict_result = await loop.run_in_executor(
-                None, lambda: self.predict(handle_id, fh=fh, X=X)
-            )
+            # Run predict or predict_interval in executor
+            if coverage is not None:
+                predict_result = await loop.run_in_executor(
+                    None, lambda: self.predict_interval(handle_id, fh=fh, X=X, coverage=coverage)
+                )
+            else:
+                predict_result = await loop.run_in_executor(
+                    None, lambda: self.predict(handle_id, fh=fh, X=X)
+                )
 
             if not predict_result["success"]:
                 self._job_manager.update_job(

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -244,7 +244,8 @@ async def list_tools() -> list[Tool]:
             name="fit_predict",
             description=(
                 "Fit an estimator on a dataset and generate predictions. "
-                "Accepts either a demo dataset name or a data_handle from load_data_source."
+                "Accepts either a demo dataset name or a data_handle from load_data_source. "
+                "Use the coverage parameter to get prediction intervals."
             ),
             inputSchema={
                 "type": "object",
@@ -269,6 +270,16 @@ async def list_tools() -> list[Tool]:
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
                     },
+                    "coverage": {
+                        "type": ["number", "array"],
+                        "description": (
+                            "Confidence level(s) for prediction intervals. "
+                            "Use a single number (e.g., 0.9 for 90% intervals) or "
+                            "a list of numbers for multiple intervals (e.g., [0.5, 0.9, 0.95]). "
+                            "Only works with estimators that support prediction intervals "
+                            "(check capability:pred_int tag)."
+                        ),
+                    },
                 },
                 "required": ["estimator_handle"],
             },
@@ -277,7 +288,8 @@ async def list_tools() -> list[Tool]:
             name="fit_predict_async",
             description=(
                 "Fit an estimator on a dataset and generate predictions "
-                "(non-blocking background job). Returns a job_id."
+                "(non-blocking background job). Returns a job_id. "
+                "Use the coverage parameter to get prediction intervals."
             ),
             inputSchema={
                 "type": "object",
@@ -294,6 +306,16 @@ async def list_tools() -> list[Tool]:
                         "type": "integer",
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
+                    },
+                    "coverage": {
+                        "type": ["number", "array"],
+                        "description": (
+                            "Confidence level(s) for prediction intervals. "
+                            "Use a single number (e.g., 0.9 for 90% intervals) or "
+                            "a list of numbers for multiple intervals (e.g., [0.5, 0.9, 0.95]). "
+                            "Only works with estimators that support prediction intervals "
+                            "(check capability:pred_int tag)."
+                        ),
                     },
                 },
                 "required": ["estimator_handle", "dataset"],
@@ -630,6 +652,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments.get("dataset", ""),
                 arguments.get("horizon", 12),
                 data_handle=arguments.get("data_handle"),
+                coverage=arguments.get("coverage"),
             )
             result = sanitize_for_json(result)
 
@@ -638,6 +661,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["estimator_handle"],
                 arguments["dataset"],
                 arguments.get("horizon", 12),
+                coverage=arguments.get("coverage"),
             )
 
         elif name == "fit_predict_with_data":

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -6,7 +6,7 @@ Executes complete forecasting workflows.
 
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from sktime_mcp.runtime.executor import get_executor
 
@@ -18,6 +18,7 @@ def fit_predict_tool(
     dataset: str,
     horizon: int = 12,
     data_handle: Optional[str] = None,
+    coverage: Optional[Union[float, list[float]]] = None,
 ) -> dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
@@ -27,12 +28,17 @@ def fit_predict_tool(
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
         data_handle: Optional handle from load_data_source for custom data
+        coverage: Optional confidence level(s) for prediction intervals.
+                  Can be a single float (e.g., 0.9 for 90% interval) or
+                  a list of floats for multiple intervals.
 
     Returns:
         Dictionary with:
         - success: bool
         - predictions: Forecast values
         - horizon: Number of steps predicted
+        - intervals: (if coverage provided) Prediction intervals with lower/upper bounds
+        - coverage: (if coverage provided) The coverage level(s) used
 
     Example:
         >>> fit_predict_tool("est_abc123", "airline", horizon=12)
@@ -41,9 +47,24 @@ def fit_predict_tool(
             "predictions": {1: 450.2, 2: 460.5, ...},
             "horizon": 12
         }
+
+        >>> fit_predict_tool("est_abc123", "airline", horizon=12, coverage=0.9)
+        {
+            "success": True,
+            "predictions": {...},
+            "intervals": {"Airline": {"coverage": 0.9, "lower": {...}, "upper": {...}}},
+            "horizon": 12,
+            "coverage": 0.9
+        }
     """
     executor = get_executor()
-    return executor.fit_predict(estimator_handle, dataset, horizon, data_handle=data_handle)
+    return executor.fit_predict(
+        estimator_handle,
+        dataset,
+        horizon,
+        data_handle=data_handle,
+        coverage=coverage,
+    )
 
 
 def fit_tool(
@@ -109,6 +130,7 @@ def fit_predict_async_tool(
     estimator_handle: str,
     dataset: str,
     horizon: int = 12,
+    coverage: Optional[Union[float, list[float]]] = None,
 ) -> dict[str, Any]:
     """
     Execute a fit-predict workflow in the background (non-blocking).
@@ -120,6 +142,9 @@ def fit_predict_async_tool(
         estimator_handle: Handle from instantiate_estimator
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
+        coverage: Optional confidence level(s) for prediction intervals.
+                  Can be a single float (e.g., 0.9 for 90% interval) or
+                  a list of floats for multiple intervals.
 
     Returns:
         Dictionary with:
@@ -133,6 +158,14 @@ def fit_predict_async_tool(
             "success": True,
             "job_id": "abc-123-def-456",
             "message": "Training job started. Use check_job_status to monitor progress."
+        }
+
+        >>> fit_predict_async_tool("est_abc123", "airline", horizon=12, coverage=0.9)
+        {
+            "success": True,
+            "job_id": "abc-123-def-456",
+            "message": "Training job started for ThetaForecaster on airline. Use check_job_status('abc-123-def-456') to monitor progress.",
+            "coverage": 0.9
         }
     """
 
@@ -168,10 +201,10 @@ def fit_predict_async_tool(
         asyncio.set_event_loop(loop)
 
     # Schedule the coroutine (non-blocking!)
-    coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id)
+    coro = executor.fit_predict_async(estimator_handle, dataset, horizon, job_id, coverage)
     asyncio.run_coroutine_threadsafe(coro, loop)
 
-    return {
+    result = {
         "success": True,
         "job_id": job_id,
         "message": f"Training job started for {estimator_name} on {dataset}. Use check_job_status('{job_id}') to monitor progress.",
@@ -179,3 +212,8 @@ def fit_predict_async_tool(
         "dataset": dataset,
         "horizon": horizon,
     }
+
+    if coverage is not None:
+        result["coverage"] = coverage
+
+    return result


### PR DESCRIPTION
## Summary

Fixes issue #176 where the `coverage` parameter was silently dropped in async workflows, preventing prediction intervals from being returned.

## Changes

- Add `predict_interval()` method to Executor class that uses sktime's `predict_interval()` for probabilistic forecasting
- Add `coverage` parameter to `Executor.fit_predict()` - when provided, uses `predict_interval()` instead of `predict()`
- Add `coverage` parameter to `Executor.fit_predict_async()` - same behavior  
- Update `fit_predict_tool()` to accept and pass coverage parameter
- Update `fit_predict_async_tool()` to accept and pass coverage parameter
- Update MCP server tool schemas for fit_predict and fit_predict_async to expose coverage parameter in the API

## Usage

```python
# Sync version with prediction intervals
result = fit_predict_tool('est_abc123', 'airline', horizon=12, coverage=0.9)

# Async version with prediction intervals  
result = fit_predict_async_tool('est_abc123', 'airline', horizon=12, coverage=0.9)
```

The coverage parameter accepts:
- A single float (e.g., 0.9 for 90% prediction intervals)
- A list of floats for multiple interval levels (e.g., [0.5, 0.9, 0.95])

Only works with estimators that support prediction intervals (check `capability:pred_int` tag).