### PR TITLE
FIX: enforce exclusive dataset/data_handle inputs in fit_predict

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -192,10 +192,19 @@ class Executor:
         data_handle: str | None = None,
     ) -> dict[str, Any]:
         """Convenience method: load data, fit, and predict."""
+        if dataset and data_handle:
+            return {
+                "success": False,
+                "error": "Provide either 'dataset' or 'data_handle', not both.",
+            }
+
         if data_handle is None and (not dataset or not str(dataset).strip()):
             return {
                 "success": False,
-                "error": "Provide either dataset (demo name) or data_handle from load_data_source.",
+                "error": (
+                    "Either 'dataset' (e.g. 'airline') or "
+                    "'data_handle' (from load_data_source) is required."
+                ),
             }
         if data_handle is not None:
             # Use custom loaded data

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -41,10 +41,19 @@ def fit_predict_tool(
             "horizon": 12
         }
     """
+    if dataset and data_handle:
+        return {
+            "success": False,
+            "error": "Provide either 'dataset' or 'data_handle', not both.",
+        }
+
     if data_handle is None and (not dataset or not str(dataset).strip()):
         return {
             "success": False,
-            "error": "Provide either dataset (demo name) or data_handle from load_data_source.",
+            "error": (
+                "Either 'dataset' (e.g. 'airline') or "
+                "'data_handle' (from load_data_source) is required."
+            ),
         }
     executor = get_executor()
     return executor.fit_predict(estimator_handle, dataset, horizon, data_handle=data_handle)

--- a/tests/test_async_custom_data.py
+++ b/tests/test_async_custom_data.py
@@ -120,5 +120,72 @@ class TestAsyncCustomData:
         assert "job_id" in result
 
 
+class TestSyncCustomData:
+    """Tests for fit_predict_tool input validation parity with async flow."""
+
+    def _get_estimator_handle(self):
+        """Create a NaiveForecaster handle for reuse."""
+        from sktime_mcp.runtime.executor import get_executor
+
+        executor = get_executor()
+        result = executor.instantiate("NaiveForecaster", {"strategy": "last"})
+        assert result["success"], f"Failed to instantiate: {result}"
+        return result["handle"]
+
+    def _load_custom_data(self):
+        """Load custom data and return the data handle."""
+        import pandas as pd
+
+        from sktime_mcp.runtime.executor import get_executor
+
+        executor = get_executor()
+        config = {
+            "type": "pandas",
+            "data": {
+                "date": pd.date_range("2021-01-01", periods=20, freq="D").tolist(),
+                "sales": [50 + i for i in range(20)],
+            },
+            "time_column": "date",
+            "target_column": "sales",
+        }
+        result = executor.load_data_source(config)
+        assert result["success"], f"Data load failed: {result}"
+        return result["data_handle"]
+
+    def test_sync_both_provided_error(self):
+        """Providing both dataset and data_handle should fail."""
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
+
+        handle = self._get_estimator_handle()
+        data_handle = self._load_custom_data()
+
+        result = fit_predict_tool(
+            estimator_handle=handle,
+            dataset="airline",
+            data_handle=data_handle,
+            horizon=3,
+        )
+
+        assert not result["success"]
+        assert result["error"] == "Provide either 'dataset' or 'data_handle', not both."
+
+    def test_sync_neither_provided_error(self):
+        """Omitting both dataset and data_handle should fail."""
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
+
+        handle = self._get_estimator_handle()
+        result = fit_predict_tool(
+            estimator_handle=handle,
+            dataset="",
+            horizon=3,
+        )
+
+        assert not result["success"]
+        assert (
+            result["error"]
+            == "Either 'dataset' (e.g. 'airline') or 'data_handle' (from load_data_source) is required."
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Reference Issues/PRs

Closes #324.

## What does this implement/fix? Explain your changes.

This PR makes the sync `fit_predict` path reject ambiguous calls that provide both `dataset` and `data_handle`.

Before this change, `fit_predict` silently preferred `data_handle` and ignored `dataset`, while still returning `success: true`. That meant the tool could execute a different request than the one expressed in the arguments.

The async variant already enforces that exactly one of `dataset` or `data_handle` must be provided, so this PR brings the sync path into parity with the existing async contract.

The new behavior is:

- both provided -> `success: false` with `Provide either dataset or data_handle, not both.`\n- neither provided -> `success: false` with a clear required-input message\n- dataset-only and data_handle-only flows continue to work as before\n\nThe validation is implemented in both:\n\n- `fit_predict_tool`\n- `Executor.fit_predict`\n\nThat keeps the behavior consistent whether the call comes through the tool layer or directly through the executor.\n\n## Does your contribution introduce a new dependency? If yes, which one?\n\nNo.\n\n## What should a reviewer concentrate their feedback on?\n\n- Whether the sync error behavior should exactly mirror the async tool wording\n- Whether validating at both tool and executor layers is the right consistency boundary\n- Whether the neither-provided message is clear enough for MCP clients\n\n## Did you add any tests for the change?\n\nYes. The PR adds sync coverage for:\n\n- both `dataset` and `data_handle` provided\n- neither input provided\n\nIt also preserves the existing async parity tests already in the suite.\n\n## Any other comments?\n\nValidation run locally:\n\n```\n.venv/bin/python -m ruff check src/sktime_mcp/tools/fit_predict.py src/sktime_mcp/runtime/executor.py tests/test_async_custom_data.py\n.venv/bin/python -m ruff format --check src/sktime_mcp/tools/fit_predict.py src/sktime_mcp/runtime/executor.py tests/test_async_custom_data.py\ngit diff --check\n.venv/bin/python -m pytest tests/test_async_custom_data.py -q\n.venv/bin/python -m pytest -q\n```\n\nFull test suite passed locally with the same pre-existing async warnings currently present on `main`.\n\n## Checklist\n\n- [x] Added tests for the change\n- [x] Ran local tests\n- [x] No new dependency introduced\n