### PR TITLE
fix: validate max_age_hours >= 1 in cleanup_old_jobs_tool to prevent silent mass-deletion

### DIFF
--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -118,11 +118,18 @@ def cleanup_old_jobs_tool(max_age_hours: int = 24) -> dict[str, Any]:
     Clean up old jobs.
 
     Args:
-        max_age_hours: Maximum age in hours (default: 24)
+        max_age_hours: Maximum age in hours for a job to be considered old (default: 24).
+            Must be a positive integer (>= 1).
 
     Returns:
         Dictionary with number of jobs removed
     """
+    if max_age_hours < 1:
+        return {
+            "success": False,
+            "error": "max_age_hours must be a positive integer (>= 1).",
+        }
+
     job_manager = get_job_manager()
 
     count = job_manager.cleanup_old_jobs(max_age_hours)

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -9,6 +9,7 @@ import pytest
 
 from sktime_mcp.runtime.executor import get_executor
 from sktime_mcp.runtime.jobs import JobStatus, get_job_manager
+from sktime_mcp.tools.job_tools import cleanup_old_jobs_tool
 
 
 def test_job_creation():
@@ -202,6 +203,27 @@ def test_cleanup_old_jobs():
     # Job should be gone
     job = job_manager.get_job(job_id)
     assert job is None
+
+
+def test_cleanup_old_jobs_tool_rejects_zero():
+    """cleanup_old_jobs_tool must reject max_age_hours=0 to prevent silent mass-deletion."""
+    result = cleanup_old_jobs_tool(max_age_hours=0)
+    assert result["success"] is False
+    assert "max_age_hours" in result["error"]
+
+
+def test_cleanup_old_jobs_tool_rejects_negative():
+    """cleanup_old_jobs_tool must reject negative max_age_hours."""
+    result = cleanup_old_jobs_tool(max_age_hours=-5)
+    assert result["success"] is False
+    assert "max_age_hours" in result["error"]
+
+
+def test_cleanup_old_jobs_tool_accepts_positive():
+    """cleanup_old_jobs_tool should accept a positive max_age_hours."""
+    result = cleanup_old_jobs_tool(max_age_hours=1)
+    assert result["success"] is True
+    assert "count" in result
 
 
 def run_all_tests():


### PR DESCRIPTION
Fixes #249.

`cleanup_old_jobs_tool` passed `max_age_hours` directly to `job_manager.cleanup_old_jobs()` without any validation. Because the cutoff is computed as `datetime.now() - timedelta(hours=max_age_hours)`:

- `max_age_hours=0` yields a cutoff equal to the current time, so every job looks "old" and is deleted silently.
- Any negative value pushes the cutoff into the future, again matching every job and wiping the entire store.

Neither case produced an error or any indication that the operation was unsafe.

**Before** (broken):

```python
result = cleanup_old_jobs_tool(max_age_hours=0)
# → {"success": True, "message": "Removed 2 old job(s)", "count": 2}
# All jobs gone, no warning.
```

**After** (fixed):

```python
result = cleanup_old_jobs_tool(max_age_hours=0)
# → {"success": False, "error": "max_age_hours must be a positive integer (>= 1)."}
```

The guard is added only in the MCP-facing tool. The underlying `job_manager.cleanup_old_jobs(0)` behaviour is unchanged — existing internal tests rely on it for teardown.

Three regression tests are added covering:
- `max_age_hours=0` → rejected
- `max_age_hours=-5` → rejected
- `max_age_hours=1` → accepted