### PR TITLE
feat: Add analyze_data tool for dataset statistical analysis (#195)

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -23,6 +23,7 @@ from sktime_mcp.tools.data_tools import (
     load_data_source_tool,
     release_data_handle_tool,
 )
+from sktime_mcp.tools.analyze_data import analyze_data_tool
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.evaluate import evaluate_estimator_tool
 from sktime_mcp.tools.fit_predict import (
@@ -436,6 +437,25 @@ async def list_tools() -> list[Tool]:
                 "required": ["data_handle"],
             },
         ),
+        Tool(
+            name="analyze_data",
+            description=(
+                "Analyze a dataset to compute standard time series statistical characteristics. "
+                "Calculates length, frequency, stationarity (via ADF test), presence of trend "
+                "(via linear regression), and seasonality (via ACF). "
+                "Helps an LLM understand the time series before choosing a forecasting algorithm."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data_handle": {
+                        "type": "string",
+                        "description": "Handle from load_data_source",
+                    },
+                },
+                "required": ["data_handle"],
+            },
+        ),
         # -- Export / Persistence --------------------------------------------
         Tool(
             name="export_code",
@@ -684,6 +704,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments.get("fill_missing", True),
                 arguments.get("remove_duplicates", True),
             )
+
+        elif name == "analyze_data":
+            result = analyze_data_tool(arguments["data_handle"])
 
         elif name == "auto_format_on_load":
             # Deprecated — now controlled via SKTIME_MCP_AUTO_FORMAT env var

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
+from sktime_mcp.tools.analyze_data import analyze_data_tool
 from sktime_mcp.tools.fit_predict import fit_predict_tool
 from sktime_mcp.tools.format_tools import (
     auto_format_on_load_tool,
@@ -20,4 +21,5 @@ __all__ = [
     "save_model_tool",
     "format_time_series_tool",
     "auto_format_on_load_tool",
+    "analyze_data_tool",
 ]

--- a/src/sktime_mcp/tools/analyze_data.py
+++ b/src/sktime_mcp/tools/analyze_data.py
@@ -1,0 +1,145 @@
+"""
+Dataset statistical analysis tool for sktime MCP.
+
+Provides tools for querying statistical characteristics of a loaded time series.
+"""
+
+import logging
+from typing import Any
+
+from sktime_mcp.runtime.executor import get_executor
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_data_tool(data_handle: str) -> dict[str, Any]:
+    """
+    Analyze standard statistical characteristics of a time series.
+
+    Args:
+        data_handle: Handle from load_data_source
+
+    Returns:
+        Dictionary with statistical summary including length, frequency,
+        stationarity, trend, and seasonality.
+    """
+    executor = get_executor()
+
+    if data_handle not in executor._data_handles:
+        return {"success": False, "error": f"Unknown data handle: {data_handle}"}
+
+    data_info = executor._data_handles[data_handle]
+    y = data_info["y"]
+
+    import numpy as np
+    import pandas as pd
+    from scipy.stats import linregress
+    from statsmodels.tsa.stattools import acf, adfuller
+
+    try:
+        # 1. Base details
+        length = len(y)
+        
+        # safely extract frequency string
+        freq = "Unknown"
+        if hasattr(y.index, "freqstr") and y.index.freqstr:
+            freq = y.index.freqstr
+        elif hasattr(y.index, "freq") and y.index.freq is not None:
+            if hasattr(y.index.freq, "freqstr"):
+                freq = y.index.freq.freqstr
+            else:
+                freq = str(y.index.freq)
+
+        # Ensure we have numeric data
+        y_numeric = pd.to_numeric(y, errors="coerce").dropna()
+        if len(y_numeric) < 10:
+            return {
+                "success": False,
+                "error": "Time series too short for reliable statistical analysis (need >= 10 non-NaN values).",
+            }
+
+        # 2. Stationarity (ADF Test)
+        try:
+            adf_result = adfuller(y_numeric.values, autolag="AIC")
+            p_value = float(adf_result[1])
+            is_stationary = p_value < 0.05
+            stationarity_stats = {
+                "is_stationary": bool(is_stationary),
+                "adf_statistic": float(adf_result[0]),
+                "p_value": p_value,
+                "critical_values": {k: float(v) for k, v in adf_result[4].items()},
+            }
+        except Exception as e:
+            logger.warning(f"ADF test failed: {e}")
+            stationarity_stats = {"error": str(e)}
+
+        # 3. Presence of trend (Linear Regression)
+        try:
+            x = np.arange(len(y_numeric))
+            slope, intercept, r_value, p_value_trend, std_err = linregress(x, y_numeric.values)
+            has_trend = p_value_trend < 0.05 and abs(slope) > 1e-5
+            trend_stats = {
+                "has_trend": bool(has_trend),
+                "slope": float(slope),
+                "p_value": float(p_value_trend),
+                "r_squared": float(r_value**2),
+            }
+        except Exception as e:
+            logger.warning(f"Trend test failed: {e}")
+            trend_stats = {"error": str(e)}
+
+        # 4. Seasonality (ACF)
+        try:
+            nlags = min(40, len(y_numeric) // 2 - 1)
+            if nlags > 0:
+                acf_vals, confint = acf(y_numeric.values, nlags=nlags, alpha=0.05)
+
+                # Identify significant peaks (outside confidence interval limits)
+                # confint gives [lower, upper] bounds centered on the ACF value
+                lower_bounds = confint[:, 0] - acf_vals
+                upper_bounds = confint[:, 1] - acf_vals
+                is_significant = (acf_vals > upper_bounds) | (acf_vals < lower_bounds)
+
+                # Ignore lag 0 which is always 1 and significant
+                is_significant[0] = False
+
+                significant_lags = np.where(is_significant)[0]
+
+                has_seasonality = len(significant_lags) > 0
+                strongest_lag = None
+                if has_seasonality:
+                    # Find highest positive significant peak
+                    positive_peaks = [lag for lag in significant_lags if acf_vals[lag] > 0]
+                    if positive_peaks:
+                        strongest_lag = int(positive_peaks[np.argmax([acf_vals[lag] for lag in positive_peaks])])
+                    else:
+                        strongest_lag = int(significant_lags[np.argmax(np.abs(acf_vals[significant_lags]))])
+
+                seasonality_stats = {
+                    "has_seasonality": bool(has_seasonality),
+                    "strongest_seasonal_period": strongest_lag,
+                    "significant_lags": [int(x) for x in significant_lags.tolist()],
+                }
+            else:
+                seasonality_stats = {"error": "Not enough data for ACF"}
+                
+        except Exception as e:
+            logger.warning(f"Seasonality test failed: {e}")
+            seasonality_stats = {"error": str(e)}
+
+        return {
+            "success": True,
+            "data_handle": data_handle,
+            "summary": {
+                "length": int(length),
+                "frequency": freq,
+                "missing_values": int(y.isna().sum()),
+            },
+            "stationarity": stationarity_stats,
+            "trend": trend_stats,
+            "seasonality": seasonality_stats,
+        }
+
+    except Exception as e:
+        logger.exception("Error analyzing data")
+        return {"success": False, "error": str(e)}

--- a/tests/test_analyze_data.py
+++ b/tests/test_analyze_data.py
@@ -1,0 +1,93 @@
+"""
+Tests for analyze_data tool.
+"""
+
+import sys
+import unittest
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, "src")
+
+
+class TestAnalyzeDataTool(unittest.TestCase):
+    def setUp(self):
+        from sktime_mcp.runtime.executor import Executor, get_executor
+        
+        # Override to an isolated executor for tests
+        self.executor = get_executor()
+        
+        # Setup dummy data handle with a clear trend, seasonality, and stationarity (non-stationary really due to trend)
+        np.random.seed(42)
+        dates = pd.date_range("2020-01-01", periods=100, freq="D")
+        
+        # 1. Stationary series
+        y_stationary = pd.Series(np.random.randn(100), index=dates)
+        
+        # 2. Trending non-stationary series
+        y_trend = pd.Series(np.linspace(0, 10, 100) + np.random.randn(100) * 0.1, index=dates)
+        
+        # 3. Seasonal series (sin wave)
+        y_seasonal = pd.Series(np.sin(np.linspace(0, 20*np.pi, 100)) + np.random.randn(100) * 0.1, index=dates)
+        
+        self.handle_stat = "data_stat_123"
+        self.handle_trend = "data_trend_123"
+        self.handle_seas = "data_seas_123"
+        
+        self.executor._data_handles[self.handle_stat] = {"y": y_stationary}
+        self.executor._data_handles[self.handle_trend] = {"y": y_trend}
+        self.executor._data_handles[self.handle_seas] = {"y": y_seasonal}
+
+    def tearDown(self):
+        # Cleanup
+        if self.handle_stat in self.executor._data_handles:
+            del self.executor._data_handles[self.handle_stat]
+        if self.handle_trend in self.executor._data_handles:
+            del self.executor._data_handles[self.handle_trend]
+        if self.handle_seas in self.executor._data_handles:
+            del self.executor._data_handles[self.handle_seas]
+
+    def test_analyze_data_stationary(self):
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+        result = analyze_data_tool(self.handle_stat)
+        
+        self.assertTrue(result["success"], f"Failed: {result.get('error')}")
+        self.assertEqual(result["summary"]["length"], 100)
+        self.assertEqual(result["summary"]["frequency"], "D")
+        self.assertEqual(result["summary"]["missing_values"], 0)
+        
+        # Should be stationary
+        self.assertTrue(result["stationarity"]["is_stationary"])
+        
+        # No significant trend
+        self.assertFalse(result["trend"]["has_trend"])
+
+    def test_analyze_data_trend(self):
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+        result = analyze_data_tool(self.handle_trend)
+        
+        self.assertTrue(result["success"])
+        # Should have a trend
+        self.assertTrue(result["trend"]["has_trend"])
+        self.assertGreater(result["trend"]["slope"], 0)
+        
+        # Likely non-stationary due to strong trend
+        self.assertFalse(result["stationarity"]["is_stationary"])
+
+    def test_analyze_data_seasonal(self):
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+        result = analyze_data_tool(self.handle_seas)
+        
+        self.assertTrue(result["success"])
+        # Should detect seasonality
+        self.assertTrue(result["seasonality"]["has_seasonality"])
+        self.assertIsNotNone(result["seasonality"]["strongest_seasonal_period"])
+
+    def test_analyze_data_invalid_handle(self):
+        from sktime_mcp.tools.analyze_data import analyze_data_tool
+        result = analyze_data_tool("invalid_handle_999")
+        self.assertFalse(result["success"])
+        self.assertIn("Unknown data handle", result["error"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #195
Fixes #242


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This PR implements native dataset statistical analysis tools for `sktime-mcp`. In agentic LLM workflows, an open and native assessment of time-series statistical characteristics significantly improves forecasting estimator selection.

Given a `data_handle`, this PR adds the `analyze_data` tool which provides a summary dictionary with:
1. **Length, Frequency, and Missing Data**: Auto-detected from the underlying Pandas data representation.
2. **Stationarity**: via `statsmodels` Augmented Dickey-Fuller (`adfuller`) test.
3. **Trend**: via `scipy.stats.linregress` computing underlying linear slopes and significance.
4. **Seasonality**: Evaluated through the Auto-Correlation Function (`acf`), flagging active strong significant correlation periods ignoring `lag 0`. 

It also adds robust error bounds to prevent statistical crashes for undersized datasets (n<10), fully unit tested internally on artificially generated timeseries (sinusoidal, deterministic slope, noise). 

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->
No, it natively leverages `statsmodels`, `scipy`, `pandas`, and `numpy` which are already required dependencies in `pyproject.toml`.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* Please review the heuristic matching logic applied to selecting `strongest_seasonal_period` natively from ACF results. 
* Feedback on how edge-case errors are routed back to the LLM agent vs. the central exception mechanism.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
N/A

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
