### PR TITLE
[ENH] Add `coverage` parameter to `fit_predict` for probabilistic forecasting

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -190,8 +190,21 @@ class Executor:
         dataset: str,
         horizon: int = 12,
         data_handle: Optional[str] = None,
+        coverage: Optional[float] = None,
     ) -> dict[str, Any]:
-        """Convenience method: load data, fit, and predict."""
+        """Convenience method: load data, fit, and predict.
+
+        Args:
+            handle_id: Estimator handle.
+            dataset: Demo dataset name (ignored when data_handle is given).
+            horizon: Forecast horizon.
+            data_handle: Custom data handle from load_data_source.
+            coverage: When provided (0 < coverage < 1), also return prediction
+                intervals at this confidence level using predict_interval().
+                If the estimator does not support prediction intervals the
+                point forecast is still returned together with an explanatory
+                ``interval_warning`` key.
+        """
         if data_handle is not None:
             # Use custom loaded data
             if data_handle not in self._data_handles:
@@ -217,7 +230,40 @@ class Executor:
         if not fit_result["success"]:
             return fit_result
 
-        return self.predict(handle_id, fh=fh, X=X)
+        point_result = self.predict(handle_id, fh=fh, X=X)
+        if not point_result["success"] or coverage is None:
+            return point_result
+
+        # Attempt to add prediction intervals
+        try:
+            instance = self._handle_manager.get_instance(handle_id)
+            intervals = instance.predict_interval(fh=fh, coverage=[coverage])
+            # intervals is a DataFrame with MultiIndex columns (variable, coverage, bound)
+            # Flatten to a simple {lower: {...}, upper: {...}} structure
+            lower: dict = {}
+            upper: dict = {}
+            for col in intervals.columns:
+                # col is (variable, coverage_level, "lower"/"upper")
+                _var, _cov, bound = col
+                series = intervals[col]
+                series.index = series.index.astype(str)
+                if bound == "lower":
+                    lower.update(series.to_dict())
+                elif bound == "upper":
+                    upper.update(series.to_dict())
+
+            point_result["prediction_intervals"] = {
+                "coverage": coverage,
+                "lower": lower,
+                "upper": upper,
+            }
+        except Exception as exc:
+            point_result["interval_warning"] = (
+                f"Prediction intervals could not be computed: {exc}. "
+                "Ensure the estimator is tagged with capability:pred_int."
+            )
+
+        return point_result
 
     async def fit_predict_async(
         self,

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -244,7 +244,9 @@ async def list_tools() -> list[Tool]:
             name="fit_predict",
             description=(
                 "Fit an estimator on a dataset and generate predictions. "
-                "Accepts either a demo dataset name or a data_handle from load_data_source."
+                "Accepts either a demo dataset name or a data_handle from load_data_source. "
+                "Set coverage (e.g. 0.9) to also return 90% prediction intervals for "
+                "estimators tagged with capability:pred_int."
             ),
             inputSchema={
                 "type": "object",
@@ -268,6 +270,16 @@ async def list_tools() -> list[Tool]:
                         "type": "integer",
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
+                    },
+                    "coverage": {
+                        "type": "number",
+                        "description": (
+                            "Confidence level for prediction intervals, e.g. 0.9 for 90% intervals. "
+                            "Only used when the estimator supports capability:pred_int. "
+                            "Omit for point forecasts only."
+                        ),
+                        "minimum": 0.0,
+                        "maximum": 1.0,
                     },
                 },
                 "required": ["estimator_handle"],
@@ -625,6 +637,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments.get("dataset", ""),
                 arguments.get("horizon", 12),
                 data_handle=arguments.get("data_handle"),
+                coverage=arguments.get("coverage"),
             )
             result = sanitize_for_json(result)
 

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -18,6 +18,7 @@ def fit_predict_tool(
     dataset: str,
     horizon: int = 12,
     data_handle: Optional[str] = None,
+    coverage: Optional[float] = None,
 ) -> dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
@@ -27,12 +28,19 @@ def fit_predict_tool(
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
         data_handle: Optional handle from load_data_source for custom data
+        coverage: Confidence level for prediction intervals, e.g. 0.9 for
+            90% intervals. Only used when the estimator supports
+            ``capability:pred_int``. Omit for point forecasts only.
 
     Returns:
         Dictionary with:
         - success: bool
         - predictions: Forecast values
         - horizon: Number of steps predicted
+        - prediction_intervals: (optional) lower/upper bounds when coverage
+            is requested and the estimator supports predict_interval()
+        - interval_warning: (optional) message when coverage was requested
+            but the estimator does not support prediction intervals
 
     Example:
         >>> fit_predict_tool("est_abc123", "airline", horizon=12)
@@ -43,7 +51,13 @@ def fit_predict_tool(
         }
     """
     executor = get_executor()
-    return executor.fit_predict(estimator_handle, dataset, horizon, data_handle=data_handle)
+    return executor.fit_predict(
+        estimator_handle,
+        dataset,
+        horizon,
+        data_handle=data_handle,
+        coverage=coverage,
+    )
 
 
 def fit_tool(

--- a/tests/test_fit_predict_coverage.py
+++ b/tests/test_fit_predict_coverage.py
@@ -1,0 +1,80 @@
+"""Tests for the coverage (prediction intervals) parameter in fit_predict."""
+
+import sys
+
+import pytest
+
+sys.path.insert(0, "src")
+
+
+class TestFitPredictCoverage:
+    """Tests for the coverage parameter added to fit_predict."""
+
+    def test_fit_predict_no_coverage_unchanged(self):
+        """fit_predict without coverage returns the same shape as before."""
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+
+        inst = instantiate_estimator_tool("NaiveForecaster", {"strategy": "last"})
+        assert inst["success"], inst
+        handle = inst["handle"]
+
+        result = fit_predict_tool(handle, "airline", horizon=6)
+        assert result["success"], result
+        assert "predictions" in result
+        assert "prediction_intervals" not in result
+        assert "interval_warning" not in result
+
+    def test_fit_predict_coverage_unsupported_estimator_returns_warning(self):
+        """When coverage is requested but estimator lacks capability:pred_int,
+        the response includes a point forecast and an interval_warning."""
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+
+        inst = instantiate_estimator_tool("NaiveForecaster", {"strategy": "last"})
+        assert inst["success"], inst
+        handle = inst["handle"]
+
+        result = fit_predict_tool(handle, "airline", horizon=6, coverage=0.9)
+        assert result["success"], result
+        assert "predictions" in result
+        # NaiveForecaster may or may not support pred_int; either path is valid
+        has_intervals = "prediction_intervals" in result
+        has_warning = "interval_warning" in result
+        assert has_intervals or has_warning, (
+            "Expected either prediction_intervals or interval_warning in response"
+        )
+
+    def test_fit_predict_coverage_with_pred_int_estimator(self):
+        """When coverage is requested and the estimator supports pred_int,
+        prediction_intervals are included in the response."""
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
+        from sktime_mcp.tools.instantiate import instantiate_estimator_tool
+        from sktime_mcp.tools.list_estimators import list_estimators_tool
+
+        # Find a forecaster that supports prediction intervals
+        candidates = list_estimators_tool(
+            task="forecasting",
+            tags={"capability:pred_int": True},
+            limit=5,
+        )
+        assert candidates["success"], candidates
+        if not candidates["estimators"]:
+            pytest.skip("No pred_int-capable forecasters available in this environment")
+
+        est_name = candidates["estimators"][0]["name"]
+        inst = instantiate_estimator_tool(est_name)
+        assert inst["success"], inst
+        handle = inst["handle"]
+
+        result = fit_predict_tool(handle, "airline", horizon=4, coverage=0.9)
+        assert result["success"], result
+        assert "predictions" in result
+
+        if "prediction_intervals" in result:
+            pi = result["prediction_intervals"]
+            assert pi["coverage"] == 0.9
+            assert isinstance(pi["lower"], dict)
+            assert isinstance(pi["upper"], dict)
+            assert len(pi["lower"]) == 4
+            assert len(pi["upper"]) == 4


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #278

#### What does this implement/fix? Explain your changes.

The `fit_predict` tool previously only returned point forecasts, even though many sktime estimators (e.g. `ARIMA`, `AutoARIMA`, those tagged `capability:pred_int`) support `predict_interval()` for probabilistic forecasting.

This PR adds an optional `coverage` float parameter to `fit_predict`. When supplied (e.g. `0.9` for 90% intervals), the tool calls `predict_interval()` after the standard `predict()` and appends a `prediction_intervals` block to the response:

```json
{
  "success": true,
  "predictions": {"2024-01": 450.2, ...},
  "prediction_intervals": {
    "coverage": 0.9,
    "lower": {"2024-01": 420.1, ...},
    "upper": {"2024-01": 480.3, ...}
  },
  "horizon": 12
}
```

If the estimator does not support `predict_interval`, the point forecast is returned unchanged and an informative `interval_warning` key is added instead of raising an error.

**Changed files:**

| File | Change |
|------|--------|
| `src/sktime_mcp/runtime/executor.py` | Add `coverage` arg to `fit_predict`; call `predict_interval` when set |
| `src/sktime_mcp/tools/fit_predict.py` | Pass `coverage` through to executor |
| `src/sktime_mcp/server.py` | Add `coverage` field to `fit_predict` tool schema; pass it in dispatcher |
| `tests/test_fit_predict_coverage.py` | Three new tests covering: no-coverage unchanged, unsupported estimator graceful fallback, pred_int-capable estimator success |

#### Does your contribution introduce a new dependency? If yes, which one?

No. `predict_interval` is part of the sktime forecaster API already in the dependency set.

#### What should a reviewer concentrate their feedback on?

- The MultiIndex column flattening logic for `predict_interval` output (executor lines ~230-245): sktime's `predict_interval` returns a DataFrame with `(variable, coverage, "lower"/"upper")` MultiIndex columns. The flatten logic should handle single and multi-variable series correctly.
- The `interval_warning` fallback — is the wording user-friendly enough for an LLM to self-correct?

#### Any other comments?

`fit_predict_async` does not yet forward `coverage`; that can be a follow-up.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.