### PR TITLE
Fix silent daily fallback in format_data_handle frequency inference

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -770,7 +770,11 @@ class Executor:
                         elif most_common_diff.days >= 28 and most_common_diff.days <= 31:
                             freq = "MS"
                         else:
-                            freq = "D"
+                            changes_made["frequency_warning"] = (
+                                f"Could not determine frequency from most common interval "
+                                f"({most_common_diff}). Reindexing skipped to avoid "
+                                f"fabricating observations."
+                            )
 
                 # Create complete date range
                 if freq:


### PR DESCRIPTION
When `format_data_handle` cannot determine a time series frequency via `pd.infer_freq`, it falls through a manual `if-elif` chain. Any interval not explicitly listed (bi-weekly, 15-minute, quarterly with irregular spacing, etc.) hit a catch-all `else: freq = \"D\"`, silently reindexing the series to daily and fabricating observations via `fill_missing`.

Closes #313 

## What changed

Replaced `else: freq = \"D\"` with a no-op that adds a `frequency_warning` key to `changes_made`. The original data is preserved and the caller is informed why reindexing was skipped.

## Before / After

| | Before | After |
|---|---|---|
| Bi-weekly series (8 rows) | Expanded to 99 daily rows, `success: True` | Unchanged at 8 rows, warning in `changes_made` |
| Unrecognized interval | Silent data corruption | Explicit warning, no fabrication |

## Verification

Ran the reproduction case from the issue : input 8 rows, output 8 rows, `frequency_warning` present in response.
cc @Shashankss1205  