### PR TITLE
FEAT: add descriptions to list_estimators results

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Discover estimators by task type and capability tags.
 }
 ```
 
-**Returns:** List of matching estimators with name, task, and summary info.
+**Returns:** List of matching estimators with name, task, short description, and summary info.
 
 ---
 

--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -39,6 +39,17 @@ class EstimatorNode:
     hyperparameters: dict[str, Any] = field(default_factory=dict)
     docstring: Optional[str] = None
 
+    def _description(self, max_length: int = 200) -> str:
+        """Return a compact, single-line description for list responses."""
+        if not self.docstring:
+            return ""
+
+        description = " ".join(self.docstring.split())
+        if len(description) <= max_length:
+            return description
+
+        return description[: max_length - 3].rstrip() + "..."
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         return {
@@ -58,6 +69,7 @@ class EstimatorNode:
             "name": self.name,
             "task": self.task,
             "module": self.module,
+            "description": self._description(),
             "tags": self.tags,
         }
 

--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -32,7 +32,7 @@ def list_estimators_tool(
     Returns:
         Dictionary with:
         - success: bool
-        - estimators: List of estimator summaries
+        - estimators: List of estimator summaries, each with a short description
         - count: Number of results returned in this page
         - total: Total matching estimators (before limit/offset)
         - offset: Current offset (for pagination)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,7 +135,33 @@ class TestTools:
 
         assert result["success"]
         assert "estimators" in result
+        assert result["estimators"]
         assert len(result["estimators"]) <= 5
+        assert "description" in result["estimators"][0]
+        assert isinstance(result["estimators"][0]["description"], str)
+        assert len(result["estimators"][0]["description"]) <= 200
+
+    def test_estimator_summary_includes_compact_description(self):
+        """Test estimator summaries include normalized docstring context."""
+        from sktime_mcp.registry.interface import EstimatorNode
+
+        class DummyEstimator:
+            """First line.
+
+            More detail on another line.
+            """
+
+        node = EstimatorNode(
+            name="DummyEstimator",
+            task="forecasting",
+            class_ref=DummyEstimator,
+            module="tests.DummyEstimator",
+            docstring=DummyEstimator.__doc__,
+        )
+
+        summary = node.to_summary()
+
+        assert summary["description"] == "First line. More detail on another line."
 
     def test_describe_unknown_estimator(self):
         """Test describing an unknown estimator."""


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses one part of #287.

#### What does this implement/fix? Explain your changes.

Adds a compact `description` field to estimator summaries returned by `list_estimators`.

The description is derived from the existing estimator docstring already loaded into `EstimatorNode`, normalized to a single line, and capped at 200 characters. This gives agents useful context during estimator discovery without requiring repeated `describe_estimator` calls for every candidate.

Also updates the README return description and adds focused tests for the new summary field.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies.

#### What should a reviewer concentrate their feedback on?

- Whether 200 characters is the right length for `list_estimators` summaries.
- Whether the field name `description` is preferred over `summary`.
- Whether the description should be empty for estimators without docstrings, as implemented here.

#### Any other comments?

This intentionally addresses only the estimator-discovery context gap from #287. The other ideas in that issue, such as composability metadata and data-source schemas, are left for separate PRs.

#### PR checklist

##### For all contributions
- [ ] I have added myself to the list of contributors. I can do this separately if maintainers want it for sktime-mcp contributions.
- [ ] Optionally, I have updated CODEOWNERS. Not applicable.
- [x] I have added unit tests and made sure they pass locally.

##### For new estimators
- [ ] Not applicable; this does not add a new estimator.

#### Validation

```bash
.venv/bin/python -m ruff check src/sktime_mcp/registry/interface.py src/sktime_mcp/tools/list_estimators.py tests/test_core.py
.venv/bin/python -m ruff format --check src/sktime_mcp/registry/interface.py src/sktime_mcp/tools/list_estimators.py tests/test_core.py
git diff --check
.venv/bin/python -m pytest tests/test_core.py -q
.venv/bin/python -m pytest -q
```

All commands pass. The full test suite reports two pre-existing async warnings unrelated to this change.
