### PR TITLE
FIX: evaluate_estimator_tool cv_folds now produces correct fold count

### DIFF
--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -47,10 +47,9 @@ def evaluate_estimator_tool(
 
     try:
         n = len(y)
-        # Handle small datasets gracefully
-        initial_window = max(int(n * 0.5), n - cv_folds * 2)
-        if initial_window < 1:
-            initial_window = 1
+        # Leave exactly cv_folds tail observations for evaluation;
+        # with step_length=1 the splitter produces one fold per remaining point.
+        initial_window = max(2, n - cv_folds)
 
         cv = ExpandingWindowSplitter(initial_window=initial_window, step_length=1, fh=[1])
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -27,7 +27,7 @@ def test_evaluate_estimator_tool():
         assert "results" in result
         assert result["cv_folds_run"] == 2
         assert len(result["results"]) == 2
-        
+
         # Verify result contains common metrics like test_MeanAbsolutePercentageError
         metric_columns = [k for k in result["results"][0].keys() if "test_" in k]
         assert len(metric_columns) > 0
@@ -35,6 +35,32 @@ def test_evaluate_estimator_tool():
     finally:
         # Clean up
         executor._handle_manager.release_handle(handle)
+
+
+@pytest.mark.parametrize("cv_folds", [1, 3, 5])
+def test_evaluate_cv_folds_count(cv_folds):
+    """cv_folds parameter must control the actual number of folds produced.
+
+    Regression test for GH #289: the previous formula used cv_folds*2 as the
+    tail size, causing the splitter to produce double the requested folds.
+    """
+    from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime.forecasting.naive import NaiveForecaster
+
+    executor = get_executor()
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+
+    try:
+        result = evaluate_estimator_tool(handle, "airline", cv_folds=cv_folds)
+
+        assert result["success"], f"Evaluate failed: {result.get('error')}"
+        assert result["cv_folds_run"] == cv_folds, (
+            f"Expected {cv_folds} folds but got {result['cv_folds_run']}"
+        )
+    finally:
+        executor._handle_manager.release_handle(handle)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Overview

Closes #289

`evaluate_estimator_tool` accepted a `cv_folds` parameter promising "Number of folds for Splitter", but the implementation computed:

```python
initial_window = max(int(n * 0.5), n - cv_folds * 2)
```

With `step_length=1`, `ExpandingWindowSplitter` produces one fold per remaining observation, so leaving `cv_folds * 2` tail points generates **double** the requested folds. For example, requesting `cv_folds=3` on the airline dataset (n=144) produced 6 folds:

- `initial_window = max(72, 138) = 138`
- 144 − 138 = **6 folds**, not 3

The existing unit test asserted `cv_folds_run == 2` for `cv_folds=2` — a contract that the original code never satisfied.

## Fix

```python
# before
initial_window = max(int(n * 0.5), n - cv_folds * 2)
if initial_window < 1:
    initial_window = 1

# after
initial_window = max(2, n - cv_folds)
```

Leaving `cv_folds` tail observations and keeping `step_length=1` gives exactly `cv_folds` folds.

## Changes

- `src/sktime_mcp/tools/evaluate.py`: corrected `initial_window` formula
- `tests/test_evaluate.py`: added `test_evaluate_cv_folds_count` parametrized over `[1, 3, 5]` to lock in the correct behaviour