### PR TITLE
fix: replace hardcoded /tmp paths with tempfile.gettempdir()

### DIFF
--- a/examples/csv_example.py
+++ b/examples/csv_example.py
@@ -5,6 +5,7 @@ This example demonstrates how to use the sktime-mcp data loading
 functionality with CSV files.
 """
 
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -20,7 +21,7 @@ sample_data = pd.DataFrame(
     }
 )
 
-csv_path = Path("/tmp/sample_sales_data.csv")
+csv_path = Path(tempfile.gettempdir()) / "sample_sales_data.csv"
 sample_data.to_csv(csv_path, index=False)
 print(f"Created sample CSV file: {csv_path}")
 print(f"File size: {csv_path.stat().st_size} bytes")
@@ -90,7 +91,7 @@ print("\n" + "=" * 60)
 print("Loading data from TSV file")
 print("=" * 60)
 
-tsv_path = Path("/tmp/sample_sales_data.tsv")
+tsv_path = Path(tempfile.gettempdir()) / "sample_sales_data.tsv"
 sample_data.to_csv(tsv_path, sep="\t", index=False)
 print(f"Created sample TSV file: {tsv_path}")
 

--- a/examples/sql_example.py
+++ b/examples/sql_example.py
@@ -6,6 +6,7 @@ functionality with SQL databases (SQLite in this example).
 """
 
 import sqlite3
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -13,7 +14,7 @@ import pandas as pd
 from sktime_mcp.runtime.executor import get_executor
 
 # Create a sample SQLite database
-db_path = Path("/tmp/sample_sales.db")
+db_path = Path(tempfile.gettempdir()) / "sample_sales.db"
 
 # Create sample data
 sample_data = pd.DataFrame(

--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -258,7 +258,7 @@ def load_model_tool(path: str) -> dict[str, Any]:
     Args:
         path: Local directory path or MLflow URI to the saved model.
               Examples:
-                - "/tmp/my_arima_model"
+                - "/tmp/my_arima_model" (Linux/macOS) or "C:\\Temp\\my_arima_model" (Windows)
                 - "runs:/<run_id>/model"
                 - "mlflow-artifacts:/<run_id>/artifacts/model"
                 - "models:/<model_name>/<version>"


### PR DESCRIPTION
#### Reference Issue
Fixes #224

#### What does this implement/fix? Explain your changes.
The example scripts `examples/csv_example.py` and `examples/sql_example.py`
used hardcoded `/tmp/` paths which fail on Windows (no such directory).
Also updated a docstring example path in `src/sktime_mcp/tools/instantiate.py`.

Changes:
- Added `import tempfile` to both example files
- Replaced all `Path("/tmp/filename")` with `Path(tempfile.gettempdir()) / "filename"`
- Updated the docstring in `instantiate.py` to show platform-aware path examples

`tempfile.gettempdir()` resolves correctly on Linux (`/tmp`), macOS (`/var/folders/...`),
and Windows (`C:\Users\<user>\AppData\Local\Temp`).

#### Does your contribution introduce a new dependency? If yes, which one?
No. `tempfile` is part of the Python standard library.

#### What should a reviewer concentrate their feedback on?
The three changed files — confirm `tempfile.gettempdir()` is the preferred
cross-platform approach over e.g. `pathlib.Path(tempfile.mkdtemp())`.

Tested locally on Windows 11 — paths resolve correctly.
Checklist — check these boxes:

 - [x] Unit tests pass locally (no new tests needed for example scripts)