### PR TITLE
[BUG] fix: validate limit parameter in list_jobs_tool to prevent silent empty results

### DIFF
--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -64,6 +64,12 @@ def list_jobs_tool(
                 "error": f"Invalid status '{status}'. Valid values: pending, running, completed, failed, cancelled",
             }
 
+    if limit < 1:
+        return {
+            "success": False,
+            "error": "limit must be a positive integer.",
+        }
+
     jobs = job_manager.list_jobs(status=status_filter, limit=limit)
 
     return {


### PR DESCRIPTION
## Summary

Fixes #320

`list_jobs_tool` validates the `status` parameter but never validates `limit`. Passing `limit=0` or a negative value silently returns an empty jobs list with `success: True`, misleading an LLM agent into thinking no jobs exist.

## Changes

- `src/sktime_mcp/tools/job_tools.py` — 6 lines added

## Type of Change
- [x] Bug fix (non-breaking — adds input validation consistent with #319 fix for list_estimators_tool)

## Checklist
- [x] Linked to issue #320
- [x] Only 1 file changed
- [x] 1 commit
- [x] Fix matches existing code style
- [x] ruff format passes
