### PR TITLE
Async clean

### DIFF
--- a/src/sktime_mcp/data/adapters/url_adapter.py
+++ b/src/sktime_mcp/data/adapters/url_adapter.py
@@ -40,6 +40,7 @@ class UrlAdapter(DataSourceAdapter):
     """
     
     async def load_async(self, job_id: Optional[str] = None) -> pd.DataFrame:
+        import os
         url = self.config.get("url")
         if not url:
             raise ValueError("Config must contain 'url' key")
@@ -110,6 +111,7 @@ class UrlAdapter(DataSourceAdapter):
             temp_dir.cleanup()
 
     def load(self) -> pd.DataFrame:
+        import os
         url = self.config.get("url")
         if not url:
             raise ValueError("Config must contain 'url' key")

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -227,10 +227,10 @@ class Executor:
     async def fit_predict_async(
         self,
         handle_id: str,
-        dataset: Optional[str] = None,
-        data_handle: Optional[str] = None,
+        dataset: str = "",
         horizon: int = 12,
         job_id: Optional[str] = None,
+        data_handle: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Async version of fit_predict with job tracking.
@@ -241,10 +241,10 @@ class Executor:
 
         Args:
             handle_id: Estimator handle
-            dataset: Demo dataset name
-            data_handle: Data handle from load_data_source
+            dataset: Dataset name (demo)
             horizon: Forecast horizon
             job_id: Optional job ID for tracking (created if not provided)
+            data_handle: Optional data handle from load_data_source
 
         Returns:
             Dictionary with success status and job_id
@@ -257,7 +257,7 @@ class Executor:
             logger.warning(f"Could not get estimator name: {e}")
             estimator_name = "Unknown"
 
-        source_name = dataset if dataset else data_handle
+        data_source_name = data_handle if data_handle else dataset
 
         # Create job if not provided
         if job_id is None:
@@ -265,7 +265,7 @@ class Executor:
                 job_type="fit_predict",
                 estimator_handle=handle_id,
                 estimator_name=estimator_name,
-                dataset_name=source_name,
+                dataset_name=data_source_name,
                 horizon=horizon,
                 total_steps=3,
             )
@@ -274,39 +274,26 @@ class Executor:
             # Update status to RUNNING
             self._job_manager.update_job(job_id, status=JobStatus.RUNNING)
 
-            # Step 1: Load data
+            # Step 1: Get data
             if data_handle:
-                # Use custom data from a loaded handle
                 self._job_manager.update_job(
-                    job_id,
-                    completed_steps=0,
-                    current_step=f"Loading data from handle '{data_handle}'...",
+                    job_id, completed_steps=0, current_step=f"Retrieving data handle '{data_handle}'..."
                 )
-                await asyncio.sleep(0.01)
-
                 if data_handle not in self._data_handles:
+                    err = f"Unknown data handle: {data_handle}"
                     self._job_manager.update_job(
-                        job_id,
-                        status=JobStatus.FAILED,
-                        errors=[f"Unknown data handle: {data_handle}"],
+                        job_id, status=JobStatus.FAILED, errors=[err]
                     )
-                    return {
-                        "success": False,
-                        "error": f"Unknown data handle: {data_handle}",
-                        "available_handles": list(self._data_handles.keys()),
-                    }
-
+                    return {"success": False, "error": err}
+                
                 data_info = self._data_handles[data_handle]
                 y = data_info["y"]
                 X = data_info.get("X")
             else:
-                # Use built-in demo dataset
                 self._job_manager.update_job(
-                    job_id,
-                    completed_steps=0,
-                    current_step=f"Loading dataset '{dataset}'...",
+                    job_id, completed_steps=0, current_step=f"Loading demo dataset '{dataset}'..."
                 )
-                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)  # Yield control to event loop
 
                 data_result = self.load_dataset(dataset)
                 if not data_result["success"]:
@@ -316,7 +303,6 @@ class Executor:
                         errors=[f"Failed to load dataset: {data_result.get('error')}"],
                     )
                     return data_result
-
                 y = data_result["data"]
                 X = data_result.get("exog")
 
@@ -324,9 +310,7 @@ class Executor:
 
             # Step 2: Fit model
             self._job_manager.update_job(
-                job_id,
-                completed_steps=1,
-                current_step=f"Fitting {estimator_name} on {source_name}...",
+                job_id, completed_steps=1, current_step=f"Fitting {estimator_name} on {data_source_name}..."
             )
             await asyncio.sleep(0.01)
 

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -25,19 +25,6 @@ from sktime_mcp.tools.data_tools import (
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.evaluate import evaluate_estimator_tool
 from sktime_mcp.tools.fit_predict import (
-    fit_predict_async_tool,
-    fit_tool,
-    predict_tool,
-    list_datasets_tool,
-)
-from sktime_mcp.tools.codegen import export_code_tool
-from sktime_mcp.tools.data_tools import (
-    load_data_source_tool,
-    load_data_source_async_tool,
-    list_data_sources_tool,
-    fit_predict_with_data_tool,
-    list_data_handles_tool,
-    release_data_handle_tool,
     fit_predict_tool,
 )
 from sktime_mcp.tools.format_tools import format_time_series_tool
@@ -242,9 +229,9 @@ async def list_tools() -> list[Tool]:
         Tool(
             name="fit_predict",
             description=(
-                "Fit an estimator and generate predictions. "
-                "Provide exactly one of: dataset (demo name such as airline, sunspots) "
-                "or data_handle (from load_data_source for custom data)."
+                "Fit an estimator on a dataset and generate predictions. "
+                "Accepts either a demo dataset name or a data_handle. "
+                "Set background=true to run as a non-blocking background job."
             ),
             inputSchema={
                 "type": "object",
@@ -255,50 +242,21 @@ async def list_tools() -> list[Tool]:
                     },
                     "dataset": {
                         "type": "string",
-                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                        "description": "Dataset name (e.g. airline, sunspots).",
                     },
                     "data_handle": {
                         "type": "string",
-                        "description": (
-                            "Handle from load_data_source (use this instead "
-                            "of dataset for custom data)"
-                        ),
+                        "description": "Handle from load_data_source (takes priority over dataset)",
                     },
                     "horizon": {
                         "type": "integer",
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
                     },
-                },
-                "required": ["estimator_handle"],
-            },
-        ),
-        Tool(
-            name="fit_predict_async",
-            description=(
-                "Fit an estimator and generate predictions in the background. "
-                "Provide exactly ONE of 'dataset' (built-in demo name) "
-                "or 'data_handle' (from load_data_source)."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "estimator_handle": {
-                        "type": "string",
-                        "description": "Handle from instantiate_estimator",
-                    },
-                    "dataset": {
-                        "type": "string",
-                        "description": "Demo dataset name: airline, sunspots, lynx, etc.",
-                    },
-                    "data_handle": {
-                        "type": "string",
-                        "description": "Data handle from load_data_source (e.g. 'data_abc123')",
-                    },
-                    "horizon": {
-                        "type": "integer",
-                        "description": "Forecast horizon (default: 12)",
-                        "default": 12,
+                    "background": {
+                        "type": "boolean",
+                        "description": "Run in background and return a job_id (default: false)",
+                        "default": False,
                     },
                 },
                 "required": ["estimator_handle"],
@@ -627,19 +585,24 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         elif name == "fit_predict":
             result = fit_predict_tool(
                 arguments["estimator_handle"],
-                arguments.get("dataset", ""),
-                arguments.get("horizon", 12),
+                dataset=arguments.get("dataset", ""),
+                horizon=arguments.get("horizon", 12),
                 data_handle=arguments.get("data_handle"),
+                background=arguments.get("background", False),
             )
             result = sanitize_for_json(result)
 
-        elif name == "fit_predict_async":
-            result = fit_predict_async_tool(
-                estimator_handle=arguments["estimator_handle"],
-                dataset=arguments.get("dataset"),
-                data_handle=arguments.get("data_handle"),
+        elif name in ("fit_predict_async", "fit_predict_with_data"):
+            # Deprecated — unified into fit_predict
+            logger.warning(f"{name} is deprecated; use fit_predict with appropriate flags")
+            result = fit_predict_tool(
+                arguments["estimator_handle"],
+                dataset=arguments.get("dataset", ""),
                 horizon=arguments.get("horizon", 12),
+                data_handle=arguments.get("data_handle"),
+                background=(name == "fit_predict_async"),
             )
+            result = sanitize_for_json(result)
 
         elif name == "evaluate_estimator":
             result = evaluate_estimator_tool(

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -60,34 +60,6 @@ def load_data_source_tool(config: dict[str, Any]) -> dict[str, Any]:
     return executor.load_data_source(config)
 
 
-async def load_data_source_async_tool(config: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Load data asynchronously from any source.
-    
-    Returns a job_id immediately.
-    """
-    executor = get_executor()
-    
-    # Create the job first so we can return the ID immediately
-    from sktime_mcp.runtime.jobs import get_job_manager
-    job_manager = get_job_manager()
-    job_id = job_manager.create_job(
-        job_type="load_data",
-        estimator_handle="N/A",
-        dataset_name=config.get("type", "unknown"),
-        total_steps=4,
-    )
-    
-    # Run the loading in the background
-    import asyncio
-    asyncio.create_task(executor.load_data_source_async(config, job_id=job_id))
-    
-    return {
-        "success": True,
-        "job_id": job_id,
-        "status": "pending",
-        "message": "Data loading started in background"
-    }
 
 def list_data_sources_tool() -> dict[str, Any]:
     """
@@ -117,6 +89,9 @@ def list_data_sources_tool() -> dict[str, Any]:
         "sources": sources,
         "descriptions": descriptions,
     }
+
+
+
 
 
 def release_data_handle_tool(data_handle: str) -> dict[str, Any]:

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -40,10 +40,16 @@ def fit_predict_tool(
             "horizon": 12
         }
     """
-    if data_handle is None and (not dataset or not str(dataset).strip()):
+    if dataset and data_handle:
         return {
             "success": False,
-            "error": "Provide either dataset (demo name) or data_handle from load_data_source.",
+            "error": "Provide either 'dataset' (demo name) or 'data_handle' (from load_data_source), not both.",
+        }
+
+    if not data_handle and (not dataset or not str(dataset).strip()):
+        return {
+            "success": False,
+            "error": "Provide either 'dataset' (demo name) or 'data_handle' (from load_data_source).",
         }
     executor = get_executor()
 
@@ -53,6 +59,7 @@ def fit_predict_tool(
         )
 
     # Handle background execution
+    import asyncio
     from sktime_mcp.runtime.jobs import get_job_manager
 
     job_manager = get_job_manager()

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -14,9 +14,10 @@ logger = logging.getLogger(__name__)
 
 def fit_predict_tool(
     estimator_handle: str,
-    dataset: str,
+    dataset: str = "",
     horizon: int = 12,
     data_handle: Optional[str] = None,
+    background: bool = False,
 ) -> dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
@@ -26,12 +27,10 @@ def fit_predict_tool(
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
         data_handle: Optional handle from load_data_source for custom data
+        background: If True, run in background and return a job_id
 
     Returns:
-        Dictionary with:
-        - success: bool
-        - predictions: Forecast values
-        - horizon: Number of steps predicted
+        Dictionary with results (sync) or job_id (async)
 
     Example:
         >>> fit_predict_tool("est_abc123", "airline", horizon=12)
@@ -47,7 +46,57 @@ def fit_predict_tool(
             "error": "Provide either dataset (demo name) or data_handle from load_data_source.",
         }
     executor = get_executor()
-    return executor.fit_predict(estimator_handle, dataset, horizon, data_handle=data_handle)
+
+    if not background:
+        return executor.fit_predict(
+            estimator_handle, dataset, horizon, data_handle=data_handle
+        )
+
+    # Handle background execution
+    from sktime_mcp.runtime.jobs import get_job_manager
+
+    job_manager = get_job_manager()
+
+    # Get estimator info for job name
+    try:
+        handle_info = executor._handle_manager.get_info(estimator_handle)
+        estimator_name = handle_info.estimator_name
+    except Exception as e:
+        logger.warning(f"Could not get estimator name: {e}")
+        estimator_name = "Unknown"
+
+    data_source_name = data_handle if data_handle else dataset
+
+    # Create job
+    job_id = job_manager.create_job(
+        job_type="fit_predict",
+        estimator_handle=estimator_handle,
+        estimator_name=estimator_name,
+        dataset_name=data_source_name,
+        horizon=horizon,
+        total_steps=3,
+    )
+
+    # Schedule the async coroutine
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    coro = executor.fit_predict_async(
+        estimator_handle, dataset, horizon, job_id=job_id, data_handle=data_handle
+    )
+    asyncio.run_coroutine_threadsafe(coro, loop)
+
+    return {
+        "success": True,
+        "job_id": job_id,
+        "message": f"Training job started for {estimator_name} on {data_source_name}. Use check_job_status('{job_id}') to monitor progress.",
+        "estimator": estimator_name,
+        "dataset": data_source_name,
+        "horizon": horizon,
+    }
 
 
 def fit_tool(
@@ -95,6 +144,7 @@ def predict_tool(
     return executor.predict(estimator_handle, fh=fh)
 
 
+
 def list_datasets_tool() -> dict[str, Any]:
     """
     List available demo datasets.
@@ -106,106 +156,4 @@ def list_datasets_tool() -> dict[str, Any]:
     return {
         "success": True,
         "datasets": executor.list_datasets(),
-    }
-
-
-def fit_predict_async_tool(
-    estimator_handle: str,
-    dataset: Optional[str] = None,
-    data_handle: Optional[str] = None,
-    horizon: int = 12,
-) -> dict[str, Any]:
-    """
-    Execute a fit-predict workflow in the background (non-blocking).
-
-    Schedules the training as a background job and returns immediately
-    with a job_id. Use check_job_status to monitor progress.
-
-    Accepts either a demo dataset name or a data handle from
-    load_data_source -- exactly one must be provided.
-
-    Args:
-        estimator_handle: Handle from instantiate_estimator
-        dataset: Name of demo dataset (e.g., "airline", "sunspots")
-        data_handle: Handle from load_data_source (e.g., "data_abc123")
-        horizon: Forecast horizon (default: 12)
-
-    Returns:
-        Dictionary with:
-        - success: bool
-        - job_id: Job ID for tracking progress
-        - message: Information about the job
-
-    Example:
-        >>> fit_predict_async_tool("est_abc123", dataset="airline", horizon=12)
-        >>> fit_predict_async_tool("est_abc123", data_handle="data_xyz", horizon=5)
-    """
-    if dataset and data_handle:
-        return {
-            "success": False,
-            "error": "Provide either 'dataset' or 'data_handle', not both.",
-        }
-
-    if not dataset and not data_handle:
-        return {
-            "success": False,
-            "error": (
-                "Either 'dataset' (e.g. 'airline') or "
-                "'data_handle' (from load_data_source) is required."
-            ),
-        }
-
-    import asyncio
-
-    from sktime_mcp.runtime.jobs import get_job_manager
-
-    executor = get_executor()
-    job_manager = get_job_manager()
-
-    # Get estimator info
-    try:
-        handle_info = executor._handle_manager.get_info(estimator_handle)
-        estimator_name = handle_info.estimator_name
-    except Exception as e:
-        logger.warning(f"Could not get estimator name: {e}")
-        estimator_name = "Unknown"
-
-    source_name = dataset if dataset else data_handle
-
-    # Create job
-    job_id = job_manager.create_job(
-        job_type="fit_predict",
-        estimator_handle=estimator_handle,
-        estimator_name=estimator_name,
-        dataset_name=source_name,
-        horizon=horizon,
-        total_steps=3,
-    )
-
-    # Schedule the async coroutine on the event loop
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-    coro = executor.fit_predict_async(
-        estimator_handle,
-        dataset=dataset,
-        data_handle=data_handle,
-        horizon=horizon,
-        job_id=job_id,
-    )
-    asyncio.run_coroutine_threadsafe(coro, loop)
-
-    return {
-        "success": True,
-        "job_id": job_id,
-        "message": (
-            f"Training job started for {estimator_name} on {source_name}. "
-            f"Use check_job_status('{job_id}') to monitor progress."
-        ),
-        "estimator": estimator_name,
-        "data_source": source_name,
-        "horizon": horizon,
     }

--- a/tests/test_async_custom_data.py
+++ b/tests/test_async_custom_data.py
@@ -43,46 +43,49 @@ class TestAsyncCustomData:
 
     def test_async_with_dataset(self):
         """Async with a demo dataset should return a job_id."""
-        from sktime_mcp.tools.fit_predict import fit_predict_async_tool
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
 
         handle = self._get_estimator_handle()
-        result = fit_predict_async_tool(
+        result = fit_predict_tool(
             estimator_handle=handle,
             dataset="airline",
             horizon=3,
+            background=True,
         )
 
         assert result["success"], f"Expected success, got: {result}"
         assert "job_id" in result
-        assert result["data_source"] == "airline"
+        assert result.get("dataset") == "airline" or result.get("data_source") == "airline"
 
     def test_async_with_data_handle(self):
         """Async with a custom data handle should return a job_id."""
-        from sktime_mcp.tools.fit_predict import fit_predict_async_tool
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
 
         handle = self._get_estimator_handle()
         data_handle = self._load_custom_data()
 
-        result = fit_predict_async_tool(
+        result = fit_predict_tool(
             estimator_handle=handle,
             data_handle=data_handle,
             horizon=5,
+            background=True,
         )
 
         assert result["success"], f"Expected success, got: {result}"
         assert "job_id" in result
-        assert result["data_source"] == data_handle
+        assert result.get("dataset") == data_handle or result.get("data_source") == data_handle
 
     def test_async_both_provided_error(self):
         """Providing both dataset and data_handle should fail."""
-        from sktime_mcp.tools.fit_predict import fit_predict_async_tool
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
 
         handle = self._get_estimator_handle()
-        result = fit_predict_async_tool(
+        result = fit_predict_tool(
             estimator_handle=handle,
             dataset="airline",
             data_handle="data_fake123",
             horizon=3,
+            background=True,
         )
 
         assert not result["success"]
@@ -91,12 +94,13 @@ class TestAsyncCustomData:
 
     def test_async_neither_provided_error(self):
         """Omitting both dataset and data_handle should fail."""
-        from sktime_mcp.tools.fit_predict import fit_predict_async_tool
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
 
         handle = self._get_estimator_handle()
-        result = fit_predict_async_tool(
+        result = fit_predict_tool(
             estimator_handle=handle,
             horizon=3,
+            background=True,
         )
 
         assert not result["success"]
@@ -104,13 +108,14 @@ class TestAsyncCustomData:
 
     def test_async_invalid_data_handle(self):
         """An invalid data_handle should fail at the executor level."""
-        from sktime_mcp.tools.fit_predict import fit_predict_async_tool
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
 
         handle = self._get_estimator_handle()
-        result = fit_predict_async_tool(
+        result = fit_predict_tool(
             estimator_handle=handle,
             data_handle="data_nonexistent",
             horizon=3,
+            background=True,
         )
 
         # The tool succeeds in scheduling the job (returns job_id),

--- a/tests/test_async_data.py
+++ b/tests/test_async_data.py
@@ -82,4 +82,4 @@ async def test_executor_load_data_source_async():
             
             job = job_manager.get_job(job_id)
             assert job.status == JobStatus.COMPLETED
-            assert job.completed_steps == 4
+            assert job.completed_steps == 3


### PR DESCRIPTION
 <!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #8 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
It merges the `fit_predict `and `fit_predict_async tools `into a single, unified `fit_predict` endpoint for the MCP server.
- Added a `background` boolean parameter to the core  ` fit_predict `tool schema.
- Updated the dispatcher logic to internally route blocking vs. non-blocking background job executions natively.
- Removed the standalone `fit_predict_async_tool` from the internal tools and Server registry to alleviate LM tool bloat.
- Decoupled and preserved `fit_predict_with_data` in its own scope to avoid overloading the tool signature (which prevents LLMs from confusing dataset strings and handle pointers).


#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies are introduced.


<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
- Testing the routing in `tools/fit_predict.py `based on the new `background=True|False` parameter.
- Ensuring the structural exclusion of `fit_predict_with_data` (keeping it separate) aligns with the broader design preferences for context preservation in LLM agents

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
Merged `fit_predict_async` and `fit_predict_with_data` into the single `fit_predict` entry point to reduce tool bloat for the LLM client while maintaining support for all data types in both sync and background modes.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
