### PR TITLE
FEAT: expose composition metadata as an MCP tool

### DIFF
--- a/docs/source/user-guide.md
+++ b/docs/source/user-guide.md
@@ -66,6 +66,7 @@ The `sktime-mcp` server exposes a suite of tools that your AI assistant uses on 
 |----------------------|-------------------------------|----------------|
 | **Find models** | The assistant searches the sktime registry by task, tags, or keywords. | *"What forecasting models are available?"* |
 | **Create a model or pipeline** | An estimator or multi-step pipeline is instantiated with your chosen parameters. | *"Set up an ARIMA(1,1,1) model"* |
+| **Inspect valid pipeline steps** | The assistant checks what types of estimators can come before or after a component. | *"What can I compose after Detrender?"* |
 | **Run a forecast** | The model is fitted on your data and predictions are generated. | *"Forecast the airline dataset 12 months ahead"* |
 | **Load your own data** | CSV, Parquet, Excel, or SQL data is loaded and prepared for modelling. | *"Load my sales data from /home/user/sales.csv"* |
 | **Export code** | A standalone Python script is generated so you can reproduce results outside the MCP server. | *"Give me the Python code for this model"* |

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -17,6 +17,7 @@ from mcp.types import TextContent, Tool
 
 from sktime_mcp.composition.validator import get_composition_validator
 from sktime_mcp.tools.codegen import export_code_tool
+from sktime_mcp.tools.composition import get_valid_compositions_tool
 from sktime_mcp.tools.data_tools import (
     load_data_source_async_tool,
     load_data_source_tool,
@@ -237,6 +238,22 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["components"],
+            },
+        ),
+        Tool(
+            name="get_valid_compositions",
+            description=(
+                "Return task types that can validly precede or follow an estimator in a pipeline"
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator": {
+                        "type": "string",
+                        "description": "Estimator name to inspect, e.g. 'Detrender' or 'ARIMA'",
+                    },
+                },
+                "required": ["estimator"],
             },
         ),
         # -- Execution -------------------------------------------------------
@@ -650,6 +667,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             result = validation.to_dict()
             result["success"] = result["valid"]
 
+        elif name == "get_valid_compositions":
+            result = get_valid_compositions_tool(arguments["estimator"])
 
         # -- Data ------------------------------------------------------------
         elif name == "list_available_data":

--- a/src/sktime_mcp/tools/composition.py
+++ b/src/sktime_mcp/tools/composition.py
@@ -1,0 +1,52 @@
+"""
+Composition metadata tools for sktime MCP.
+
+Expose pipeline planning information from the composition validator.
+"""
+
+from typing import Any
+
+from sktime_mcp.composition.validator import get_composition_validator
+
+
+def get_valid_compositions_tool(estimator: str) -> dict[str, Any]:
+    """
+    Return task types that can precede or follow an estimator in a pipeline.
+
+    Args:
+        estimator: Name of the estimator to inspect.
+
+    Returns:
+        Dictionary with:
+        - success: bool
+        - estimator: Requested estimator name
+        - can_precede: Task types this estimator can precede
+        - can_follow: Task types that can precede this estimator
+        - next_step_hint: How agents can use the returned metadata
+    """
+    if not isinstance(estimator, str) or not estimator.strip():
+        return {"success": False, "error": "estimator must be a non-empty string"}
+
+    estimator_name = estimator.strip()
+    validator = get_composition_validator()
+    compositions = validator.get_valid_compositions(estimator_name)
+
+    if "error" in compositions:
+        return {
+            "success": False,
+            "estimator": estimator_name,
+            "error": compositions["error"],
+            "can_precede": compositions.get("can_precede", []),
+            "can_follow": compositions.get("can_follow", []),
+        }
+
+    return {
+        "success": True,
+        "estimator": estimator_name,
+        "can_precede": sorted(compositions["can_precede"]),
+        "can_follow": sorted(compositions["can_follow"]),
+        "next_step_hint": (
+            "Use list_estimators with one of the can_precede task values to find "
+            "valid next pipeline components."
+        ),
+    }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -146,6 +146,45 @@ class TestTools:
         assert not result["success"]
         assert "error" in result
 
+    def test_get_valid_compositions_tool(self):
+        """Test valid composition metadata for a known transformer."""
+        from sktime_mcp.tools.composition import get_valid_compositions_tool
+
+        result = get_valid_compositions_tool("Detrender")
+
+        assert result["success"]
+        assert result["estimator"] == "Detrender"
+        assert "forecasting" in result["can_precede"]
+        assert "transformation" in result["can_follow"]
+        assert "next_step_hint" in result
+
+    def test_get_valid_compositions_tool_unknown_estimator(self):
+        """Unknown estimators should return a structured error."""
+        from sktime_mcp.tools.composition import get_valid_compositions_tool
+
+        result = get_valid_compositions_tool("NotARealEstimator12345")
+
+        assert not result["success"]
+        assert result["can_precede"] == []
+        assert result["can_follow"] == []
+        assert "Unknown estimator" in result["error"]
+
+    async def test_get_valid_compositions_registered_and_callable(self):
+        """Test get_valid_compositions is exposed through the MCP server."""
+        import json
+
+        from sktime_mcp.server import call_tool, list_tools
+
+        tools = await list_tools()
+        assert "get_valid_compositions" in {tool.name for tool in tools}
+
+        response = await call_tool("get_valid_compositions", {"estimator": "ARIMA"})
+        payload = json.loads(response[0].text)
+
+        assert payload["success"]
+        assert payload["estimator"] == "ARIMA"
+        assert "forecasting" in payload["can_follow"]
+
     def test_list_available_data_no_filter(self):
         """list_available_data with no args returns both system_demos and active_handles."""
         from sktime_mcp.tools.list_available_data import list_available_data_tool


### PR DESCRIPTION
## Reference Issues/PRs

Addresses one part of #287.

## What does this implement/fix? Explain your changes.

This PR exposes the existing composition validator metadata through a new MCP tool, `get_valid_compositions`. Given an estimator name, the tool returns the task types that can validly precede or follow that estimator in a pipeline.

The implementation is intentionally small: it reuses `CompositionValidator.get_valid_compositions()` instead of adding new composition rules, registers the tool in the MCP server, and adds tests for the direct tool function and server-level tool dispatch.

## Does your contribution introduce a new dependency? If yes, which one?

No.

## What should a reviewer concentrate their feedback on?

- Whether `get_valid_compositions` is the right MCP tool name
- Whether the response shape is useful for agents building sktime pipelines
- Whether returning task-type compatibility is the right first step before adding estimator-level candidate suggestions

## Did you add any tests for the change?

Yes. The PR adds coverage for:

- successful composition metadata lookup for a known estimator
- structured error output for an unknown estimator
- MCP server registration and dispatch for the new tool

## Any other comments?

Validation run locally:

```
.venv/bin/python -m ruff check src/sktime_mcp/server.py src/sktime_mcp/tools/composition.py tests/test_core.py
.venv/bin/python -m ruff format --check src/sktime_mcp/server.py src/sktime_mcp/tools/composition.py tests/test_core.py
git diff --check
.venv/bin/python -m pytest tests/test_core.py -q
.venv/bin/python -m pytest -q
.venv/bin/sphinx-build -E -b html docs/source docs/build/html
```

Full tests passed with two pre-existing async warnings. The docs build completed successfully with pre-existing documentation warnings unrelated to this change.

## Checklist

- [x] Added tests for the change
- [x] Ran local tests
- [x] No new dependency introduced
