### PR TITLE
Add get_timeseries_diagnostics MCP tool

### DIFF
--- a/src/sktime_mcp/examples/diagnostics_demo.py
+++ b/src/sktime_mcp/examples/diagnostics_demo.py
@@ -1,0 +1,10 @@
+from sktime.datasets import load_airline
+from sktime_mcp.tools import get_timeseries_diagnostics
+
+# load example dataset
+y = load_airline()
+
+diagnostics = get_timeseries_diagnostics(y)
+
+print("Time Series Diagnostics")
+print(diagnostics)

--- a/src/sktime_mcp/test_diag.py
+++ b/src/sktime_mcp/test_diag.py
@@ -1,0 +1,5 @@
+from sktime_mcp.tools import get_timeseries_diagnostics
+
+series = [112,118,132,129,121,135,148,148,136,119,104,118]
+
+print(get_timeseries_diagnostics(series))

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -3,6 +3,7 @@
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.fit_predict import fit_predict_tool
+from .timeseries_diagnostics import get_timeseries_diagnostics
 from sktime_mcp.tools.format_tools import (
     auto_format_on_load_tool,
     format_time_series_tool,

--- a/src/sktime_mcp/tools/timeseries_diagnostics.py
+++ b/src/sktime_mcp/tools/timeseries_diagnostics.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from statsmodels.tsa.stattools import adfuller
+from sktime.utils.seasonality import autocorrelation_seasonality_test
+
+
+def get_timeseries_diagnostics(series: list):
+
+    series = pd.Series(series)
+
+    diagnostics = {}
+
+    diagnostics["length"] = len(series)
+    diagnostics["missing_values"] = int(series.isna().sum())
+
+    # stationarity
+    try:
+        adf = adfuller(series.dropna())
+        diagnostics["is_stationary"] = adf[1] < 0.05
+        diagnostics["adf_p_value"] = float(adf[1])
+    except Exception:
+        diagnostics["is_stationary"] = None
+        diagnostics["adf_p_value"] = None
+
+    # seasonality
+    try:
+        seasonal = autocorrelation_seasonality_test(series.dropna(), sp=12)
+        diagnostics["is_seasonal"] = bool(seasonal)
+        diagnostics["seasonal_period"] = 12 if seasonal else None
+    except Exception:
+        diagnostics["is_seasonal"] = None
+        diagnostics["seasonal_period"] = None
+
+    stats = series.describe()
+
+    diagnostics["stats"] = {
+        "mean": float(stats["mean"]),
+        "std": float(stats["std"]),
+        "min": float(stats["min"]),
+        "max": float(stats["max"]),
+    }
+
+    diagnostics["model_hints"] = {}
+
+    if diagnostics["is_seasonal"]:
+        diagnostics["model_hints"]["recommended_models"] = ["SARIMA", "ETS"]
+    else:
+        diagnostics["model_hints"]["recommended_models"] = ["ARIMA"]
+
+    if diagnostics["is_stationary"] is False:
+        diagnostics["model_hints"]["needs_differencing"] = True
+
+    return diagnostics


### PR DESCRIPTION
## Summary

This PR introduces a new MCP tool: `get_timeseries_diagnostics`.

The tool analyzes a time series and returns structured metadata describing key statistical properties such as:

- length of the series
- missing values
- stationarity (ADF test)
- seasonality
- descriptive statistics

## Motivation

LLM agents often select forecasting models without understanding the structural properties of the underlying time series.

This tool provides diagnostic metadata that can help agents reason about appropriate model choices before building forecasting pipelines.

## Example Usage

An example script (`examples/diagnostics_demo.py`) demonstrates the tool using the AirPassengers dataset from sktime.

## Potential Use

This tool can support the **Agentic Forecaster** idea by enabling agents to select compatible forecasting estimators based on the time series diagnostics.