### PR TITLE
FIX: reject invalid var_name values in export_code_tool

### DIFF
--- a/src/sktime_mcp/tools/codegen.py
+++ b/src/sktime_mcp/tools/codegen.py
@@ -4,6 +4,7 @@ Code generation tool for sktime MCP.
 Generates Python code to recreate estimators and pipelines.
 """
 
+import keyword
 from typing import Any
 
 from sktime_mcp.registry.interface import get_registry
@@ -43,6 +44,11 @@ def _get_estimator_module(estimator_name: str) -> str | None:
     if node and node.class_ref:
         return node.class_ref.__module__
     return None
+
+
+def _is_valid_var_name(var_name: str) -> bool:
+    """Return True when var_name is a valid non-keyword Python identifier."""
+    return isinstance(var_name, str) and var_name.isidentifier() and not keyword.iskeyword(var_name)
 
 
 def _generate_single_estimator_code(
@@ -220,6 +226,12 @@ def export_code_tool(
         handle_info = handle_manager.get_info(handle)
     except KeyError:
         return {"success": False, "error": f"Handle not found: {handle}"}
+
+    if not _is_valid_var_name(var_name):
+        return {
+            "success": False,
+            "error": "var_name must be a valid Python identifier and not a keyword.",
+        }
 
     estimator_name = handle_info.estimator_name
     params = handle_info.params

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -15,6 +15,7 @@ from sktime_mcp.tools.codegen import (
     _format_value,
     _generate_pipeline_code,
     _generate_single_estimator_code,
+    _is_valid_var_name,
     export_code_tool,
 )
 from sktime_mcp.tools.instantiate import (
@@ -109,6 +110,26 @@ class TestSingleEstimatorCodeGen:
         result = _generate_single_estimator_code("NotARealEstimator99999", {})
         assert not result["success"]
         assert "error" in result
+
+
+class TestVarNameValidation:
+    """Tests for Python variable name validation in code export."""
+
+    def test_valid_var_name(self):
+        """A normal identifier should be accepted."""
+        assert _is_valid_var_name("my_forecaster") is True
+
+    def test_space_in_var_name_invalid(self):
+        """Names with spaces should be rejected."""
+        assert _is_valid_var_name("my forecaster") is False
+
+    def test_leading_digit_invalid(self):
+        """Names starting with digits should be rejected."""
+        assert _is_valid_var_name("123model") is False
+
+    def test_keyword_invalid(self):
+        """Python keywords should be rejected."""
+        assert _is_valid_var_name("class") is False
 
 
 class TestPipelineCodeGen:
@@ -228,6 +249,19 @@ class TestExportCodeTool:
             result = export_code_tool(handle, var_name="my_forecaster")
             assert result["success"]
             assert "my_forecaster" in result["code"]
+        finally:
+            self._cleanup_handle(handle)
+
+    @pytest.mark.parametrize("var_name", ["my model", "123model", "class"])
+    def test_invalid_var_name_fails(self, var_name):
+        """Invalid Python identifiers should fail fast."""
+        handle = self._create_handle()
+        try:
+            result = export_code_tool(handle, var_name=var_name)
+            assert result["success"] is False
+            assert (
+                result["error"] == "var_name must be a valid Python identifier and not a keyword."
+            )
         finally:
             self._cleanup_handle(handle)
 


### PR DESCRIPTION
## Reference Issues/PRs

Closes #328.

## What does this implement/fix? Explain your changes.

This PR makes `export_code_tool` validate `var_name` before generating Python code.

Before this change, the tool accepted arbitrary strings and interpolated them directly into the generated code. That meant invalid identifiers like:

- `"my model"`
- `"123model"`
- `"class"`

could still return `success: true` while producing non-executable Python.

The new behavior rejects invalid names with:

```python
{"success": False, "error": "var_name must be a valid Python identifier and not a keyword."}
```

This keeps the tool contract honest: a successful export should produce executable code, not syntactically broken output.

## Does your contribution introduce a new dependency? If yes, which one?

No.

## What should a reviewer concentrate their feedback on?

- Whether validating `var_name` at the tool boundary is the right scope
- Whether `str.isidentifier()` plus `keyword.iskeyword()` is sufficient for this use case
- Whether the error message is clear enough for MCP clients and agents to self-correct

## Did you add any tests for the change?

Yes. The PR adds tests covering:

- valid identifier names
- names with spaces
- names starting with digits
- reserved Python keywords
- `export_code_tool` failing fast on invalid `var_name` inputs

## Any other comments?

Validation run locally:

```
.venv/bin/python -m ruff check src/sktime_mcp/tools/codegen.py tests/test_codegen.py
.venv/bin/python -m ruff format --check src/sktime_mcp/tools/codegen.py tests/test_codegen.py
git diff --check
.venv/bin/python -m pytest tests/test_codegen.py -q
.venv/bin/python -m pytest -q
```

Full test suite passed locally with the same pre-existing async warnings currently present on `main`.

## Checklist

- [x] Added tests for the change
- [x] Ran local tests
- [x] No new dependency introduced
