### PR TITLE
FEAT: expose available task discovery as an MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ Discover estimators by task type and capability tags.
 
 **Returns:** List of matching estimators with name, task, and summary info.
 
+Use `get_available_tasks` to discover valid task filter values before calling
+`list_estimators`.
+
 ---
 
 #### 2. `search_estimators`

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -44,6 +44,7 @@ from sktime_mcp.tools.job_tools import (
 from sktime_mcp.tools.list_available_data import list_available_data_tool
 from sktime_mcp.tools.list_estimators import (
     get_available_tags,
+    get_available_tasks,
     list_estimators_tool,
 )
 from sktime_mcp.tools.save_model import save_model_tool
@@ -155,6 +156,15 @@ async def list_tools() -> list[Tool]:
                 },
                 "required": ["estimator"],
             },
+        ),
+        Tool(
+            name="get_available_tasks",
+            description=(
+                "List valid task names that can be used with list_estimators, "
+                "such as forecasting, classification, regression, transformation, "
+                "and clustering."
+            ),
+            inputSchema={"type": "object", "properties": {}},
         ),
         Tool(
             name="get_available_tags",
@@ -597,6 +607,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         elif name == "describe_estimator":
             result = describe_estimator_tool(arguments["estimator"])
 
+        elif name == "get_available_tasks":
+            result = get_available_tasks()
+
         elif name == "get_available_tags":
             result = get_available_tags()
 
@@ -649,7 +662,6 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             validation = validator.validate_pipeline(arguments["components"])
             result = validation.to_dict()
             result["success"] = result["valid"]
-
 
         # -- Data ------------------------------------------------------------
         elif name == "list_available_data":

--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -83,9 +83,12 @@ def list_estimators_tool(
 def get_available_tasks() -> dict[str, Any]:
     """Get list of available task types."""
     registry = get_registry()
+    tasks = registry.get_available_tasks()
     return {
         "success": True,
-        "tasks": registry.get_available_tasks(),
+        "tasks": tasks,
+        "count": len(tasks),
+        "next_step_hint": ("Use one of these values as the task argument in list_estimators."),
     }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -137,6 +137,34 @@ class TestTools:
         assert "estimators" in result
         assert len(result["estimators"]) <= 5
 
+    def test_get_available_tasks_tool(self):
+        """Test available task discovery helper."""
+        from sktime_mcp.tools.list_estimators import get_available_tasks
+
+        result = get_available_tasks()
+
+        assert result["success"]
+        assert "forecasting" in result["tasks"]
+        assert "classification" in result["tasks"]
+        assert result["count"] == len(result["tasks"])
+        assert "list_estimators" in result["next_step_hint"]
+
+    async def test_get_available_tasks_registered_and_callable(self):
+        """Test get_available_tasks is exposed through the MCP server."""
+        import json
+
+        from sktime_mcp.server import call_tool, list_tools
+
+        tools = await list_tools()
+        assert "get_available_tasks" in {tool.name for tool in tools}
+
+        response = await call_tool("get_available_tasks", {})
+        payload = json.loads(response[0].text)
+
+        assert payload["success"]
+        assert "forecasting" in payload["tasks"]
+        assert payload["count"] == len(payload["tasks"])
+
     def test_describe_unknown_estimator(self):
         """Test describing an unknown estimator."""
         from sktime_mcp.tools.describe_estimator import describe_estimator_tool


### PR DESCRIPTION
## Reference Issues/PRs

Closes #305.

## What does this implement/fix? Explain your changes.

This PR exposes the existing `get_available_tasks()` helper through the MCP server as a new `get_available_tasks` tool. Agents can now ask the server for valid task filter values before calling `list_estimators`.

The response includes the task names, a count, and a short next-step hint for using the result with `list_estimators`.

## Does your contribution introduce a new dependency? If yes, which one?

No.

## What should a reviewer concentrate their feedback on?

- Whether `get_available_tasks` is the right tool name
- Whether the small response shape is enough for agent workflows
- Whether this should remain separate from `get_available_tags` or be combined later in a broader discovery tool

## Did you add any tests for the change?

Yes. The PR adds coverage for:

- the direct `get_available_tasks()` helper response
- MCP tool registration in `list_tools()`
- server dispatch through `call_tool("get_available_tasks", {})`

## Any other comments?

Validation run locally:

```
.venv/bin/python -m ruff check src/sktime_mcp/server.py src/sktime_mcp/tools/list_estimators.py tests/test_core.py
.venv/bin/python -m ruff format --check src/sktime_mcp/server.py src/sktime_mcp/tools/list_estimators.py tests/test_core.py
git diff --check
.venv/bin/python -m pytest tests/test_core.py -q
.venv/bin/python -m pytest -q
.venv/bin/sphinx-build -E -b html docs/source docs/build/html
```

Full tests passed with two pre-existing async warnings. The docs build completed successfully with pre-existing documentation warnings unrelated to this change.

## Checklist

- [x] Added tests for the change
- [x] Ran local tests
- [x] No new dependency introduced
