### PR TITLE
fix: correct cv_folds count and update deprecated import in evaluate …

### DIFF
--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any
 
 from sktime.forecasting.model_evaluation import evaluate
-from sktime.forecasting.model_selection import ExpandingWindowSplitter
+from sktime.split import ExpandingWindowSplitter
 
 from sktime_mcp.runtime.executor import get_executor
 
@@ -47,10 +47,7 @@ def evaluate_estimator_tool(
 
     try:
         n = len(y)
-        # Handle small datasets gracefully
-        initial_window = max(int(n * 0.5), n - cv_folds * 2)
-        if initial_window < 1:
-            initial_window = 1
+        initial_window = max(1, n - cv_folds)
 
         cv = ExpandingWindowSplitter(initial_window=initial_window, step_length=1, fh=[1])
 


### PR DESCRIPTION
## Problem
`evaluate_estimator` ignores the `cv_folds` parameter — the actual number of folds run is approximately `cv_folds * 2` due to a wrong formula in `initial_window` calculation.

## Fix
Changed `initial_window = max(int(n * 0.5), n - cv_folds * 2)` to `initial_window = max(1, n - cv_folds)`, which produces exactly `cv_folds` splits.

updated the deprecated `ExpandingWindowSplitter` import from `sktime.forecasting.model_selection` to `sktime.split`.

## Test
`tests/test_evaluate.py::test_evaluate_estimator_tool` now passes.

Applying to ESoC 2026 for the sktime agentic project. Happy to iterate based on maintainer feedback!