### PR TITLE
[BUG] Reject unfitted estimators in `save_model_tool` before MLflow call

### DIFF
--- a/src/sktime_mcp/tools/save_model.py
+++ b/src/sktime_mcp/tools/save_model.py
@@ -44,6 +44,16 @@ def save_model_tool(
     except KeyError:
         return {"success": False, "error": f"Handle not found: {estimator_handle}"}
 
+    if not handle_manager.is_fitted(estimator_handle):
+        handle_info = handle_manager.get_info(estimator_handle)
+        return {
+            "success": False,
+            "error": (
+                f"Estimator '{handle_info.estimator_name}' (handle: {estimator_handle}) "
+                "has not been fitted. Call fit_predict before saving."
+            ),
+        }
+
     if mlflow_params is not None and not isinstance(mlflow_params, dict):
         return {"success": False, "error": "mlflow_params must be a dictionary"}
 

--- a/tests/test_save_model_fitted_check.py
+++ b/tests/test_save_model_fitted_check.py
@@ -1,0 +1,61 @@
+"""Tests for the fitted-check guard added to save_model_tool."""
+
+import sys
+
+sys.path.insert(0, "src")
+
+
+class TestSaveModelFittedCheck:
+    """Tests that save_model_tool rejects unfitted estimators early."""
+
+    def test_save_unfitted_estimator_returns_error(self):
+        """Saving an unfitted handle must fail with a clear error message."""
+        from sktime_mcp.runtime.handles import get_handle_manager
+        from sktime_mcp.tools.save_model import save_model_tool
+
+        handle_manager = get_handle_manager()
+        handle = handle_manager.create_handle("NaiveForecaster", object())
+
+        try:
+            result = save_model_tool(handle, "/tmp/should_not_be_created")
+        finally:
+            handle_manager.release_handle(handle)
+
+        assert not result["success"]
+        assert "not been fitted" in result["error"]
+        assert "NaiveForecaster" in result["error"]
+
+    def test_save_unknown_handle_still_returns_error(self):
+        """Passing a nonexistent handle must still return a clear error."""
+        from sktime_mcp.tools.save_model import save_model_tool
+
+        result = save_model_tool("est_nonexistent_handle", "/tmp/model")
+
+        assert not result["success"]
+        assert "Handle not found" in result["error"]
+
+    def test_save_fitted_estimator_proceeds(self, monkeypatch, tmp_path):
+        """A fitted handle must pass the guard and reach the save call."""
+        import sktime_mcp.tools.save_model as save_model_module
+        from sktime_mcp.runtime.handles import get_handle_manager
+        from sktime_mcp.tools.save_model import save_model_tool
+
+        calls = {}
+
+        def fake_save_model(**kwargs):
+            calls.update(kwargs)
+
+        monkeypatch.setattr(save_model_module, "_get_mlflow_save_model", lambda: fake_save_model)
+
+        handle_manager = get_handle_manager()
+        handle = handle_manager.create_handle("NaiveForecaster", object())
+        handle_manager.mark_fitted(handle)
+
+        try:
+            result = save_model_tool(handle, str(tmp_path / "model_dir"))
+        finally:
+            handle_manager.release_handle(handle)
+
+        assert result["success"], result
+        assert result["saved_path"] == str(tmp_path / "model_dir")
+        assert "path" in calls


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #280

#### What does this implement/fix? Explain your changes.

`save_model_tool` previously serialised estimator handles unconditionally — including ones that had never been fitted. The resulting artefact raises `NotFittedError` when loaded and asked to predict, and the only signal came from MLflow deep in the call stack, making it hard to diagnose.

This PR adds a two-line pre-flight check immediately after the handle is resolved:

```python
if not handle_manager.is_fitted(estimator_handle):
    handle_info = handle_manager.get_info(estimator_handle)
    return {
        "success": False,
        "error": (
            f"Estimator '{handle_info.estimator_name}' (handle: {estimator_handle}) "
            "has not been fitted. Call fit_predict before saving."
        ),
    }
```

`HandleManager.is_fitted()` already existed and was used by the `predict` path — this change simply wires it into `save_model_tool`.

**Changed files:**

| File | Change |
|------|--------|
| `src/sktime_mcp/tools/save_model.py` | Add `is_fitted` guard before the MLflow call |
| `tests/test_save_model_fitted_check.py` | Three new tests: unfitted → error, unknown handle → error, fitted → proceeds to save |

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Wording of the error message — should it reference `fit_predict` specifically, or the lower-level `fit` call as well?
- Whether the check should be a warning rather than a hard error (i.e. allow saving unfitted models with an explicit flag). Current opinion: hard error is safer and consistent with the predict path.

#### Any other comments?

The existing `test_save_model_tool` test in `test_core.py` already tests the happy path via `mark_fitted`; the new tests cover the new guard and the unchanged unknown-handle path.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.