### PR TITLE
Add coordination router for MCP tools

### DIFF
--- a/examples/router_demo.py
+++ b/examples/router_demo.py
@@ -1,0 +1,13 @@
+from sktime_mcp.coordination.router import MCPToolRouter
+
+router = MCPToolRouter()
+
+series = [112,118,132,129,121,135,148,148,136,119,104,118]
+
+result = router.route(
+    "get_timeseries_diagnostics",
+    series
+)
+
+print("Diagnostics:", result)
+print("Stored memory:", router.memory.get("last_diagnostics"))

--- a/src/sktime_mcp/coordination/router.py
+++ b/src/sktime_mcp/coordination/router.py
@@ -1,0 +1,40 @@
+from sktime_mcp.tools import get_timeseries_diagnostics
+
+
+class MCPMemory:
+    """
+    Shared memory for MCP workflows.
+    """
+
+    def __init__(self):
+        self.memory = {}
+
+    def store(self, key, value):
+        self.memory[key] = value
+
+    def get(self, key):
+        return self.memory.get(key)
+
+    def clear(self):
+        self.memory = {}
+
+
+class MCPToolRouter:
+    """
+    Simple router that executes tools and stores results.
+    """
+
+    def __init__(self):
+        self.memory = MCPMemory()
+
+    def route(self, tool_name, payload):
+
+        if tool_name == "get_timeseries_diagnostics":
+
+            result = get_timeseries_diagnostics(payload)
+
+            self.memory.store("last_diagnostics", result)
+
+            return result
+
+        raise ValueError(f"Unknown tool: {tool_name}")

--- a/src/sktime_mcp/examples/diagnostics_demo.py
+++ b/src/sktime_mcp/examples/diagnostics_demo.py
@@ -1,0 +1,10 @@
+from sktime.datasets import load_airline
+from sktime_mcp.tools import get_timeseries_diagnostics
+
+# load example dataset
+y = load_airline()
+
+diagnostics = get_timeseries_diagnostics(y)
+
+print("Time Series Diagnostics")
+print(diagnostics)

--- a/src/sktime_mcp/test_diag.py
+++ b/src/sktime_mcp/test_diag.py
@@ -1,0 +1,5 @@
+from sktime_mcp.tools import get_timeseries_diagnostics
+
+series = [112,118,132,129,121,135,148,148,136,119,104,118]
+
+print(get_timeseries_diagnostics(series))

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -3,6 +3,7 @@
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.fit_predict import fit_predict_tool
+from .timeseries_diagnostics import get_timeseries_diagnostics
 from sktime_mcp.tools.format_tools import (
     auto_format_on_load_tool,
     format_time_series_tool,

--- a/src/sktime_mcp/tools/timeseries_diagnostics.py
+++ b/src/sktime_mcp/tools/timeseries_diagnostics.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from statsmodels.tsa.stattools import adfuller
+from sktime.utils.seasonality import autocorrelation_seasonality_test
+
+
+def get_timeseries_diagnostics(series: list):
+
+    series = pd.Series(series)
+
+    diagnostics = {}
+
+    diagnostics["length"] = len(series)
+    diagnostics["missing_values"] = int(series.isna().sum())
+
+    # stationarity
+    try:
+        adf = adfuller(series.dropna())
+        diagnostics["is_stationary"] = adf[1] < 0.05
+        diagnostics["adf_p_value"] = float(adf[1])
+    except Exception:
+        diagnostics["is_stationary"] = None
+        diagnostics["adf_p_value"] = None
+
+    # seasonality
+    try:
+        seasonal = autocorrelation_seasonality_test(series.dropna(), sp=12)
+        diagnostics["is_seasonal"] = bool(seasonal)
+        diagnostics["seasonal_period"] = 12 if seasonal else None
+    except Exception:
+        diagnostics["is_seasonal"] = None
+        diagnostics["seasonal_period"] = None
+
+    stats = series.describe()
+
+    diagnostics["stats"] = {
+        "mean": float(stats["mean"]),
+        "std": float(stats["std"]),
+        "min": float(stats["min"]),
+        "max": float(stats["max"]),
+    }
+
+    diagnostics["model_hints"] = {}
+
+    if diagnostics["is_seasonal"]:
+        diagnostics["model_hints"]["recommended_models"] = ["SARIMA", "ETS"]
+    else:
+        diagnostics["model_hints"]["recommended_models"] = ["ARIMA"]
+
+    if diagnostics["is_stationary"] is False:
+        diagnostics["model_hints"]["needs_differencing"] = True
+
+    return diagnostics


### PR DESCRIPTION
This PR introduces a lightweight coordination router for MCP tools.

The router enables:
- shared memory between tool calls
- structured routing of tool executions
- simple support for multi-step workflows

This allows agents to chain multiple MCP tools while maintaining state.
For example: diagnostics → model selection → forecasting.

A demo script is included in examples/router_demo.py.