### PR TITLE
fix: use get_params() for deep parameter key validation in instantiate_estimator

### DIFF
--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -79,22 +79,36 @@ def _validate_params(
                 "warnings": warnings,
             }
 
-    # check if keys match known hyperparameters (warn, don't error)
+    # deep validation: check keys against estimator's actual get_params()
     if estimator_name and params:
         registry = get_registry()
         node = registry.get_estimator_by_name(estimator_name)
 
-        if node is not None and node.hyperparameters:
-            known_keys = set(node.hyperparameters.keys())
-            provided_keys = set(params.keys())
-            unknown_keys = provided_keys - known_keys
+        if node is not None:
+            valid_keys = None
 
-            if unknown_keys:
-                warnings.append(
-                    f"Unknown parameter(s) for {estimator_name}: "
-                    f"{sorted(unknown_keys)}. "
-                    f"Known parameters: {sorted(known_keys)}"
-                )
+            # prefer get_params() from a default instance — more reliable than
+            # registry metadata which is derived from __init__ signatures only
+            try:
+                cls = node.estimator_class
+                valid_keys = set(cls().get_params(deep=False).keys())
+            except Exception:
+                # fall back to registry hyperparameter keys if instantiation fails
+                if node.hyperparameters:
+                    valid_keys = set(node.hyperparameters.keys())
+
+            if valid_keys is not None:
+                unknown_keys = set(params.keys()) - valid_keys
+                if unknown_keys:
+                    return {
+                        "valid": False,
+                        "error": (
+                            f"Unknown parameter(s) for {estimator_name}: "
+                            f"{sorted(unknown_keys)}. "
+                            f"Valid parameters are: {sorted(valid_keys)}"
+                        ),
+                        "warnings": warnings,
+                    }
 
     return {"valid": True, "warnings": warnings}
 

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -73,15 +73,38 @@ class TestValidateParams:
         assert result["valid"] is False
         assert "Unsupported type" in result["error"]
 
-    def test_unknown_key_produces_warning(self):
-        """Unknown param key should pass validation but produce a warning."""
+    def test_unknown_key_returns_error(self):
+        """Unknown param key must return valid=False with a helpful error (issue #219)."""
         result = _validate_params(
             {"nonexistent_param_xyz": 1},
             estimator_name="NaiveForecaster",
         )
+        assert result["valid"] is False
+        assert "nonexistent_param_xyz" in result["error"]
+        assert "Valid parameters" in result["error"]
+
+    def test_valid_key_passes(self):
+        """Known param key for NaiveForecaster should pass deep validation."""
+        result = _validate_params(
+            {"strategy": "last"},
+            estimator_name="NaiveForecaster",
+        )
         assert result["valid"] is True
-        assert len(result["warnings"]) > 0
-        assert "nonexistent_param_xyz" in result["warnings"][0]
+
+    def test_typo_in_key_returns_error_with_valid_list(self):
+        """Typo'd param key should fail and list valid alternatives."""
+        result = _validate_params(
+            {"window_leangth": 5},  # typo: leangth vs length
+            estimator_name="NaiveForecaster",
+        )
+        assert result["valid"] is False
+        assert "window_leangth" in result["error"]
+        assert "Valid parameters" in result["error"]
+
+    def test_no_estimator_name_skips_deep_validation(self):
+        """Without estimator_name, any string-keyed dict is valid."""
+        result = _validate_params({"anything": 1})
+        assert result["valid"] is True
 
 
 class TestInstantiateEstimatorValidation:
@@ -104,6 +127,15 @@ class TestInstantiateEstimatorValidation:
         result = instantiate_estimator_tool("NaiveForecaster", {"fn": print})
         assert result["success"] is False
         assert "Unsupported type" in result["error"]
+
+    def test_unknown_key_returns_error_with_valid_list(self):
+        """Unknown param key should return error listing valid params (issue #219)."""
+        result = instantiate_estimator_tool(
+            "NaiveForecaster", {"nonexistent_param_xyz": 1}
+        )
+        assert result["success"] is False
+        assert "nonexistent_param_xyz" in result["error"]
+        assert "Valid parameters" in result["error"]
 
 
 class TestPipelineParamsValidation:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #219. See also #3 (original type validation PR).

#### What does this implement/fix? Explain your changes.
Previously, `instantiate_estimator_tool` validated param *types* but not
param *keys*. Passing a typo'd key like `{"window_leangth": 5}` would
silently create a broken estimator with no feedback — especially problematic
in LLM workflows where the model can't recover from silent failures.

A partial fix existed (lines 82–97 of `instantiate.py`) that warned using
registry metadata derived from `__init__` signatures, but:
- It only warned, never errored
- Registry metadata can be incomplete or stale

**Fix:** Replaced the warning-only approach with a proper error using the
estimator's actual `get_params(deep=False)` output from a default instance.
This is the canonical sktime API for discovering valid parameters.

Fallback: if the class can't be instantiated with defaults, we fall back to
registry hyperparameter keys (existing behaviour) to avoid false negatives.

Unknown keys now return `success=False` with a message listing all valid
parameter names, e.g.:
Unknown parameter(s) for NaiveForecaster: ['window_leangth'].
Valid parameters are: ['sp', 'strategy', 'window_length']



#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Lines 82–111 of `instantiate.py` — the `get_params()` deep validation block.
- The fallback logic when `cls()` instantiation raises an exception.
- Whether changing from warning → error is the right severity, or if a
  stricter/looser approach is preferred.

Updated `tests/test_param_validation.py`:
- `test_unknown_key_produces_warning` → replaced with `test_unknown_key_returns_error`
- Added `test_valid_key_passes`, `test_typo_in_key_returns_error_with_valid_list`,
  `test_no_estimator_name_skips_deep_validation`
- Added `test_unknown_key_returns_error_with_valid_list` to `TestInstantiateEstimatorValidation`

All 38 tests pass locally.