### PR TITLE
FIX: reject invalid cv_folds values in evaluate_estimator_tool

### DIFF
--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -49,9 +49,20 @@ def evaluate_estimator_tool(
     y = data_result["data"]
     X = data_result.get("exog")
 
+    if isinstance(cv_folds, bool):
+        return {"success": False, "error": "cv_folds must be a positive integer."}
+
+    try:
+        requested_folds = int(cv_folds)
+    except (TypeError, ValueError):
+        return {"success": False, "error": "cv_folds must be a positive integer."}
+
+    if requested_folds < 1:
+        return {"success": False, "error": "cv_folds must be a positive integer."}
+
     try:
         n = len(y)
-        folds = max(1, min(int(cv_folds), max(1, n - 1)))
+        folds = min(requested_folds, max(1, n - 1))
         # Exactly `folds` backtest windows: train grows, last fold uses n-1 obs before last point.
         initial_window = max(1, n - folds)
         cv = ExpandingWindowSplitter(initial_window=initial_window, step_length=1, fh=[1])
@@ -69,7 +80,7 @@ def evaluate_estimator_tool(
             "success": True,
             "results": metrics,
             "cv_folds_run": len(metrics),
-            "cv_folds_requested": int(cv_folds),
+            "cv_folds_requested": requested_folds,
         }
     except Exception as e:
         logger.exception("Error during evaluate")

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -38,5 +38,25 @@ def test_evaluate_estimator_tool():
         executor._handle_manager.release_handle(handle)
 
 
+@pytest.mark.parametrize("cv_folds", [0, -1, "abc", True])
+def test_evaluate_estimator_tool_rejects_invalid_cv_folds(cv_folds):
+    """Invalid fold counts should fail fast instead of being coerced."""
+    from sktime.forecasting.naive import NaiveForecaster
+
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+
+    executor = get_executor()
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+
+    try:
+        result = evaluate_estimator_tool(handle, "airline", cv_folds=cv_folds)
+
+        assert result["success"] is False
+        assert result["error"] == "cv_folds must be a positive integer."
+    finally:
+        executor._handle_manager.release_handle(handle)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Reference Issues/PRs

Closes #322.

## What does this implement/fix? Explain your changes.

This PR makes `evaluate_estimator_tool` fail fast when `cv_folds` is invalid instead of silently coercing the request to a one-fold evaluation.

Before this change, calls like `cv_folds=0` or `cv_folds=-1` returned `success: true` and ran one fold anyway. That made the response inconsistent with the user request and could mislead MCP clients or LLM agents into believing the requested evaluation actually happened.

The new behavior rejects invalid values with:

```python
{"success": False, "error": "cv_folds must be a positive integer."}
```

Valid inputs still behave the same as before, including clamping large fold counts to the dataset size limit.

## Does your contribution introduce a new dependency? If yes, which one?

No.

## What should a reviewer concentrate their feedback on?

- Whether the validation boundary for `cv_folds` is appropriate
- Whether accepting integer-like string inputs via `int(cv_folds)` is acceptable for tool-level robustness
- Whether the error wording should align with other parameter-validation responses

## Did you add any tests for the change?

Yes. The PR adds tests covering:

- `cv_folds=0`
- `cv_folds=-1`
- `cv_folds="abc"`
- `cv_folds=True`

All of these now return a clear validation error.

## Any other comments?

Validation run locally:

```
.venv/bin/python -m ruff check src/sktime_mcp/tools/evaluate.py tests/test_evaluate.py
.venv/bin/python -m ruff format --check src/sktime_mcp/tools/evaluate.py tests/test_evaluate.py
git diff --check
.venv/bin/python -m pytest tests/test_evaluate.py -q
.venv/bin/python -m pytest -q
```

Full test suite passed locally with pre-existing async warnings unrelated to this change.

## Checklist

- [x] Added tests for the change
- [x] Ran local tests
- [x] No new dependency introduced
