### PR TITLE
feat: add analyze_data tool for dataset statistical analysis

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -16,6 +16,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from sktime_mcp.composition.validator import get_composition_validator
+from sktime_mcp.tools.analyze_data import analyze_data_tool
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.data_tools import (
     fit_predict_with_data_tool,
@@ -436,6 +437,34 @@ async def list_tools() -> list[Tool]:
                 "required": ["data_handle"],
             },
         ),
+        Tool(
+            name="analyze_data",
+            description=(
+                "Analyze a loaded time series and compute statistical characteristics. "
+                "Returns stationarity (ADF test), trend (linear regression), "
+                "and seasonality (ACF analysis) to guide model selection."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Handle from load_data_source",
+                    },
+                    "include_acf": {
+                        "type": "boolean",
+                        "description": "Include full ACF/PACF values in output (default: True)",
+                        "default": True,
+                    },
+                    "max_acf_lags": {
+                        "type": "integer",
+                        "description": "Maximum lags for ACF analysis (default: 24)",
+                        "default": 24,
+                    },
+                },
+                "required": ["data_handle"],
+            },
+        ),
         # -- Export / Persistence --------------------------------------------
         Tool(
             name="export_code",
@@ -684,6 +713,14 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments.get("fill_missing", True),
                 arguments.get("remove_duplicates", True),
             )
+
+        elif name == "analyze_data":
+            result = analyze_data_tool(
+                arguments["data_handle"],
+                arguments.get("include_acf", True),
+                arguments.get("max_acf_lags", 24),
+            )
+            result = sanitize_for_json(result)
 
         elif name == "auto_format_on_load":
             # Deprecated — now controlled via SKTIME_MCP_AUTO_FORMAT env var

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -1,5 +1,6 @@
 """Tools module for sktime MCP."""
 
+from sktime_mcp.tools.analyze_data import analyze_data_tool
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.fit_predict import fit_predict_tool
@@ -12,6 +13,7 @@ from sktime_mcp.tools.list_estimators import list_estimators_tool
 from sktime_mcp.tools.save_model import save_model_tool
 
 __all__ = [
+    "analyze_data_tool",
     "list_estimators_tool",
     "describe_estimator_tool",
     "instantiate_estimator_tool",

--- a/src/sktime_mcp/tools/analyze_data.py
+++ b/src/sktime_mcp/tools/analyze_data.py
@@ -1,0 +1,411 @@
+"""
+analyze_data tool for sktime MCP.
+
+Provides statistical analysis of time series data including
+stationarity, trend, and seasonality detection.
+"""
+
+import logging
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+from statsmodels.stats.diagnostic import acorr_ljungbox
+from statsmodels.tsa.stattools import acf, adfuller, pacf
+
+from sktime_mcp.runtime.executor import get_executor
+
+logger = logging.getLogger(__name__)
+
+
+def _compute_basic_stats(y: pd.Series) -> dict[str, Any]:
+    """Compute basic time series statistics."""
+    stats = {
+        "length": len(y),
+        "is_nan": float(y.isna().sum()),
+        "is_zero": float((y == 0).sum()),
+        "min": float(y.min()) if not y.isna().all() else None,
+        "max": float(y.max()) if not y.isna().all() else None,
+        "mean": float(y.mean()) if not y.isna().all() else None,
+        "std": float(y.std()) if not y.isna().all() else None,
+    }
+
+    # Frequency detection
+    freq = y.index.freq
+    if freq is None:
+        freq = pd.infer_freq(y.index)
+
+    stats["frequency"] = str(freq) if freq else None
+    stats["has_index"] = True
+
+    # Time range
+    if len(y) > 0:
+        stats["start"] = str(y.index.min())
+        stats["end"] = str(y.index.max())
+
+    return stats
+
+
+def _compute_stationarity(y: pd.Series) -> dict[str, Any]:
+    """Compute stationarity using Augmented Dickey-Fuller test."""
+    clean_y = y.dropna()
+
+    if len(clean_y) < 10:
+        return {
+            "test": "adf",
+            "statistic": None,
+            "p_value": None,
+            "critical_values": None,
+            "is_stationary": None,
+            "error": "Insufficient data for ADF test (need at least 10 points)",
+        }
+
+    try:
+        result = adfuller(clean_y, autolag="AIC")
+
+        return {
+            "test": "adf",
+            "statistic": float(result[0]),
+            "p_value": float(result[1]),
+            "critical_values": {k: float(v) for k, v in result[4].items()},
+            "is_stationary": bool(result[1] < 0.05),
+            "lags_used": int(result[2]),
+        }
+    except Exception as e:
+        logger.warning(f"ADF test failed: {e}")
+        return {
+            "test": "adf",
+            "statistic": None,
+            "p_value": None,
+            "critical_values": None,
+            "is_stationary": None,
+            "error": str(e),
+        }
+
+
+def _compute_trend(y: pd.Series) -> dict[str, Any]:
+    """Compute trend using linear regression."""
+    clean_y = y.dropna()
+
+    if len(clean_y) < 3:
+        return {
+            "has_trend": None,
+            "trend_slope": None,
+            "trend_intercept": None,
+            "trend_p_value": None,
+            "r_squared": None,
+            "error": "Insufficient data for trend analysis (need at least 3 points)",
+        }
+
+    try:
+        # Use index as x values (numeric)
+        x = np.arange(len(clean_y))
+        y_values = clean_y.values
+
+        # Linear regression using numpy polyfit
+        slope, intercept = np.polyfit(x, y_values, 1)
+
+        # Calculate R-squared
+        y_pred = slope * x + intercept
+        ss_res = np.sum((y_values - y_pred) ** 2)
+        ss_tot = np.sum((y_values - np.mean(y_values)) ** 2)
+        r_squared = 1 - (ss_res / ss_tot) if ss_tot != 0 else 0
+
+        # Compute p-value using statsmodels for proper significance
+        from scipy import stats as scipy_stats
+
+        n = len(x)
+        df = n - 2  # degrees of freedom
+        se = np.sqrt(ss_res / df)
+        se_slope = se / np.sqrt(np.sum((x - np.mean(x)) ** 2))
+        t_stat = slope / se_slope if se_slope != 0 else 0
+        p_value = 2 * (1 - scipy_stats.t.cdf(abs(t_stat), df))
+
+        # Determine if trend is significant
+        has_trend = bool(abs(p_value) < 0.05 and abs(slope) > 1e-6)
+
+        return {
+            "has_trend": has_trend,
+            "trend_slope": float(slope),
+            "trend_intercept": float(intercept),
+            "trend_p_value": float(p_value),
+            "r_squared": float(r_squared),
+        }
+    except Exception as e:
+        logger.warning(f"Trend analysis failed: {e}")
+        return {
+            "has_trend": None,
+            "trend_slope": None,
+            "trend_intercept": None,
+            "trend_p_value": None,
+            "r_squared": None,
+            "error": str(e),
+        }
+
+
+def _compute_seasonality(y: pd.Series, max_lags: int = 24) -> dict[str, Any]:
+    """Compute seasonality using ACF analysis."""
+    clean_y = y.dropna()
+
+    if len(clean_y) < 10:
+        return {
+            "has_seasonality": None,
+            "seasonal_strength": None,
+            "seasonal_period": None,
+            "acf_values": None,
+            "pacf_values": None,
+            "ljung_box_p_value": None,
+            "error": "Insufficient data for seasonality analysis (need at least 10 points)",
+        }
+
+    try:
+        # Determine appropriate number of lags
+        n_lags = min(max_lags, len(clean_y) // 2 - 1)
+
+        if n_lags < 2:
+            return {
+                "has_seasonality": None,
+                "seasonal_strength": None,
+                "seasonal_period": None,
+                "acf_values": None,
+                "pacf_values": None,
+                "ljung_box_p_value": None,
+                "error": "Insufficient data for seasonality analysis",
+            }
+
+        # Compute ACF and PACF
+        acf_values = acf(clean_y, nlags=n_lags, fft=True)
+        pacf_values = pacf(clean_y, nlags=n_lags)
+
+        # Ljung-Box test for autocorrelation
+        try:
+            lb_result = acorr_ljungbox(clean_y, lags=[min(10, n_lags)], return_df=True)
+            lb_p_value = float(lb_result["lb_pvalue"].iloc[0])
+        except Exception:
+            lb_p_value = None
+
+        # Detect dominant seasonal period by finding peaks in ACF
+        seasonal_period = None
+        seasonal_strength = None
+
+        if len(acf_values) > 2:
+            # Look for peaks beyond lag 0
+            acf_no_lag0 = acf_values[1:]
+            if len(acf_no_lag0) > 0:
+                # Find indices where ACF is above confidence interval
+                conf_int = 1.96 / np.sqrt(len(clean_y))
+                significant_lags = np.where(acf_no_lag0 > conf_int)[0]
+
+                if len(significant_lags) > 0:
+                    # Find the first significant lag after lag 0
+                    seasonal_period = int(significant_lags[0] + 1)
+                    seasonal_strength = float(acf_values[seasonal_period]) if seasonal_period < len(acf_values) else None
+
+        # Determine if seasonality is present
+        # Based on significant autocorrelation at seasonal lags
+        has_seasonality = seasonal_period is not None and seasonal_strength is not None and seasonal_strength > conf_int
+
+        return {
+            "has_seasonality": bool(has_seasonality) if has_seasonality is not None else None,
+            "seasonal_strength": float(seasonal_strength) if seasonal_strength is not None else None,
+            "seasonal_period": seasonal_period,
+            "acf_values": [float(v) for v in acf_values],
+            "pacf_values": [float(v) for v in pacf_values],
+            "ljung_box_p_value": lb_p_value,
+            "confidence_interval": float(1.96 / np.sqrt(len(clean_y))),
+        }
+    except Exception as e:
+        logger.warning(f"Seasonality analysis failed: {e}")
+        return {
+            "has_seasonality": None,
+            "seasonal_strength": None,
+            "seasonal_period": None,
+            "acf_values": None,
+            "pacf_values": None,
+            "ljung_box_p_value": None,
+            "error": str(e),
+        }
+
+
+def _compute_summary(
+    stationarity: dict[str, Any],
+    trend: dict[str, Any],
+    seasonality: dict[str, Any],
+) -> dict[str, Any]:
+    """Compute a summary interpretation of the analysis."""
+    summary_parts = []
+
+    # Stationarity summary
+    if stationarity.get("is_stationary") is True:
+        summary_parts.append("Series is stationary")
+    elif stationarity.get("is_stationary") is False:
+        summary_parts.append("Series is non-stationary (has unit root)")
+    elif stationarity.get("is_stationary") is None:
+        summary_parts.append(f"Stationarity unknown ({stationarity.get('error', 'test failed')})")
+
+    # Trend summary
+    if trend.get("has_trend") is True:
+        slope = trend.get("trend_slope", 0)
+        direction = "increasing" if slope > 0 else "decreasing"
+        summary_parts.append(f"Series has a significant {direction} trend (slope={slope:.4f})")
+    elif trend.get("has_trend") is False:
+        summary_parts.append("No significant trend detected")
+    elif trend.get("has_trend") is None:
+        summary_parts.append(f"Trend analysis inconclusive ({trend.get('error', 'test failed')})")
+
+    # Seasonality summary
+    if seasonality.get("has_seasonality") is True:
+        period = seasonality.get("seasonal_period")
+        strength = seasonality.get("seasonal_strength", 0)
+        summary_parts.append(f"Seasonality detected (period={period}, strength={strength:.3f})")
+    elif seasonality.get("has_seasonality") is False:
+        summary_parts.append("No significant seasonality detected")
+    elif seasonality.get("has_seasonality") is None:
+        summary_parts.append(f"Seasonality unknown ({seasonality.get('error', 'test failed')})")
+
+    return {
+        "interpretation": "; ".join(summary_parts),
+        "recommendations": _get_recommendations(stationarity, trend, seasonality),
+    }
+
+
+def _get_recommendations(
+    stationarity: dict[str, Any],
+    trend: dict[str, Any],
+    seasonality: dict[str, Any],
+) -> list[str]:
+    """Get modeling recommendations based on analysis."""
+    recommendations = []
+
+    if stationarity.get("is_stationary") is False:
+        recommendations.append("Consider differencing or Detrender to make series stationary")
+        recommendations.append("ARIMA with d>0 or SARIMA may be appropriate")
+
+    if trend.get("has_trend") is True:
+        recommendations.append("Consider including trend component in model")
+        recommendations.append("Detrender transformer may help")
+
+    if seasonality.get("has_seasonality") is True:
+        period = seasonality.get("seasonal_period")
+        if period:
+            recommendations.append(f"Consider seasonal models (period={period})")
+            recommendations.append("SARIMA, Prophet, or seasonal exponential smoothing recommended")
+
+    if (
+        stationarity.get("is_stationary") is not False
+        and trend.get("has_trend") is not True
+        and seasonality.get("has_seasonality") is not True
+    ):
+        recommendations.append("Simple models like ARIMA or exponential smoothing may suffice")
+
+    if not recommendations:
+        recommendations.append("Further analysis needed before selecting a model")
+
+    return recommendations
+
+
+def analyze_data_tool(
+    data_handle: str,
+    include_acf: bool = True,
+    max_acf_lags: int = 24,
+) -> dict[str, Any]:
+    """
+    Analyze a loaded time series dataset and return statistical characteristics.
+
+    Computes stationarity (ADF test), trend (linear regression), and
+    seasonality (ACF analysis) to help guide model selection.
+
+    Args:
+        data_handle: Handle from load_data_source
+        include_acf: Whether to include full ACF/PACF values (default: True)
+        max_acf_lags: Maximum number of lags for ACF analysis (default: 24)
+
+    Returns:
+        Dictionary with:
+        - success: bool
+        - data_handle: str
+        - basic_stats: dict (length, frequency, min, max, mean, std, etc.)
+        - stationarity: dict (ADF test results)
+        - trend: dict (linear regression results)
+        - seasonality: dict (ACF analysis results)
+        - summary: dict (interpretation and recommendations)
+        - errors: list of any errors encountered during analysis
+
+    Example:
+        >>> analyze_data_tool(data_handle="data_abc123")
+        {
+            "success": True,
+            "data_handle": "data_abc123",
+            "basic_stats": {"length": 144, "frequency": "MS", ...},
+            "stationarity": {"test": "adf", "p_value": 0.01, "is_stationary": True, ...},
+            "trend": {"has_trend": False, "trend_slope": 0.001, ...},
+            "seasonality": {"has_seasonality": True, "seasonal_period": 12, ...},
+            "summary": {"interpretation": "...", "recommendations": [...]}
+        }
+    """
+    executor = get_executor()
+
+    # Validate data handle exists
+    if data_handle not in executor._data_handles:
+        return {
+            "success": False,
+            "error": f"Unknown data handle: {data_handle}",
+            "available_handles": list(executor._data_handles.keys()),
+        }
+
+    data_info = executor._data_handles[data_handle]
+    y = data_info["y"]
+    errors = []
+
+    # Validate input
+    if y is None or (isinstance(y, pd.Series) and len(y) == 0):
+        return {
+            "success": False,
+            "error": "Data series is empty",
+        }
+
+    # Check if data is all NaN
+    if isinstance(y, pd.Series) and y.isna().all():
+        return {
+            "success": False,
+            "error": "Data series contains only NaN values",
+        }
+
+    try:
+        # Compute basic statistics
+        basic_stats = _compute_basic_stats(y)
+
+        # Compute stationarity
+        stationarity = _compute_stationarity(y)
+
+        # Compute trend
+        trend = _compute_trend(y)
+
+        # Compute seasonality
+        seasonality = _compute_seasonality(y, max_lags=max_acf_lags)
+
+        # Optionally truncate ACF values for cleaner output
+        if not include_acf:
+            seasonality["acf_values"] = None
+            seasonality["pacf_values"] = None
+
+        # Compute summary
+        summary = _compute_summary(stationarity, trend, seasonality)
+
+        return {
+            "success": True,
+            "data_handle": data_handle,
+            "basic_stats": basic_stats,
+            "stationarity": stationarity,
+            "trend": trend,
+            "seasonality": seasonality,
+            "summary": summary,
+        }
+
+    except Exception as e:
+        logger.exception("Error during data analysis")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }

--- a/tests/test_analyze_data.py
+++ b/tests/test_analyze_data.py
@@ -1,0 +1,456 @@
+"""
+Tests for analyze_data tool.
+"""
+
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, "src")
+
+
+class TestAnalyzeDataTool:
+    """Tests for the analyze_data tool."""
+
+    @pytest.fixture
+    def clean_executor(self):
+        """Get a clean executor instance for testing."""
+        from sktime_mcp.runtime.executor import get_executor
+
+        executor = get_executor()
+        # Clear any existing data handles
+        executor._data_handles.clear()
+        yield executor
+        # Cleanup after
+        executor._data_handles.clear()
+
+    @pytest.fixture
+    def airline_data_handle(self, clean_executor):
+        """Load airline dataset and return its data handle."""
+        result = clean_executor.load_data_source({
+            "type": "pandas",
+            "data": {
+                "date": pd.date_range("1949-01-01", periods=144, freq="M").strftime("%Y-%m").tolist(),
+                "passengers": [112, 118, 132, 129, 121, 135, 148, 148, 136, 119, 104, 118,
+                               115, 126, 141, 135, 125, 149, 170, 170, 158, 133, 114, 140,
+                               145, 150, 178, 163, 172, 178, 199, 199, 184, 162, 146, 166,
+                               171, 180, 193, 181, 183, 218, 230, 242, 209, 191, 172, 194,
+                               196, 196, 220, 201, 229, 243, 264, 272, 237, 211, 180, 201,
+                               204, 188, 235, 227, 234, 264, 302, 293, 259, 229, 203, 229,
+                               242, 233, 267, 269, 270, 315, 364, 347, 312, 274, 237, 278,
+                               284, 277, 317, 313, 318, 374, 413, 405, 355, 306, 271, 306,
+                               315, 301, 356, 348, 355, 422, 465, 467, 404, 347, 305, 336,
+                               340, 318, 362, 348, 363, 435, 491, 505, 404, 359, 310, 337,
+                               360, 342, 406, 396, 420, 472, 548, 559, 463, 407, 362, 405,
+                               417, 391, 419, 461, 472, 535, 622, 606, 508, 461, 390, 432],
+            },
+            "time_column": "date",
+            "target_column": "passengers",
+        })
+        assert result["success"], f"Failed to load data: {result.get('error')}"
+        return result["data_handle"]
+
+    @pytest.fixture
+    def stationary_data_handle(self, clean_executor):
+        """Create a stationary series (white noise)."""
+        np.random.seed(42)
+        data = np.random.randn(100)
+        index = pd.date_range("2020-01-01", periods=100, freq="D")
+
+        result = clean_executor.load_data_source({
+            "type": "pandas",
+            "data": {
+                "date": [str(d) for d in index],
+                "value": data.tolist(),
+            },
+            "time_column": "date",
+            "target_column": "value",
+        })
+        assert result["success"]
+        return result["data_handle"]
+
+    @pytest.fixture
+    def trend_data_handle(self, clean_executor):
+        """Create a series with clear upward trend."""
+        n = 100
+        index = pd.date_range("2020-01-01", periods=n, freq="D")
+        trend_values = np.linspace(10, 100, n) + np.random.randn(n) * 5
+
+        result = clean_executor.load_data_source({
+            "type": "pandas",
+            "data": {
+                "date": [str(d) for d in index],
+                "value": trend_values.tolist(),
+            },
+            "time_column": "date",
+            "target_column": "value",
+        })
+        assert result["success"]
+        return result["data_handle"]
+
+    def test_analyze_with_airline_data(self, airline_data_handle):
+        """Test analyze_data with airline dataset (has trend and seasonality)."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(airline_data_handle)
+
+        assert result["success"], f"Analysis failed: {result.get('error')}"
+        assert result["data_handle"] == airline_data_handle
+        assert "basic_stats" in result
+        assert "stationarity" in result
+        assert "trend" in result
+        assert "seasonality" in result
+        assert "summary" in result
+
+        # Check basic stats
+        assert result["basic_stats"]["length"] == 144
+        assert result["basic_stats"]["min"] is not None
+        assert result["basic_stats"]["max"] is not None
+        assert result["basic_stats"]["mean"] is not None
+
+        # Check stationarity
+        assert result["stationarity"]["test"] == "adf"
+        assert result["stationarity"]["p_value"] is not None
+        assert "is_stationary" in result["stationarity"]
+
+        # Check trend
+        assert "has_trend" in result["trend"]
+        assert "trend_slope" in result["trend"]
+
+        # Check seasonality
+        assert "has_seasonality" in result["seasonality"]
+        assert "seasonal_period" in result["seasonality"]
+
+        # Check summary
+        assert "interpretation" in result["summary"]
+        assert "recommendations" in result["summary"]
+        assert len(result["summary"]["recommendations"]) > 0
+
+    def test_analyze_stationary_data(self, stationary_data_handle):
+        """Test analyze_data with stationary (white noise) data."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(stationary_data_handle)
+
+        assert result["success"]
+        # White noise should be stationary
+        assert result["stationarity"]["is_stationary"] is True
+        # White noise typically has no significant trend
+        assert result["trend"]["has_trend"] is False or result["trend"]["has_trend"] is None
+        # White noise may or may not have seasonality depending on random chance
+
+    def test_analyze_trend_data(self, trend_data_handle):
+        """Test analyze_data with data that has a clear trend."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(trend_data_handle)
+
+        assert result["success"]
+        # Data with trend should show significant trend
+        assert result["trend"]["has_trend"] is True
+        assert result["trend"]["trend_slope"] > 0  # Upward trend
+
+    def test_analyze_unknown_handle(self):
+        """Test analyze_data with an unknown data handle."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool("data_nonexistent_handle_123")
+
+        assert not result["success"]
+        assert "error" in result
+        assert "Unknown data handle" in result["error"]
+
+    def test_analyze_empty_series(self, clean_executor):
+        """Test analyze_data with an empty series."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        # Create empty data handle - loading itself will fail with empty data
+        result = clean_executor.load_data_source({
+            "type": "pandas",
+            "data": {"date": [], "value": []},
+            "time_column": "date",
+            "target_column": "value",
+        })
+        # Data loading fails for empty series (pandas requires at least 3 dates)
+        assert not result["success"]
+        assert "error" in result
+
+    def test_analyze_all_nan_series(self, clean_executor):
+        """Test analyze_data with a series containing only NaN values."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = clean_executor.load_data_source({
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [np.nan, np.nan, np.nan],
+            },
+            "time_column": "date",
+            "target_column": "value",
+        })
+        assert result["success"]
+        data_handle = result["data_handle"]
+
+        result = analyze_data_tool(data_handle)
+
+        assert not result["success"]
+        assert "NaN" in result["error"] or "empty" in result["error"]
+
+    def test_analyze_insufficient_data(self, clean_executor):
+        """Test analyze_data with insufficient data points."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        # Note: pandas requires at least 3 dates to infer frequency,
+        # so loading with 3 dates may fail during load_data_source
+        load_result = clean_executor.load_data_source({
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],  # 3 dates - minimum
+                "value": [1.0, 2.0, 3.0],
+            },
+            "time_column": "date",
+            "target_column": "value",
+        })
+
+        # If loading succeeds (3 dates is the minimum), test the analysis
+        # If loading fails, it's expected behavior due to pandas limitations
+        if load_result["success"]:
+            data_handle = load_result["data_handle"]
+            analysis_result = analyze_data_tool(data_handle)
+            # Should handle gracefully - analysis succeeds but some tests have insufficient data
+            assert analysis_result["success"]
+            # Stationarity test should report insufficient data
+            assert (
+                analysis_result["stationarity"].get("error") is not None
+                or analysis_result["stationarity"].get("p_value") is not None
+            )
+        else:
+            # Loading failed due to pandas frequency inference requirement
+            assert "error" in load_result
+
+    def test_analyze_include_acf_false(self, airline_data_handle):
+        """Test analyze_data with include_acf=False."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(airline_data_handle, include_acf=False)
+
+        assert result["success"]
+        # ACF values should be None when include_acf=False
+        assert result["seasonality"]["acf_values"] is None
+        assert result["seasonality"]["pacf_values"] is None
+
+    def test_analyze_max_acf_lags(self, airline_data_handle):
+        """Test analyze_data with custom max_acf_lags."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(airline_data_handle, max_acf_lags=5)
+
+        assert result["success"]
+        # ACF values should not exceed max_acf_lags + 1 (including lag 0)
+        if result["seasonality"]["acf_values"]:
+            assert len(result["seasonality"]["acf_values"]) <= 6
+
+    def test_basic_stats_computation(self, airline_data_handle):
+        """Test that basic statistics are computed correctly."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(airline_data_handle)
+
+        assert result["success"]
+        stats = result["basic_stats"]
+
+        # Check required fields
+        assert "length" in stats
+        assert "mean" in stats
+        assert "std" in stats
+        assert "min" in stats
+        assert "max" in stats
+        assert "frequency" in stats
+        assert "start" in stats
+        assert "end" in stats
+        assert "is_nan" in stats
+
+        # Verify values are numeric
+        assert isinstance(stats["length"], int)
+        assert isinstance(stats["mean"], float)
+
+    def test_stationarity_adf_test(self, airline_data_handle):
+        """Test that ADF test returns proper structure."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(airline_data_handle)
+
+        assert result["success"]
+        stat = result["stationarity"]
+
+        assert stat["test"] == "adf"
+        assert "statistic" in stat
+        assert "p_value" in stat
+        assert "critical_values" in stat
+        assert "is_stationary" in stat
+        # Check critical values structure
+        if stat["critical_values"]:
+            assert isinstance(stat["critical_values"], dict)
+            assert "1%" in stat["critical_values"] or "5%" in stat["critical_values"] or "10%" in stat["critical_values"]
+
+    def test_trend_linear_regression(self, airline_data_handle):
+        """Test that trend analysis returns proper structure."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(airline_data_handle)
+
+        assert result["success"]
+        trend = result["trend"]
+
+        assert "has_trend" in trend
+        assert "trend_slope" in trend
+        assert "trend_intercept" in trend
+        assert "trend_p_value" in trend
+        assert "r_squared" in trend
+
+    def test_summary_interpretation(self, airline_data_handle):
+        """Test that summary interpretation is generated."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        result = analyze_data_tool(airline_data_handle)
+
+        assert result["success"]
+        summary = result["summary"]
+
+        assert "interpretation" in summary
+        assert "recommendations" in summary
+        # Interpretation should be a non-empty string
+        assert isinstance(summary["interpretation"], str)
+        assert len(summary["interpretation"]) > 0
+        # Recommendations should be a list
+        assert isinstance(summary["recommendations"], list)
+
+    def test_summary_recommendations_vary_by_data(self, stationary_data_handle, trend_data_handle):
+        """Test that recommendations differ based on data characteristics."""
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+
+        # Stationary data should not need differencing
+        stationary_result = analyze_data_tool(stationary_data_handle)
+        stationary_recs = stationary_result["summary"]["recommendations"]
+
+        # Trend data should suggest trend-related models
+        trend_result = analyze_data_tool(trend_data_handle)
+        trend_recs = trend_result["summary"]["recommendations"]
+
+        # Both should have recommendations
+        assert len(stationary_recs) > 0
+        assert len(trend_recs) > 0
+
+
+class TestAnalyzeDataFunctions:
+    """Unit tests for individual analyze_data functions."""
+
+    def test_compute_basic_stats(self):
+        """Test _compute_basic_stats function."""
+        from sktime_mcp.tools.analyze_data import _compute_basic_stats
+
+        index = pd.date_range("2020-01-01", periods=10, freq="D")
+        series = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0], index=index)
+
+        stats = _compute_basic_stats(series)
+
+        assert stats["length"] == 10
+        assert stats["min"] == 1.0
+        assert stats["max"] == 10.0
+        assert stats["mean"] == 5.5
+        assert stats["is_nan"] == 0
+
+    def test_compute_basic_stats_with_nan(self):
+        """Test _compute_basic_stats with NaN values."""
+        from sktime_mcp.tools.analyze_data import _compute_basic_stats
+
+        index = pd.date_range("2020-01-01", periods=5, freq="D")
+        series = pd.Series([1.0, np.nan, 3.0, np.nan, 5.0], index=index)
+
+        stats = _compute_basic_stats(series)
+
+        assert stats["length"] == 5
+        assert stats["is_nan"] == 2
+        assert stats["min"] == 1.0
+        assert stats["max"] == 5.0
+
+    def test_compute_stationarity_adf(self):
+        """Test _compute_stationarity with ADF test."""
+        from sktime_mcp.tools.analyze_data import _compute_stationarity
+
+        # Stationary series (white noise)
+        stationary = pd.Series(np.random.randn(100))
+
+        result = _compute_stationarity(stationary)
+
+        assert result["test"] == "adf"
+        assert result["p_value"] is not None
+        assert result["is_stationary"] is not None
+
+    def test_compute_trend_linear_regression(self):
+        """Test _compute_trend with linear regression."""
+        from sktime_mcp.tools.analyze_data import _compute_trend
+
+        # Series with upward trend
+        trend_values = np.linspace(10, 100, 50)
+        series = pd.Series(trend_values)
+
+        result = _compute_trend(series)
+
+        assert "has_trend" in result
+        assert "trend_slope" in result
+        assert result["trend_slope"] > 0  # Should detect upward trend
+
+    def test_compute_seasonality_acf(self):
+        """Test _compute_seasonality with ACF analysis."""
+        from sktime_mcp.tools.analyze_data import _compute_seasonality
+
+        # Series with known periodicity (sine wave)
+        t = np.linspace(0, 4 * np.pi, 100)
+        seasonal = np.sin(t) + np.random.randn(100) * 0.1
+        series = pd.Series(seasonal)
+
+        result = _compute_seasonality(series, max_lags=24)
+
+        assert "has_seasonality" in result
+        assert "acf_values" in result
+        assert "pacf_values" in result
+
+    def test_compute_summary(self):
+        """Test _compute_summary function."""
+        from sktime_mcp.tools.analyze_data import _compute_summary
+
+        stationarity = {"is_stationary": False, "error": None}
+        trend = {"has_trend": True, "trend_slope": 0.5}
+        seasonality = {"has_seasonality": True, "seasonal_period": 12}
+
+        summary = _compute_summary(stationarity, trend, seasonality)
+
+        assert "interpretation" in summary
+        assert "recommendations" in summary
+        assert len(summary["recommendations"]) > 0
+        # Check that interpretation mentions non-stationary
+        assert "non-stationary" in summary["interpretation"].lower()
+
+    def test_get_recommendations(self):
+        """Test _get_recommendations function."""
+        from sktime_mcp.tools.analyze_data import _get_recommendations
+
+        # Non-stationary with trend and seasonality
+        recommendations = _get_recommendations(
+            {"is_stationary": False},
+            {"has_trend": True, "trend_slope": 0.5},
+            {"has_seasonality": True, "seasonal_period": 12}
+        )
+
+        assert len(recommendations) > 0
+        # Should recommend differencing for non-stationary
+        assert any("differenc" in r.lower() for r in recommendations)
+        # Should recommend seasonal models
+        assert any("seasonal" in r.lower() or "sarima" in r.lower() for r in recommendations)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Add `analyze_data` tool for computing statistical characteristics of loaded time series datasets.

### Features
- **Basic statistics**: length, frequency, min/max/mean/std, NaN count
- **Stationarity**: Augmented Dickey-Fuller test with p-value and critical values
- **Trend detection**: Linear regression slope, intercept, p-value, R²
- **Seasonality**: ACF/PACF analysis, Ljung-Box test, seasonal period detection
- **Summary**: Human-readable interpretation and modeling recommendations

### Example Usage
```python
# Load data first
data_handle = load_data_source({...})

# Analyze the data
result = analyze_data_tool(data_handle)
# Returns: basic_stats, stationarity, trend, seasonality, summary
```

### Testing
- 21 unit tests covering normal cases and edge cases
- All tests passing

Closes #195