### PR TITLE
[BUG] Remove Python 3.9 from CI matrix — package requires ≥ 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,11 @@ include = [
 
 [tool.black]
 line-length = 100
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 # Enable a broader set of rules


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #277

#### What does this implement/fix? Explain your changes.

The CI `test` job matrix was running against `["3.9", "3.10", "3.11", "3.12"]` even though `pyproject.toml` declares `requires-python = ">=3.10"` and `mcp>=1.0.0` does not support Python 3.9.

This PR:
1. Removes `"3.9"` from the `python-version` matrix in `.github/workflows/ci.yml`.
2. Updates `[tool.black] target-version` from `["py39", "py310", "py311", "py312"]` to `["py310", "py311", "py312"]`.
3. Updates `[tool.ruff] target-version` from `"py39"` to `"py310"`.

No source code changes. No new dependencies.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Confirm the three config changes are consistent with each other and with `requires-python = ">=3.10"`.

#### Any other comments?

The `pyproject.toml` `requires-python` was already correct (`>=3.10`); only the tooling config files needed updating.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.