### PR TITLE
FEAT: expose suggest_pipeline as an MCP tool

### DIFF
--- a/docs/source/user-guide.md
+++ b/docs/source/user-guide.md
@@ -198,7 +198,7 @@ Tell the assistant the components and their order:
 
 > *"Build a pipeline that deseasonalizes, detrends, then applies ARIMA(1,1,1) to forecast."*
 
-The assistant will first validate that these components are compatible (e.g., that transformers feed into a forecaster correctly). If something is incompatible, it will explain why and suggest alternatives.
+The assistant can suggest a starting pipeline for your task, then validate that the chosen components are compatible (e.g., that transformers feed into a forecaster correctly). If something is incompatible, it will explain why and suggest alternatives.
 
 **Step 2: Run it on data**
 Once the pipeline is created, use it like any other model:
@@ -210,6 +210,12 @@ The entire pipeline (preprocessing + forecasting) runs end-to-end, and you get p
 <details>
 <summary>🔧 MCP tool calls (what happens under the hood)</summary>
 
+```json
+{
+  "tool": "suggest_pipeline",
+  "arguments": {"task": "forecasting"}
+}
+```
 ```json
 {
   "tool": "validate_pipeline",

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -47,6 +47,7 @@ from sktime_mcp.tools.list_estimators import (
     list_estimators_tool,
 )
 from sktime_mcp.tools.save_model import save_model_tool
+from sktime_mcp.tools.suggest_pipeline import suggest_pipeline_tool
 
 # ---------------------------------------------------------------------------
 # Server configuration via environment variables
@@ -237,6 +238,24 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["components"],
+            },
+        ),
+        Tool(
+            name="suggest_pipeline",
+            description="Suggest a valid estimator pipeline for a target task",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "task": {
+                        "type": "string",
+                        "description": "Target task, e.g. forecasting or classification",
+                    },
+                    "requirements": {
+                        "type": "object",
+                        "description": "Optional capability requirements for the suggestion",
+                    },
+                },
+                "required": ["task"],
             },
         ),
         # -- Execution -------------------------------------------------------
@@ -650,6 +669,11 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             result = validation.to_dict()
             result["success"] = result["valid"]
 
+        elif name == "suggest_pipeline":
+            result = suggest_pipeline_tool(
+                arguments["task"],
+                arguments.get("requirements"),
+            )
 
         # -- Data ------------------------------------------------------------
         elif name == "list_available_data":

--- a/src/sktime_mcp/tools/suggest_pipeline.py
+++ b/src/sktime_mcp/tools/suggest_pipeline.py
@@ -1,0 +1,48 @@
+"""
+suggest_pipeline tool for sktime MCP.
+
+Suggests valid estimator pipelines using the existing composition validator.
+"""
+
+from typing import Any, Optional
+
+from sktime_mcp.composition.validator import get_composition_validator
+
+
+def suggest_pipeline_tool(
+    task: str,
+    requirements: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """
+    Suggest a valid estimator pipeline for a target task.
+
+    Args:
+        task: Target task, e.g. "forecasting" or "classification".
+        requirements: Optional capability requirements to pass to the validator.
+
+    Returns:
+        Dictionary with:
+        - success: bool
+        - task: Requested target task
+        - requirements: Requirements used for the suggestion
+        - suggestions: Ordered estimator names for the suggested pipeline
+        - count: Number of suggested pipeline components
+    """
+    if not isinstance(task, str) or not task.strip():
+        return {"success": False, "error": "task must be a non-empty string"}
+
+    if requirements is not None and not isinstance(requirements, dict):
+        return {"success": False, "error": "requirements must be a dictionary"}
+
+    validator = get_composition_validator()
+    normalized_task = task.strip()
+    normalized_requirements = requirements or {}
+    suggestions = validator.suggest_pipeline(normalized_task, normalized_requirements)
+
+    return {
+        "success": True,
+        "task": normalized_task,
+        "requirements": normalized_requirements,
+        "suggestions": suggestions,
+        "count": len(suggestions),
+    }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -146,6 +146,42 @@ class TestTools:
         assert not result["success"]
         assert "error" in result
 
+    def test_suggest_pipeline_tool(self):
+        """Test suggest_pipeline tool response shape."""
+        from sktime_mcp.tools.suggest_pipeline import suggest_pipeline_tool
+
+        result = suggest_pipeline_tool("forecasting")
+
+        assert result["success"]
+        assert result["task"] == "forecasting"
+        assert result["suggestions"]
+        assert result["count"] == len(result["suggestions"])
+
+    def test_suggest_pipeline_tool_rejects_invalid_requirements(self):
+        """Non-dict requirements should return a structured error."""
+        from sktime_mcp.tools.suggest_pipeline import suggest_pipeline_tool
+
+        result = suggest_pipeline_tool("forecasting", requirements=["handles_missing"])
+
+        assert not result["success"]
+        assert "requirements" in result["error"]
+
+    async def test_suggest_pipeline_registered_and_callable(self):
+        """Test suggest_pipeline is exposed through the MCP server."""
+        import json
+
+        from sktime_mcp.server import call_tool, list_tools
+
+        tools = await list_tools()
+        assert "suggest_pipeline" in {tool.name for tool in tools}
+
+        response = await call_tool("suggest_pipeline", {"task": "forecasting"})
+        payload = json.loads(response[0].text)
+
+        assert payload["success"]
+        assert payload["task"] == "forecasting"
+        assert payload["suggestions"]
+
     def test_list_available_data_no_filter(self):
         """list_available_data with no args returns both system_demos and active_handles."""
         from sktime_mcp.tools.list_available_data import list_available_data_tool


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #288.

#### What does this implement/fix? Explain your changes.

Exposes the existing `CompositionValidator.suggest_pipeline()` logic as an MCP tool named `suggest_pipeline`.

The new tool accepts:

- `task`: target task such as `forecasting` or `classification`
- `requirements`: optional capability requirements passed through to the validator

It returns a structured response with `success`, `task`, `requirements`, `suggestions`, and `count`.

This lets agents ask the MCP server for a valid starting pipeline before validating or instantiating it, without changing the existing validator algorithm.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies.

#### What should a reviewer concentrate their feedback on?

- The `suggest_pipeline` MCP schema and response shape.
- Whether the tool should return `success: true` with an empty `suggestions` list for unsupported tasks, matching the current validator behavior.
- The minimal user-guide update showing the tool in the pipeline workflow.

#### Any other comments?

This PR intentionally keeps the change narrow: it exposes existing validator functionality, adds focused tests, and adds a small docs mention required by the developer guide.

#### PR checklist

##### For all contributions
- [ ] I have added myself to the list of contributors. I can do this separately if maintainers want it for sktime-mcp contributions.
- [ ] Optionally, I have updated CODEOWNERS. Not applicable.
- [x] I have added unit tests and made sure they pass locally.

##### For new estimators
- [ ] Not applicable; this does not add a new estimator.

#### Validation

```bash
.venv/bin/python -m ruff check src/sktime_mcp/server.py src/sktime_mcp/tools/suggest_pipeline.py tests/test_core.py
.venv/bin/python -m ruff format --check src/sktime_mcp/server.py src/sktime_mcp/tools/suggest_pipeline.py tests/test_core.py
git diff --check
.venv/bin/python -m pytest tests/test_core.py -q
.venv/bin/python -m pytest -q
.venv/bin/sphinx-build -E -b html docs/source docs/build/html
```

All commands pass. The full test suite reports two pre-existing async warnings unrelated to this change. The docs build exits successfully and still reports pre-existing warnings in unrelated pages.
