### PR TITLE
 [ENH] Merge Sync and Async Tooling into a Single Interface

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -26,7 +26,7 @@ from sktime_mcp.tools.data_tools import (
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.evaluate import evaluate_estimator_tool
 from sktime_mcp.tools.fit_predict import (
-    fit_predict_async_tool,
+    fit_predict_tool,
 )
 from sktime_mcp.tools.format_tools import format_time_series_tool
 from sktime_mcp.tools.instantiate import (
@@ -232,7 +232,8 @@ async def list_tools() -> list[Tool]:
             description=(
                 "Fit an estimator and generate predictions. "
                 "Provide exactly one of: dataset (demo name such as airline, sunspots) "
-                "or data_handle (from load_data_source for custom data)."
+                "or data_handle (from load_data_source for custom data). "
+                "Set background=true to run as a background job."
             ),
             inputSchema={
                 "type": "object",
@@ -257,36 +258,10 @@ async def list_tools() -> list[Tool]:
                         "description": "Forecast horizon (default: 12)",
                         "default": 12,
                     },
-                },
-                "required": ["estimator_handle"],
-            },
-        ),
-        Tool(
-            name="fit_predict_async",
-            description=(
-                "Fit an estimator and generate predictions in the background. "
-                "Provide exactly ONE of 'dataset' (built-in demo name) "
-                "or 'data_handle' (from load_data_source)."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "estimator_handle": {
-                        "type": "string",
-                        "description": "Handle from instantiate_estimator",
-                    },
-                    "dataset": {
-                        "type": "string",
-                        "description": "Demo dataset name: airline, sunspots, lynx, etc.",
-                    },
-                    "data_handle": {
-                        "type": "string",
-                        "description": "Data handle from load_data_source (e.g. 'data_abc123')",
-                    },
-                    "horizon": {
-                        "type": "integer",
-                        "description": "Forecast horizon (default: 12)",
-                        "default": 12,
+                    "background": {
+                        "type": "boolean",
+                        "description": "Run in background and return a job_id (default: false)",
+                        "default": False,
                     },
                 },
                 "required": ["estimator_handle"],
@@ -618,16 +593,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments.get("dataset", ""),
                 arguments.get("horizon", 12),
                 data_handle=arguments.get("data_handle"),
+                background=arguments.get("background", False),
             )
             result = sanitize_for_json(result)
-
-        elif name == "fit_predict_async":
-            result = fit_predict_async_tool(
-                estimator_handle=arguments["estimator_handle"],
-                dataset=arguments.get("dataset"),
-                data_handle=arguments.get("data_handle"),
-                horizon=arguments.get("horizon", 12),
-            )
 
         elif name == "evaluate_estimator":
             result = evaluate_estimator_tool(

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -14,9 +14,10 @@ logger = logging.getLogger(__name__)
 
 def fit_predict_tool(
     estimator_handle: str,
-    dataset: str,
+    dataset: str | None = None,
     horizon: int = 12,
     data_handle: str | None = None,
+    background: bool = False,
 ) -> dict[str, Any]:
     """
     Execute a complete fit-predict workflow.
@@ -26,11 +27,13 @@ def fit_predict_tool(
         dataset: Name of demo dataset (e.g., "airline", "sunspots")
         horizon: Forecast horizon (default: 12)
         data_handle: Optional handle from load_data_source for custom data
+        background: If True, run in background and return job_id (default: False)
 
     Returns:
         Dictionary with:
         - success: bool
-        - predictions: Forecast values
+        - predictions: Forecast values (if background=False)
+        - job_id: Job ID (if background=True)
         - horizon: Number of steps predicted
 
     Example:
@@ -41,6 +44,14 @@ def fit_predict_tool(
             "horizon": 12
         }
     """
+    if background:
+        return fit_predict_async_tool(
+            estimator_handle=estimator_handle,
+            dataset=dataset,
+            data_handle=data_handle,
+            horizon=horizon,
+        )
+
     if data_handle is None and (not dataset or not str(dataset).strip()):
         return {
             "success": False,


### PR DESCRIPTION
 <!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #8 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
It merges the `fit_predict `and `fit_predict_async tools `into a single, unified `fit_predict` endpoint for the MCP server.
- Added a `background` boolean parameter to the core  ` fit_predict `tool schema.
- Updated the dispatcher logic to internally route blocking vs. non-blocking background job executions natively.
- Removed the standalone `fit_predict_async_tool` from the internal tools and Server registry to alleviate LM tool bloat.
- Decoupled and preserved `fit_predict_with_data` in its own scope to avoid overloading the tool signature (which prevents LLMs from confusing dataset strings and handle pointers).


#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies are introduced.


<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?
- Testing the routing in `tools/fit_predict.py `based on the new `background=True|False` parameter.
- Ensuring the structural exclusion of `fit_predict_with_data` (keeping it separate) aligns with the broader design preferences for context preservation in LLM agents

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
Merged `fit_predict_async` and `fit_predict_with_data` into the single `fit_predict` entry point to reduce tool bloat for the LLM client while maintaining support for all data types in both sync and background modes.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
