### PR TITLE
fix: export_code generates private module import paths instead of pub…

### DIFF
--- a/src/sktime_mcp/tools/codegen.py
+++ b/src/sktime_mcp/tools/codegen.py
@@ -36,12 +36,20 @@ def _format_value(value: Any) -> str:
         return repr(value)
 
 
+def _get_public_module(module: str) -> str:
+    """Strip private submodule suffixes to get the public API import path."""
+    parts = module.split(".")
+    while parts and parts[-1].startswith("_"):
+        parts.pop()
+    return ".".join(parts)
+
+
 def _get_estimator_module(estimator_name: str) -> Optional[str]:
-    """Get the module path for an estimator."""
+    """Get the public module path for an estimator."""
     registry = get_registry()
     node = registry.get_estimator_by_name(estimator_name)
     if node and node.class_ref:
-        return node.class_ref.__module__
+        return _get_public_module(node.class_ref.__module__)
     return None
 
 
@@ -95,7 +103,7 @@ def _generate_pipeline_code(
         if not node:
             return {"success": False, "error": f"Unknown estimator in pipeline: {comp_name}"}
         component_tasks.append(node.task)
-        module = node.class_ref.__module__
+        module = _get_public_module(node.class_ref.__module__)
         imports.add(f"from {module} import {comp_name}")
 
     # Determine pipeline type


### PR DESCRIPTION
## Bug
`export_code` uses `class.__module__` to resolve the import path, which returns
the private implementation module (e.g. `sktime.forecasting.naive._naive`)
instead of the public API path (`sktime.forecasting.naive`).

The exported code runs today, but private modules are not part of sktime's
public API contract — any internal refactor can silently break it.

## Fix
Added `_get_public_module()` helper that strips trailing underscore-prefixed
submodule components from the raw `__module__` string. Applied to both single
estimator and pipeline codegen paths.

## How I found it
Discovered while testing the full workflow (instantiate → fit_predict →
evaluate → export_code) through Claude Desktop with the sktime-mcp integration


as part of my ESOC 2026 application for the sktime Agentic Track.