### PR TITLE
FIX: retain active job records when delete=true is requested

### DIFF
--- a/src/sktime_mcp/runtime/jobs.py
+++ b/src/sktime_mcp/runtime/jobs.py
@@ -196,6 +196,11 @@ class JobManager:
 
             job = self.jobs[job_id]
 
+            # Cancelled jobs are terminal from the client's perspective.
+            # Ignore late updates from background work that may still be winding down.
+            if job.status == JobStatus.CANCELLED:
+                return True
+
             # Update status
             if status is not None:
                 old_status = job.status

--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -96,8 +96,7 @@ def cancel_job_tool(job_id: str, delete: bool = False) -> dict[str, Any]:
         job_manager.cancel_job(job_id)
         msg = f"Job '{job_id}' cancelled"
         if delete:
-            job_manager.delete_job(job_id)
-            msg += " and removed"
+            msg += "; record retained because active jobs cannot be removed immediately"
         return {"success": True, "message": msg}
 
     if delete:

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -135,6 +135,50 @@ def test_cancel_job():
     job_manager.delete_job(job_id)
 
 
+def test_cancel_job_delete_keeps_running_job_record():
+    """delete=True should not remove a running job record immediately."""
+    from sktime_mcp.tools.job_tools import cancel_job_tool
+
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job("fit_predict", "handle", "ARIMA")
+    job_manager.update_job(job_id, status=JobStatus.RUNNING)
+
+    result = cancel_job_tool(job_id, delete=True)
+
+    assert result["success"]
+    assert "retained" in result["message"]
+
+    job = job_manager.get_job(job_id)
+    assert job is not None
+    assert job.status == JobStatus.CANCELLED
+
+    job_manager.delete_job(job_id)
+
+
+def test_cancelled_job_ignores_late_updates():
+    """Cancelled jobs should stay cancelled even if background work reports later."""
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job("fit_predict", "handle", "ARIMA", total_steps=3)
+    job_manager.update_job(job_id, status=JobStatus.RUNNING)
+    job_manager.cancel_job(job_id)
+
+    job_manager.update_job(
+        job_id,
+        status=JobStatus.COMPLETED,
+        completed_steps=3,
+        current_step="Finished",
+        result={"predictions": {1: 100}},
+    )
+
+    job = job_manager.get_job(job_id)
+    assert job is not None
+    assert job.status == JobStatus.CANCELLED
+    assert job.completed_steps == 0
+    assert job.result is None
+
+    job_manager.delete_job(job_id)
+
+
 def test_cleanup_old_jobs():
     """Test cleaning up old jobs."""
     job_manager = get_job_manager()


### PR DESCRIPTION
## Reference Issues/PRs

Closes #166.

## What does this implement/fix? Explain your changes.

This PR fixes the current equivalent of the old `delete_job()` ghost-deletion bug described in #166.

The original issue predates the tool consolidation, but the same behavior still exists today through `cancel_job(job_id, delete=True)`:

- if a job is `pending` or `running`, the tool marks it cancelled
- then immediately deletes the job record
- but the background coroutine can continue running and reporting late updates

That leaves MCP clients with no way to inspect a still-active task and makes cancellation semantics misleading.

This PR makes two focused changes:

1. `cancel_job_tool(..., delete=True)` no longer removes active job records immediately. It cancels the job and returns a message explaining that the record is being retained.
2. `JobManager.update_job()` now treats `CANCELLED` as terminal and ignores late background updates, so cancelled jobs do not get overwritten to `COMPLETED` or accrue new result data after cancellation.

Together, these changes preserve observability and prevent cancelled jobs from being silently rewritten by in-flight background work.

## Does your contribution introduce a new dependency? If yes, which one?

No.

## What should a reviewer concentrate their feedback on?

- Whether `CANCELLED` should be treated as terminal in `update_job()`
- Whether retaining the record for active jobs is the right behavior for `delete=True`
- Whether the tool message is clear enough about why immediate removal is refused

## Did you add any tests for the change?

Yes. The PR adds tests for:

- `cancel_job_tool(job_id, delete=True)` retaining a running job record
- cancelled jobs ignoring late updates from background work

## Any other comments?

Validation run locally:

```
.venv/bin/python -m ruff check src/sktime_mcp/runtime/jobs.py src/sktime_mcp/tools/job_tools.py tests/test_background_jobs.py
.venv/bin/python -m ruff format --check src/sktime_mcp/runtime/jobs.py src/sktime_mcp/tools/job_tools.py tests/test_background_jobs.py
git diff --check
.venv/bin/python -m pytest tests/test_background_jobs.py -q
.venv/bin/python -m pytest -q
```

Full test suite passed locally with the same pre-existing async warnings currently present on `main`.

## Checklist

- [x] Added tests for the change
- [x] Ran local tests
- [x] No new dependency introduced
