### PR TITLE
FIX: prioritize exact estimator matches in search

### DIFF
--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -306,7 +306,7 @@ class RegistryInterface:
 
     def search_estimators(self, query: str) -> list[EstimatorNode]:
         """
-        Search estimators by name or docstring.
+        Search estimators by name, module, or docstring.
 
         Args:
             query: Search string (case-insensitive)
@@ -315,20 +315,31 @@ class RegistryInterface:
             List of matching EstimatorNode objects
         """
         self._ensure_loaded()
-        query_lower = query.lower()
+        query_lower = query.strip().lower()
 
         results = []
         for node in self._cache.values():
-            # Search in name
-            if query_lower in node.name.lower():
-                results.append(node)
+            name_lower = node.name.lower()
+            module_lower = node.module.lower()
+            docstring_lower = node.docstring.lower() if node.docstring else ""
+
+            if name_lower == query_lower:
+                score = 0
+            elif name_lower.startswith(query_lower):
+                score = 1
+            elif query_lower in name_lower:
+                score = 2
+            elif query_lower in module_lower:
+                score = 3
+            elif query_lower in docstring_lower:
+                score = 4
+            else:
                 continue
 
-            # Search in docstring
-            if node.docstring and query_lower in node.docstring.lower():
-                results.append(node)
+            results.append((score, node.name.lower(), node))
 
-        return results
+        results.sort(key=lambda item: (item[0], item[1]))
+        return [node for _, _, node in results]
 
 
 # Singleton instance for shared use

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -42,6 +42,26 @@ class TestRegistryInterface:
             assert node.name == "NaiveForecaster"
             assert node.task == "forecasting"
 
+    def test_search_prioritizes_exact_estimator_name(self):
+        """Exact estimator name matches should rank before broad matches."""
+        from sktime_mcp.registry.interface import get_registry
+
+        registry = get_registry()
+        matches = registry.search_estimators("NaiveForecaster")
+
+        assert len(matches) > 0
+        assert matches[0].name == "NaiveForecaster"
+
+    def test_search_prioritizes_case_insensitive_exact_name(self):
+        """Exact estimator ranking should be case-insensitive."""
+        from sktime_mcp.registry.interface import get_registry
+
+        registry = get_registry()
+        matches = registry.search_estimators("naiveforecaster")
+
+        assert len(matches) > 0
+        assert matches[0].name == "NaiveForecaster"
+
 
 class TestHandleManager:
     """Tests for the Handle Manager."""
@@ -136,6 +156,19 @@ class TestTools:
         assert result["success"]
         assert "estimators" in result
         assert len(result["estimators"]) <= 5
+
+    def test_list_estimators_query_prioritizes_exact_name(self):
+        """Exact-name query should keep the intended estimator in small pages."""
+        from sktime_mcp.tools.list_estimators import list_estimators_tool
+
+        result = list_estimators_tool(
+            task="forecasting",
+            query="NaiveForecaster",
+            limit=5,
+        )
+
+        assert result["success"]
+        assert result["estimators"][0]["name"] == "NaiveForecaster"
 
     def test_describe_unknown_estimator(self):
         """Test describing an unknown estimator."""


### PR DESCRIPTION
## Reference Issues/PRs

Closes #311.

## What does this implement/fix? Explain your changes.

This PR updates estimator search ranking so exact estimator class-name matches are returned before broader name, module, or docstring matches.

The change fixes an agent workflow issue observed while testing a basic forecasting workflow: `list_estimators(task="forecasting", query="NaiveForecaster", limit=5)` returned broad forecasting matches before the exact `NaiveForecaster` class, so an agent using a small result page could miss the intended estimator.

The new ranking is:

1. exact case-insensitive estimator name matches
2. estimator names starting with the query
3. estimator names containing the query
4. module-path matches
5. docstring matches

## Does your contribution introduce a new dependency? If yes, which one?

No.

## What should a reviewer concentrate their feedback on?

- Whether the ranking order is appropriate for agent-facing estimator search
- Whether module matches should remain included after name matches
- Whether additional tie-breaking should be considered later

## Did you add any tests for the change?

Yes. The PR adds tests for:

- direct registry search prioritizing exact estimator names
- case-insensitive exact-name matching
- `list_estimators(query=..., task=..., limit=...)` keeping the exact estimator first in a small page

## Any other comments?

Validation run locally:

```
.venv/bin/python -m ruff check src/sktime_mcp/registry/interface.py tests/test_core.py
.venv/bin/python -m ruff format --check src/sktime_mcp/registry/interface.py tests/test_core.py
git diff --check
.venv/bin/python -m pytest tests/test_core.py -q
.venv/bin/python -m pytest -q
```

Full tests passed with two pre-existing async warnings.

Manual behavior check after the fix:

```
list_estimators(task="forecasting", query="NaiveForecaster", limit=5)
# first result: NaiveForecaster
```

## Checklist

- [x] Added tests for the change
- [x] Ran local tests
- [x] No new dependency introduced
