### PR TITLE
Add recommend_estimators MCP tool for LLM-guided, constraint-aware estimator ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,31 @@ Search estimators by name or description using text query.
 
 ---
 
+#### `recommend_estimators`
+Recommend estimators for an LLM/user request using hard constraints and soft preferences.
+
+**Arguments:**
+- `query` (optional): Natural-language requirement text
+- `task` (optional): Hard task filter
+- `required_tags` (optional): Hard capability constraints
+- `preferred_tags` (optional): Soft capability preferences for ranking
+- `limit` (optional): Maximum recommendations (default: 5)
+
+**Example:**
+```json
+{
+  "query": "Forecast monthly sales with prediction intervals and missing values",
+  "preferred_tags": {
+    "capability:pred_int": true
+  },
+  "limit": 5
+}
+```
+
+**Returns:** Ranked recommendations with score and rationale per estimator.
+
+---
+
 #### 3. `describe_estimator`
 Get detailed information about a specific estimator's capabilities.
 

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -141,6 +141,20 @@ Here are some standalone examples of using specific tools.
 }
 ```
 
+**Recommend Estimators (LLM-friendly)**
+```json
+{
+  "name": "recommend_estimators",
+  "arguments": {
+    "query": "Forecast monthly sales with prediction intervals and missing values",
+    "preferred_tags": {
+      "capability:pred_int": true
+    },
+    "limit": 5
+  }
+}
+```
+
 **Search by Name**
 ```json
 {

--- a/examples/02_llm_query_simulation.py
+++ b/examples/02_llm_query_simulation.py
@@ -24,6 +24,7 @@ from sktime_mcp.tools.describe_estimator import describe_estimator_tool, search_
 from sktime_mcp.tools.fit_predict import fit_predict_tool
 from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 from sktime_mcp.tools.list_estimators import list_estimators_tool
+from sktime_mcp.tools.recommend_estimators import recommend_estimators_tool
 
 
 def print_llm_thought(thought: str):
@@ -252,6 +253,41 @@ def simulate_query_5():
         print(f"   - Transformation: {transformers['total']} estimators")
 
 
+def simulate_query_6():
+    """
+    Query: "Recommend a forecasting model for missing data with intervals"
+    """
+    print("\n" + "=" * 70)
+    print("  QUERY 6: LLM-Oriented Recommendation")
+    print("=" * 70)
+    print('\nUser: "Recommend a forecasting model for missing data with intervals"')
+
+    print_llm_thought("I will ask for ranked recommendations with transparent rationale")
+    print_tool_call(
+        "recommend_estimators",
+        {
+            "query": "forecast monthly sales with prediction intervals and missing values",
+            "preferred_tags": {"capability:pred_int": True},
+            "limit": 3,
+        },
+    )
+
+    result = recommend_estimators_tool(
+        query="forecast monthly sales with prediction intervals and missing values",
+        preferred_tags={"capability:pred_int": True},
+        limit=3,
+    )
+    print_result(result)
+
+    print("\n🤖 LLM Response:")
+    if result["success"] and result["recommendations"]:
+        print("   Top recommendations:")
+        for rec in result["recommendations"]:
+            print(f"   - {rec['name']} (score={rec['score']})")
+    else:
+        print("   No recommendations matched your constraints.")
+
+
 def main():
     print("\n" + "🤖" * 30)
     print("  sktime-mcp: LLM Query Simulation Demo")
@@ -264,6 +300,7 @@ def main():
     simulate_query_3()  # Validate pipeline
     simulate_query_4()  # Semantic search
     simulate_query_5()  # Task comparison
+    simulate_query_6()  # Ranked recommendations
 
     print("\n" + "=" * 70)
     print("  ✅ All LLM Query Simulations Complete!")
@@ -273,7 +310,8 @@ def main():
     print("  2. Registry provides ground truth about capabilities")
     print("  3. Tag-based filtering enables constraint satisfaction")
     print("  4. Pipeline validation prevents invalid compositions")
-    print("  5. Handle-based execution is safe and reproducible")
+    print("  5. Ranked recommendations improve agentic decision-making")
+    print("  6. Handle-based execution is safe and reproducible")
 
 
 if __name__ == "__main__":

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -27,6 +27,7 @@ from sktime_mcp.tools.describe_estimator import (
     describe_estimator_tool,
     search_estimators_tool,
 )
+from sktime_mcp.tools.recommend_estimators import recommend_estimators_tool
 from sktime_mcp.tools.fit_predict import (
     fit_predict_async_tool,
     fit_predict_tool,
@@ -315,6 +316,39 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["query"],
+            },
+        ),
+        Tool(
+            name="recommend_estimators",
+            description=(
+                "Recommend estimators for an LLM/user request using hard constraints "
+                "(task/required_tags) and soft preferences (preferred_tags)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Optional natural-language requirement text",
+                    },
+                    "task": {
+                        "type": "string",
+                        "description": "Optional hard task filter",
+                    },
+                    "required_tags": {
+                        "type": "object",
+                        "description": "Hard capability constraints",
+                    },
+                    "preferred_tags": {
+                        "type": "object",
+                        "description": "Soft capability preferences used in ranking",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum recommendations to return (default: 5)",
+                        "default": 5,
+                    },
+                },
             },
         ),
         Tool(
@@ -651,6 +685,14 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             result = search_estimators_tool(
                 arguments["query"],
                 arguments.get("limit", 20),
+            )
+        elif name == "recommend_estimators":
+            result = recommend_estimators_tool(
+                query=arguments.get("query"),
+                task=arguments.get("task"),
+                required_tags=arguments.get("required_tags"),
+                preferred_tags=arguments.get("preferred_tags"),
+                limit=arguments.get("limit", 5),
             )
         elif name == "export_code":
             result = export_code_tool(

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -9,10 +9,12 @@ from sktime_mcp.tools.format_tools import (
 )
 from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 from sktime_mcp.tools.list_estimators import list_estimators_tool
+from sktime_mcp.tools.recommend_estimators import recommend_estimators_tool
 from sktime_mcp.tools.save_model import save_model_tool
 
 __all__ = [
     "list_estimators_tool",
+    "recommend_estimators_tool",
     "describe_estimator_tool",
     "instantiate_estimator_tool",
     "fit_predict_tool",

--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any
 
 from sktime.forecasting.model_evaluation import evaluate
-from sktime.forecasting.model_selection import ExpandingWindowSplitter
+from sktime.split import ExpandingWindowSplitter
 
 from sktime_mcp.runtime.executor import get_executor
 
@@ -47,10 +47,12 @@ def evaluate_estimator_tool(
 
     try:
         n = len(y)
-        # Handle small datasets gracefully
-        initial_window = max(int(n * 0.5), n - cv_folds * 2)
-        if initial_window < 1:
-            initial_window = 1
+        if cv_folds <= 0:
+            return {"success": False, "error": "cv_folds must be a positive integer"}
+
+        # Configure splitter so it runs approximately `cv_folds` folds with fh=[1].
+        # If dataset is too small, ExpandingWindowSplitter will run fewer folds.
+        initial_window = max(1, n - cv_folds)
 
         cv = ExpandingWindowSplitter(initial_window=initial_window, step_length=1, fh=[1])
 
@@ -66,7 +68,7 @@ def evaluate_estimator_tool(
         return {
             "success": True,
             "results": metrics,
-            "cv_folds_run": len(metrics)
+            "cv_folds_run": len(metrics),
         }
     except Exception as e:
         logger.exception("Error during evaluate")

--- a/src/sktime_mcp/tools/recommend_estimators.py
+++ b/src/sktime_mcp/tools/recommend_estimators.py
@@ -1,0 +1,168 @@
+"""
+recommend_estimators tool for sktime MCP.
+
+Provides a lightweight recommendation layer for LLM agents by combining:
+- hard constraints (task + required tags)
+- soft preferences (preferred tags)
+- query keyword inference
+"""
+
+from typing import Any, Optional
+
+from sktime_mcp.registry.interface import EstimatorNode, get_registry
+
+
+def _infer_constraints_from_query(query: str) -> dict[str, Any]:
+    """Infer task and tag constraints from free-text query."""
+    text = query.lower()
+
+    inferred_task = None
+    if any(token in text for token in ["forecast", "forecasting", "horizon"]):
+        inferred_task = "forecasting"
+    elif any(token in text for token in ["classify", "classification", "classifier"]):
+        inferred_task = "classification"
+    elif any(token in text for token in ["regression", "regressor", "predict value"]):
+        inferred_task = "regression"
+    elif any(token in text for token in ["transform", "preprocess", "transformation"]):
+        inferred_task = "transformation"
+
+    inferred_required_tags: dict[str, Any] = {}
+
+    if any(token in text for token in ["prediction interval", "interval", "uncertainty"]):
+        inferred_required_tags["capability:pred_int"] = True
+
+    if any(token in text for token in ["missing values", "missing data", "na values"]):
+        inferred_required_tags["handles-missing-data"] = True
+
+    if "multivariate" in text:
+        inferred_required_tags["capability:multivariate"] = True
+
+    return {
+        "task": inferred_task,
+        "required_tags": inferred_required_tags,
+    }
+
+
+def _tokenize_query(query: str) -> list[str]:
+    """Tokenize user query for lightweight lexical scoring."""
+    return [token for token in query.lower().split() if len(token) >= 4]
+
+
+def _score_estimator(
+    node: EstimatorNode,
+    preferred_tags: dict[str, Any],
+    query_tokens: list[str],
+) -> tuple[int, dict[str, Any]]:
+    """Score estimator with transparent score breakdown."""
+    score = 0
+
+    matched_preferences = []
+    for tag_name, expected_value in preferred_tags.items():
+        if node.tags.get(tag_name) == expected_value:
+            score += 3
+            matched_preferences.append(tag_name)
+
+    name_matches = []
+    for token in query_tokens:
+        if token in node.name.lower():
+            score += 2
+            name_matches.append(token)
+
+    doc_matches = []
+    if node.docstring:
+        doc_text = node.docstring.lower()
+        for token in query_tokens:
+            if token in doc_text:
+                score += 1
+                doc_matches.append(token)
+
+    rationale = {
+        "matched_preferred_tags": sorted(set(matched_preferences)),
+        "name_keyword_matches": sorted(set(name_matches)),
+        "doc_keyword_matches": sorted(set(doc_matches)),
+    }
+    return score, rationale
+
+
+def recommend_estimators_tool(
+    query: Optional[str] = None,
+    task: Optional[str] = None,
+    required_tags: Optional[dict[str, Any]] = None,
+    preferred_tags: Optional[dict[str, Any]] = None,
+    limit: int = 5,
+) -> dict[str, Any]:
+    """
+    Recommend estimators using hard constraints and soft preferences.
+
+    Args:
+        query: Optional natural-language requirement text.
+        task: Optional hard task filter.
+        required_tags: Optional hard capability constraints.
+        preferred_tags: Optional soft capability preferences used for ranking.
+        limit: Maximum number of recommendations to return.
+
+    Returns:
+        Dictionary with ranked recommendations and score explanations.
+    """
+    if limit <= 0:
+        return {
+            "success": False,
+            "error": "limit must be a positive integer.",
+        }
+
+    inferred = {"task": None, "required_tags": {}}
+    if query:
+        inferred = _infer_constraints_from_query(query)
+
+    effective_task = task or inferred["task"]
+    effective_required_tags = dict(inferred["required_tags"])
+    if required_tags:
+        effective_required_tags.update(required_tags)
+
+    effective_preferred_tags = preferred_tags or {}
+
+    registry = get_registry()
+
+    try:
+        candidates = registry.get_all_estimators(
+            task=effective_task,
+            tags=effective_required_tags if effective_required_tags else None,
+        )
+
+        query_tokens = _tokenize_query(query) if query else []
+
+        scored = []
+        for node in candidates:
+            score, rationale = _score_estimator(node, effective_preferred_tags, query_tokens)
+            scored.append(
+                {
+                    "name": node.name,
+                    "task": node.task,
+                    "module": node.module,
+                    "score": score,
+                    "rationale": rationale,
+                    "tags": node.tags,
+                }
+            )
+
+        scored.sort(key=lambda item: (-item["score"], item["name"]))
+        recommendations = scored[:limit]
+
+        return {
+            "success": True,
+            "recommendations": recommendations,
+            "count": len(recommendations),
+            "total_candidates": len(scored),
+            "applied_filters": {
+                "task": effective_task,
+                "required_tags": effective_required_tags,
+                "preferred_tags": effective_preferred_tags,
+            },
+            "inferred_from_query": inferred,
+            "query": query,
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+        }

--- a/tests/test_recommend_estimators.py
+++ b/tests/test_recommend_estimators.py
@@ -1,0 +1,55 @@
+"""Tests for recommend_estimators MCP tool."""
+
+import sys
+
+sys.path.insert(0, "src")
+
+from sktime_mcp.tools.recommend_estimators import recommend_estimators_tool
+
+
+class TestRecommendEstimatorsTool:
+    """Behavior tests for recommendation workflow."""
+
+    def test_invalid_limit_rejected(self):
+        """limit must be a positive integer."""
+        result = recommend_estimators_tool(limit=0)
+        assert result["success"] is False
+        assert "limit" in result["error"]
+
+    def test_query_infers_forecasting_constraints(self):
+        """Free-text query should infer common forecasting constraints."""
+        result = recommend_estimators_tool(
+            query="Need monthly forecasting with prediction intervals and missing values",
+            limit=3,
+        )
+
+        assert result["success"] is True
+        assert result["inferred_from_query"]["task"] == "forecasting"
+        assert result["inferred_from_query"]["required_tags"].get("capability:pred_int") is True
+        assert result["count"] <= 3
+
+    def test_required_tags_are_applied(self):
+        """All returned recommendations must satisfy hard tag filters."""
+        result = recommend_estimators_tool(
+            task="forecasting",
+            required_tags={"capability:pred_int": True},
+            limit=5,
+        )
+
+        assert result["success"] is True
+        for rec in result["recommendations"]:
+            assert rec["task"] == "forecasting"
+            assert rec["tags"].get("capability:pred_int") is True
+
+    def test_scores_are_sorted_descending(self):
+        """Returned recommendations should be sorted by score descending."""
+        result = recommend_estimators_tool(
+            query="forecast with intervals",
+            task="forecasting",
+            preferred_tags={"capability:pred_int": True},
+            limit=5,
+        )
+
+        assert result["success"] is True
+        scores = [rec["score"] for rec in result["recommendations"]]
+        assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## Summary

This PR adds a new agentic/LLM-facing MCP capability: `recommend_estimators`, enabling ranked model recommendations from natural-language requirements plus explicit constraints.

The tool combines:
- **Hard filters**: `task`, `required_tags`
- **Soft ranking**: `preferred_tags`
- **Lightweight query inference** for common forecasting, classification, regression, and transformation intents

Recommendations return **transparent scoring rationale per estimator** to support agent decision traces.

MCP integration is included end-to-end (tool registration + dispatch), along with docs and example flow updates.

New tests cover:
- Invalid input handling  
- Query inference  
- Hard-tag filtering  
- Descending score ordering  

---

## Additional Fix in this PR

- Fixes cross-validation fold alignment in evaluation flow so `cv_folds_run` matches requested folds when feasible  
- Updates deprecated splitter import path  
- Adds guard for non-positive `cv_folds`  

---

## Validation

- Ran targeted checks for recommendation + core tools  
- Ran full suite: **75 passed, 2 warnings**