### PR TITLE
fix: use <= in cleanup_old_jobs to handle zero-age boundary

### DIFF
--- a/src/sktime_mcp/runtime/jobs.py
+++ b/src/sktime_mcp/runtime/jobs.py
@@ -305,7 +305,7 @@ class JobManager:
         cutoff = datetime.now() - timedelta(hours=max_age_hours)
 
         with self.lock:
-            old_job_ids = [job_id for job_id, job in self.jobs.items() if job.created_at < cutoff]
+            old_job_ids = [job_id for job_id, job in self.jobs.items() if job.created_at <= cutoff]
 
             for job_id in old_job_ids:
                 del self.jobs[job_id]


### PR DESCRIPTION
## Problem
cleanup_old_jobs(max_age_hours=0) fails to remove a job created immediately before the call. The cutoff is computed as datetime.now(), and jobs created at that exact timestamp have created_at == cutoff, so the strict < comparison excludes them.

## Fix
Change < to <= so jobs with created_at == cutoff are also removed.

## Test
tests/test_background_jobs.py::test_cleanup_old_jobs now passes.

Applying to ESoC 2026 for the sktime agentic project. Happy to iterate based on maintainer feedback!
