### PR TITLE
Add get_agent_trace MCP tool for structured agent workflow tracing

### DIFF
--- a/examples/csv_example.py
+++ b/examples/csv_example.py
@@ -4,7 +4,7 @@ Example: Loading data from a CSV file.
 This example demonstrates how to use the sktime-mcp data loading
 functionality with CSV files.
 """
-
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -19,8 +19,9 @@ sample_data = pd.DataFrame(
         "temperature": [20 + (i % 10) for i in range(100)],
     }
 )
+tmp_dir = Path(tempfile.gettempdir())
 
-csv_path = Path("/tmp/sample_sales_data.csv")
+csv_path = tmp_dir / "sample_sales_data.csv"
 sample_data.to_csv(csv_path, index=False)
 print(f"Created sample CSV file: {csv_path}")
 print(f"File size: {csv_path.stat().st_size} bytes")
@@ -90,7 +91,8 @@ print("\n" + "=" * 60)
 print("Loading data from TSV file")
 print("=" * 60)
 
-tsv_path = Path("/tmp/sample_sales_data.tsv")
+tmp_dir = Path(tempfile.gettempdir())
+tsv_path = tmp_dir / "sample_sales_data.tsv"
 sample_data.to_csv(tsv_path, sep="\t", index=False)
 print(f"Created sample TSV file: {tsv_path}")
 

--- a/examples/router_demo.py
+++ b/examples/router_demo.py
@@ -1,0 +1,13 @@
+from sktime_mcp.coordination.router import MCPToolRouter
+
+router = MCPToolRouter()
+
+series = [112,118,132,129,121,135,148,148,136,119,104,118]
+
+result = router.route(
+    "get_timeseries_diagnostics",
+    series
+)
+
+print("Diagnostics:", result)
+print("Stored memory:", router.memory.get("last_diagnostics"))

--- a/examples/sql_example.py
+++ b/examples/sql_example.py
@@ -4,7 +4,7 @@ Example: Loading data from a SQL database.
 This example demonstrates how to use the sktime-mcp data loading
 functionality with SQL databases (SQLite in this example).
 """
-
+import tempfile
 import sqlite3
 from pathlib import Path
 
@@ -13,7 +13,9 @@ import pandas as pd
 from sktime_mcp.runtime.executor import get_executor
 
 # Create a sample SQLite database
-db_path = Path("/tmp/sample_sales.db")
+tmp_dir = Path(tempfile.gettempdir())
+
+db_path = tmp_dir / "sample_sales.db"
 
 # Create sample data
 sample_data = pd.DataFrame(

--- a/src/sktime_mcp/coordination/router.py
+++ b/src/sktime_mcp/coordination/router.py
@@ -1,0 +1,40 @@
+from sktime_mcp.tools import get_timeseries_diagnostics
+
+
+class MCPMemory:
+    """
+    Shared memory for MCP workflows.
+    """
+
+    def __init__(self):
+        self.memory = {}
+
+    def store(self, key, value):
+        self.memory[key] = value
+
+    def get(self, key):
+        return self.memory.get(key)
+
+    def clear(self):
+        self.memory = {}
+
+
+class MCPToolRouter:
+    """
+    Simple router that executes tools and stores results.
+    """
+
+    def __init__(self):
+        self.memory = MCPMemory()
+
+    def route(self, tool_name, payload):
+
+        if tool_name == "get_timeseries_diagnostics":
+
+            result = get_timeseries_diagnostics(payload)
+
+            self.memory.store("last_diagnostics", result)
+
+            return result
+
+        raise ValueError(f"Unknown tool: {tool_name}")

--- a/src/sktime_mcp/coordination/router.py
+++ b/src/sktime_mcp/coordination/router.py
@@ -1,3 +1,6 @@
+import time
+
+from sktime_mcp.tools.get_agent_trace import record_trace
 from sktime_mcp.tools import get_timeseries_diagnostics
 
 
@@ -10,30 +13,63 @@ class MCPMemory:
         self.memory = {}
 
     def store(self, key, value):
+        """Store a value in memory."""
         self.memory[key] = value
 
     def get(self, key):
+        """Retrieve a value from memory."""
         return self.memory.get(key)
 
     def clear(self):
+        """Clear memory."""
         self.memory = {}
 
 
 class MCPToolRouter:
     """
-    Simple router that executes tools and stores results.
+    Simple router that executes MCP tools and stores results.
+    Also records execution traces for debugging agent workflows.
     """
 
     def __init__(self):
         self.memory = MCPMemory()
 
-    def route(self, tool_name, payload):
+    def route(self, session_id: str, tool_name: str, payload):
+        """
+        Execute a tool and record its trace.
+
+        Parameters
+        ----------
+        session_id : str
+            Unique identifier for the agent session.
+        tool_name : str
+            Name of the tool to execute.
+        payload : dict
+            Input payload for the tool.
+
+        Returns
+        -------
+        dict
+            Tool execution result.
+        """
+
+        start_time = time.time()
 
         if tool_name == "get_timeseries_diagnostics":
 
             result = get_timeseries_diagnostics(payload)
 
+            # store result in shared memory
             self.memory.store("last_diagnostics", result)
+
+            # record trace
+            record_trace(
+                session_id=session_id,
+                tool=tool_name,
+                input_data=payload,
+                output_data=result,
+                start_time=start_time,
+            )
 
             return result
 

--- a/src/sktime_mcp/examples/diagnostics_demo.py
+++ b/src/sktime_mcp/examples/diagnostics_demo.py
@@ -1,0 +1,10 @@
+from sktime.datasets import load_airline
+from sktime_mcp.tools import get_timeseries_diagnostics
+
+# load example dataset
+y = load_airline()
+
+diagnostics = get_timeseries_diagnostics(y)
+
+print("Time Series Diagnostics")
+print(diagnostics)

--- a/src/sktime_mcp/test_diag.py
+++ b/src/sktime_mcp/test_diag.py
@@ -1,0 +1,5 @@
+from sktime_mcp.tools import get_timeseries_diagnostics
+
+series = [112,118,132,129,121,135,148,148,136,119,104,118]
+
+print(get_timeseries_diagnostics(series))

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -11,7 +11,7 @@ from sktime_mcp.tools.format_tools import (
 from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 from sktime_mcp.tools.list_estimators import list_estimators_tool
 from sktime_mcp.tools.save_model import save_model_tool
-
+from .get_agent_trace import get_agent_trace, record_trace
 __all__ = [
     "list_estimators_tool",
     "describe_estimator_tool",

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -3,6 +3,7 @@
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.fit_predict import fit_predict_tool
+from .timeseries_diagnostics import get_timeseries_diagnostics
 from sktime_mcp.tools.format_tools import (
     auto_format_on_load_tool,
     format_time_series_tool,

--- a/src/sktime_mcp/tools/get_agent_trace.py
+++ b/src/sktime_mcp/tools/get_agent_trace.py
@@ -1,0 +1,55 @@
+"""
+MCP Tool: get_agent_trace
+
+Provides a structured execution trace for an agent session.
+Useful for debugging multi-step agent workflows involving MCP tools.
+"""
+import time
+from datetime import datetime
+from typing import Dict, Any, List
+
+# Simple in-memory trace store
+TRACE_STORE: Dict[str, List[Dict[str, Any]]] = {}
+
+
+def record_trace(session_id: str, tool: str, input_data: dict, output_data: dict, start_time: float):
+    """
+    Record a step in an agent session.
+    """
+
+    end_time = time.time()
+
+    if session_id not in TRACE_STORE:
+        TRACE_STORE[session_id] = []
+
+    step = {
+        "step": len(TRACE_STORE[session_id]) + 1,
+        "tool": tool,
+        "input": input_data,
+        "output": output_data,
+        "timestamp": datetime.utcnow().isoformat(),
+        "execution_time_seconds": round(end_time - start_time, 4),
+    }
+
+    TRACE_STORE[session_id].append(step)
+
+
+def get_agent_trace(session_id: str) -> Dict[str, Any]:
+    """
+    Retrieve the full execution trace for a session.
+
+    Parameters
+    ----------
+    session_id : str
+        The agent session identifier.
+
+    Returns
+    -------
+    dict
+        Structured trace of tool calls for the session.
+    """
+
+    return {
+        "session_id": session_id,
+        "steps": TRACE_STORE.get(session_id, []),
+    }

--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -258,7 +258,7 @@ def load_model_tool(path: str) -> dict[str, Any]:
     Args:
         path: Local directory path or MLflow URI to the saved model.
               Examples:
-                - "/tmp/my_arima_model"
+               str(Path(tempfile.gettempdir()) / "my_arima_model")
                 - "runs:/<run_id>/model"
                 - "mlflow-artifacts:/<run_id>/artifacts/model"
                 - "models:/<model_name>/<version>"

--- a/src/sktime_mcp/tools/timeseries_diagnostics.py
+++ b/src/sktime_mcp/tools/timeseries_diagnostics.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from statsmodels.tsa.stattools import adfuller
+from sktime.utils.seasonality import autocorrelation_seasonality_test
+
+
+def get_timeseries_diagnostics(series: list):
+
+    series = pd.Series(series)
+
+    diagnostics = {}
+
+    diagnostics["length"] = len(series)
+    diagnostics["missing_values"] = int(series.isna().sum())
+
+    # stationarity
+    try:
+        adf = adfuller(series.dropna())
+        diagnostics["is_stationary"] = adf[1] < 0.05
+        diagnostics["adf_p_value"] = float(adf[1])
+    except Exception:
+        diagnostics["is_stationary"] = None
+        diagnostics["adf_p_value"] = None
+
+    # seasonality
+    try:
+        seasonal = autocorrelation_seasonality_test(series.dropna(), sp=12)
+        diagnostics["is_seasonal"] = bool(seasonal)
+        diagnostics["seasonal_period"] = 12 if seasonal else None
+    except Exception:
+        diagnostics["is_seasonal"] = None
+        diagnostics["seasonal_period"] = None
+
+    stats = series.describe()
+
+    diagnostics["stats"] = {
+        "mean": float(stats["mean"]),
+        "std": float(stats["std"]),
+        "min": float(stats["min"]),
+        "max": float(stats["max"]),
+    }
+
+    diagnostics["model_hints"] = {}
+
+    if diagnostics["is_seasonal"]:
+        diagnostics["model_hints"]["recommended_models"] = ["SARIMA", "ETS"]
+    else:
+        diagnostics["model_hints"]["recommended_models"] = ["ARIMA"]
+
+    if diagnostics["is_stationary"] is False:
+        diagnostics["model_hints"]["needs_differencing"] = True
+
+    return diagnostics


### PR DESCRIPTION
<This PR introduces a new MCP tool `get_agent_trace` for structured tracing
of multi-step agent workflows.

The tool records:
- tool name
- inputs
- outputs
- timestamps
- execution time

Tracing is automatically integrated with the MCP router, enabling
observability for agent pipelines such as diagnostics → model selection → forecasting.
