### PR TITLE
fix(docs): replace search_estimators with list_estimators across docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Discover estimators by task type and capability tags.
 
 ---
 
-#### 2. `search_estimators`
+#### 2. `list_estimators` (query mode)
 Search estimators by name or description using text query.
 
 **Arguments:**

--- a/docs/source/background-jobs.md
+++ b/docs/source/background-jobs.md
@@ -245,7 +245,7 @@ job_id = job_result["job_id"]
 datasets = list_available_data(is_demo=True)
 
 # Search for other estimators
-estimators = search_estimators("prophet")
+estimators = list_estimators(query="prophet")
 
 # 4. Check training progress
 status = check_job_status(job_id)

--- a/docs/source/implementation.md
+++ b/docs/source/implementation.md
@@ -134,7 +134,7 @@ LLM → JSON-RPC request → server.call_tool() → tool function → sanitize �
    - **Key Methods**:
      - `get_all_estimators(task, tags)`: Filter estimators by task and tags
      - `get_estimator_by_name(name)`: Lookup specific estimator
-     - `search_estimators(query)`: Text search in names/docstrings
+     - `list_estimators(query=...)`: Text search in names/docstrings
      - `get_available_tasks()`: List all task types
      - `get_available_tags()`: List all capability tags
    - **Internal Methods**:
@@ -315,15 +315,11 @@ Each file implements one or more MCP tools that LLMs can call.
 
 #### `list_estimators.py`
 **Tools**:
-1. **`list_estimators_tool(task, tags, limit)`**
+1. **`list_estimators_tool(task, tags, query, limit)`**
    - Calls `registry.get_all_estimators(task, tags)`
    - Returns: `{"success": True, "estimators": [...], "total": 50}`
 
-2. **`search_estimators_tool(query, limit)`**
-   - Calls `registry.search_estimators(query)`
-   - Text search in estimator names/docstrings
-
-3. **`get_available_tags()`**
+2. **`get_available_tags()`**
    - Returns all capability tags
    - Example: `["capability:pred_int", "handles-missing-data", ...]`
 

--- a/examples/02_llm_query_simulation.py
+++ b/examples/02_llm_query_simulation.py
@@ -20,7 +20,7 @@ import sys
 sys.path.insert(0, "src")
 
 from sktime_mcp.composition.validator import get_composition_validator
-from sktime_mcp.tools.describe_estimator import describe_estimator_tool, search_estimators_tool
+from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.fit_predict import fit_predict_tool
 from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 from sktime_mcp.tools.list_estimators import list_estimators_tool
@@ -205,15 +205,15 @@ def simulate_query_4():
     # Step 1: Search
     print_llm_thought("Searching for 'exponential' in estimator names and docs...")
 
-    print_tool_call("search_estimators", {"query": "exponential", "limit": 5})
-    result = search_estimators_tool("exponential", limit=5)
+    print_tool_call("list_estimators", {"query": "exponential", "limit": 5})
+    result = list_estimators_tool(query="exponential", limit=5)
     print_result(result)
 
     # Step 2: Generate response
     print("\n🤖 LLM Response:")
-    if result["success"] and result["results"]:
+    if result["success"] and result["estimators"]:
         print(f"   Found {result['count']} estimators related to exponential smoothing:")
-        for est in result["results"]:
+        for est in result["estimators"]:
             print(f"   - {est['name']} ({est['task']})")
     else:
         print("   No estimators found matching 'exponential'")


### PR DESCRIPTION
Closes #202 

This PR updates documentation and examples to use `list_estimators(query=...)` instead of the deprecated `search_estimators`, ensuring consistency with the current MCP interface.

Changes are limited to user-facing docs and examples.