### PR TITLE
fix(#220): PandasAdapter auto time-column detection was unreachable dead code

### DIFF
--- a/src/sktime_mcp/data/adapters/pandas_adapter.py
+++ b/src/sktime_mcp/data/adapters/pandas_adapter.py
@@ -51,7 +51,7 @@ class PandasAdapter(DataSourceAdapter):
             if time_col not in df.columns:
                 raise ValueError(f"Time column '{time_col}' not found in data")
             df = df.set_index(time_col)
-        elif not isinstance(df.index, (pd.DatetimeIndex, pd.RangeIndex, pd.Index)):
+        elif not isinstance(df.index, (pd.DatetimeIndex, pd.RangeIndex)):
             # Try to detect time column
             time_col = self._detect_time_column(df)
             if time_col:


### PR DESCRIPTION
## Summary
The condition isinstance(df.index, (pd.DatetimeIndex, pd.RangeIndex, pd.Index)) was ALWAYS True because pd.Index is the base class of ALL pandas indexes. This made the 'not' always False, making _detect_time_column() unreachable dead code.

## The Fix
Removed pd.Index from the tuple:
- Before: isinstance(df.index, (pd.DatetimeIndex, pd.RangeIndex, pd.Index))  # Always True!
- After: isinstance(df.index, (pd.DatetimeIndex, pd.RangeIndex))

This allows auto-detection to run when index is not DatetimeIndex or RangeIndex.

## Changes
- src/sktime_mcp/data/adapters/pandas_adapter.py: Removed pd.Index from the isinstance check

## Testing
- DatetimeIndex index -> skip detection (correct)
- RangeIndex index -> skip detection (correct)  
- Plain Index (strings/numbers) -> trigger auto-detection (now works!)