### PR TITLE
feat: Add compare_estimators tool for autonomous model selection

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -67,13 +67,24 @@ logger = logging.getLogger(__name__)
 server = Server("sktime-mcp")
 
 
-def sanitize_for_json(obj):
+def sanitize_for_json(obj, _seen=None):
     """Recursively convert objects to JSON-serializable format."""
+    if _seen is None:
+        _seen = set()
+    
+    if isinstance(obj, (bool, type(None), int, float, str)):
+        return obj
+    
+    obj_id = id(obj)
+    if obj_id in _seen:
+        return "<circular>"
+    _seen.add(obj_id)
+    
     if isinstance(obj, dict):
-        return {str(k): sanitize_for_json(v) for k, v in obj.items()}
+        return {str(k): sanitize_for_json(v, _seen) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple)):
-        return [sanitize_for_json(item) for item in obj]
-    elif hasattr(obj, "__dict__") and not isinstance(obj, (str, int, float, bool, type(None))):
+        return [sanitize_for_json(item, _seen) for item in obj]
+    elif hasattr(obj, "__dict__"):
         return str(obj)
     else:
         return obj


### PR DESCRIPTION
## Summary
Implements the `compare_estimators` MCP tool that accepts a list of estimator handles, runs cross-validation on each using the same dataset, and returns results ranked by a chosen metric.

## Motivation
This closes the final gap in the fully autonomous agentic loop:
- `extract_ts_metadata()` - know what data looks like
- `instantiate_estimator()` x N - create candidate models  
- `compare_estimators()` - **NEW: rank all candidates automatically**
- `fit_predict(best_handle)` - execute with the winner

## Changes

### `src/sktime_mcp/tools/evaluate.py`
- Added metric mapping constants (`MAE`, `MSE`, `RMSE`, `MAPE`, `SMAPE`, `MASE`, `MedAE`)
- Added `_get_metric_instance()` helper
- Added `_extract_metric_value()` helper
- Implemented `compare_estimators_tool()` with full validation and cross-validation ranking

### `src/sktime_mcp/server.py`
- Added `compare_estimators` tool definition in `list_tools()`
- Added handler dispatch in `call_tool()`

### `tests/test_evaluate.py`
- Added 12 test cases covering all edge cases

## Inputs
```json
{
  "estimator_handles": ["est_abc123", "est_def456"],
  "dataset": "airline",
  "metric": "MAPE",
  "horizon": 12
}
```

## Outputs
```json
{
  "success": true,
  "ranked": [
    {"rank": 1, "handle": "est_abc123", "estimator": "AutoARIMA", "score": 4.2},
    {"rank": 2, "handle": "est_def456", "estimator": "ARIMA", "score": 7.1}
  ],
  "best_handle": "est_abc123",
  "best_estimator": "AutoARIMA",
  "metric": "MAPE"
}
```

## Testing
- Syntax validation passed
- Tests cover: empty handles, missing dataset, both dataset+data_handle, invalid params, unknown handles/datasets/metrics, ranking order, all metrics