### PR TITLE
fix: return error for invalid task or tag filters in list_estimators

### DIFF
--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -3,6 +3,7 @@ list_estimators tool for sktime MCP.
 Discovers estimators by task type, capability tags, and/or name search.
 """
 
+import difflib
 from typing import Any, Optional
 
 from sktime_mcp.registry.interface import get_registry
@@ -41,6 +42,32 @@ def list_estimators_tool(
     """
     registry = get_registry()
     try:
+        # Validate task
+        if task is not None:
+            valid_tasks = registry.get_available_tasks()
+            if task not in valid_tasks:
+                suggestions = difflib.get_close_matches(task, valid_tasks, n=3, cutoff=0.6)
+                return {
+                    "success": False,
+                    "error": f"Invalid task: '{task}'. Valid options: {valid_tasks}."
+                    + (f" Did you mean: {suggestions}?" if suggestions else ""),
+                }
+
+        # Validate tag keys
+        if tags is not None:
+            valid_tag_keys = {t["tag"] for t in registry.get_available_tags()}
+            invalid_keys = [k for k in tags if k not in valid_tag_keys]
+            if invalid_keys:
+                suggestions = {
+                    k: difflib.get_close_matches(k, valid_tag_keys, n=1, cutoff=0.6)
+                    for k in invalid_keys
+                }
+                return {
+                    "success": False,
+                    "error": f"Invalid tag key(s): {invalid_keys}. Use get_available_tags to see valid keys.",
+                    "suggestions": {k: v[0] if v else None for k, v in suggestions.items()},
+                }
+
         if query:
             estimators = registry.search_estimators(query)
             if task:


### PR DESCRIPTION
## Problem

`list_estimators` silently returns `success: true` with zero results 
when given an invalid task name or unknown tag key. An LLM agent 
interprets this as "no estimators match" rather than "the filter was wrong", 
derailing downstream model selection.

Closes #316

## Fix

Added validation before filtering:

- **Invalid task** — returns `success: false` with the list of valid tasks 
  and a typo suggestion via `difflib.get_close_matches` 
  (e.g. `"forcasting"` → suggests `"forecasting"`)
- **Invalid tag key** — returns `success: false` with the invalid keys 
  and close-match suggestions, directing the agent to call 
  `get_available_tags` for the full catalog

Valid inputs are unaffected.

## Example

```python
list_estimators_tool(task="forcasting")
# {"success": False, "error": "Invalid task: 'forcasting'. Valid options: [...]. Did you mean: ['forecasting']?"}

list_estimators_tool(tags={"pred_int": True})
# {"success": False, "error": "Invalid tag key(s): ['pred_int']...", "suggestions": {"pred_int": None}}

testi the agentic workflow end-to-end as part of my ESOC 2026 application for the sktime Agentic Track.


