### PR TITLE
[BUG] Fix cleanup_old_jobs_tool accepting zero/negative max_age_hours (#249)

### DIFF
--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -118,11 +118,20 @@ def cleanup_old_jobs_tool(max_age_hours: int = 24) -> dict[str, Any]:
     Clean up old jobs.
 
     Args:
-        max_age_hours: Maximum age in hours (default: 24)
+        max_age_hours: Maximum age in hours. Must be a positive integer (>= 1).
+            Passing 0 or a negative value would set the cutoff to "now" or the
+            future, causing all jobs to be silently deleted. (default: 24)
 
     Returns:
-        Dictionary with number of jobs removed
+        Dictionary with number of jobs removed, or an error dict if the
+        argument is invalid.
     """
+    if max_age_hours < 1:
+        return {
+            "success": False,
+            "error": "max_age_hours must be a positive integer (>= 1).",
+        }
+
     job_manager = get_job_manager()
 
     count = job_manager.cleanup_old_jobs(max_age_hours)

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -188,20 +188,73 @@ def test_cancel_job():
 
 
 def test_cleanup_old_jobs():
-    """Test cleaning up old jobs."""
+    """Test cleaning up old jobs with a valid max_age_hours."""
+    from datetime import datetime, timedelta
+
     job_manager = get_job_manager()
 
     # Create a job
     job_id = job_manager.create_job("fit_predict", "handle", "ARIMA")
 
-    # Cleanup jobs older than 0 hours (should remove all)
-    count = job_manager.cleanup_old_jobs(max_age_hours=0)
+    # Manually backdating creation time to simulate an old job (25 hours ago)
+    with job_manager.lock:
+        job_manager.jobs[job_id].created_at = datetime.now() - timedelta(hours=25)
 
-    print(f"✓ Cleaned up {count} old job(s)")
+    # Cleanup jobs older than 24 hours — should remove our backdated job
+    count = job_manager.cleanup_old_jobs(max_age_hours=24)
+    assert count >= 1
+
+    print(f"\u2713 Cleaned up {count} old job(s)")
 
     # Job should be gone
     job = job_manager.get_job(job_id)
     assert job is None
+
+
+def test_cleanup_old_jobs_tool_zero_age_rejected():
+    """Test that cleanup_old_jobs_tool rejects max_age_hours=0.
+
+    Passing 0 would make the cutoff == datetime.now(), causing every job
+    to appear 'old' and be silently deleted.  The tool must refuse.
+    """
+    from sktime_mcp.tools.job_tools import cleanup_old_jobs_tool
+
+    result = cleanup_old_jobs_tool(max_age_hours=0)
+    assert result["success"] is False
+    assert "error" in result
+    assert ">= 1" in result["error"]
+
+    print("\u2713 max_age_hours=0 correctly rejected")
+
+
+def test_cleanup_old_jobs_tool_negative_age_rejected():
+    """Test that cleanup_old_jobs_tool rejects negative max_age_hours.
+
+    A negative value makes timedelta subtract a negative delta, shifting
+    the cutoff into the future so ALL jobs match and get deleted.
+    """
+    from sktime_mcp.tools.job_tools import cleanup_old_jobs_tool
+
+    for bad_value in [-1, -10, -100]:
+        result = cleanup_old_jobs_tool(max_age_hours=bad_value)
+        assert result["success"] is False, f"Expected failure for max_age_hours={bad_value}"
+        assert "error" in result
+        assert "max_age_hours" in result["error"]
+
+    print("\u2713 Negative max_age_hours values correctly rejected")
+
+
+def test_cleanup_old_jobs_tool_valid_age():
+    """Test that cleanup_old_jobs_tool succeeds with a valid max_age_hours."""
+    from sktime_mcp.tools.job_tools import cleanup_old_jobs_tool
+
+    result = cleanup_old_jobs_tool(max_age_hours=24)
+    assert result["success"] is True
+    assert "count" in result
+    assert "message" in result
+
+    print(f"\u2713 Valid max_age_hours=24 accepted, removed {result['count']} job(s)")
+
 
 
 def run_all_tests():
@@ -227,6 +280,15 @@ def run_all_tests():
 
     print("\n6. Testing cleanup old jobs...")
     test_cleanup_old_jobs()
+
+    print("\n7. Testing cleanup tool validation (zero age)...")
+    test_cleanup_old_jobs_tool_zero_age_rejected()
+
+    print("\n8. Testing cleanup tool validation (negative age)...")
+    test_cleanup_old_jobs_tool_negative_age_rejected()
+
+    print("\n9. Testing cleanup tool validation (valid age)...")
+    test_cleanup_old_jobs_tool_valid_age()
 
     print("\n" + "=" * 60)
     print("✅ All tests passed!")


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #249

#### What does this implement/fix? Explain your changes.
The cleanup_old_jobs_tool was silently deleting all jobs when someone passed max_age_hours=0 or a negative value like -1. This happened because datetime.now() - timedelta(hours=0) gives the current time, so every job looked "old" and got wiped out without any warning.

I added a simple validation check at the top of cleanup_old_jobs_tool() if max_age_hours is less than 1, the tool now returns a clear error message instead of proceeding with the deletion. I also updated the docstring to document this behavior.

#### Does your contribution introduce a new dependency? If yes, which one?

No, no new dependencies added.

#### What should a reviewer concentrate their feedback on?

- The validation guard in src/sktime_mcp/tools/job_tools.py (lines 129–133) just 2 lines of logic plus the error return.
- The updated test_cleanup_old_jobs test in tests/test_background_jobs.py the old version actually relied on the bug (max_age_hours=0) to work, so I fixed it to backdate a job properly instead.
- The 3 new test functions that cover zero, negative, and valid values.

#### Any other comments?
This is a separate issue from #221 (which is about negative limit in list_estimators_tool). Here the problem is specifically the missing validation in cleanup_old_jobs_tool.
#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
