### PR TITLE
FIX: validate limit parameter in search_estimators_tool 

### DIFF
--- a/src/sktime_mcp/tools/describe_estimator.py
+++ b/src/sktime_mcp/tools/describe_estimator.py
@@ -84,6 +84,12 @@ def search_estimators_tool(query: str, limit: int = 20) -> dict[str, Any]:
     Returns:
         Dictionary with matching estimators
     """
+    if limit < 1:
+        return {
+            "success": False,
+            "error": "limit must be a positive integer.",
+        }
+
     registry = get_registry()
 
     try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -248,5 +248,48 @@ class TestTools:
         assert calls["serialization_format"] == "pickle"
 
 
+class TestSearchEstimatorsLimit:
+    """Tests for the limit parameter validation in search_estimators_tool."""
+
+    def test_limit_zero_returns_error(self):
+        """limit=0 should return an error, not an empty list."""
+        from sktime_mcp.tools.describe_estimator import search_estimators_tool
+
+        result = search_estimators_tool("NaiveForecaster", limit=0)
+
+        assert not result["success"]
+        assert result["error"] == "limit must be a positive integer."
+
+    def test_limit_negative_one_returns_error(self):
+        """limit=-1 should return an error, not the last result."""
+        from sktime_mcp.tools.describe_estimator import search_estimators_tool
+
+        result = search_estimators_tool("NaiveForecaster", limit=-1)
+
+        assert not result["success"]
+        assert result["error"] == "limit must be a positive integer."
+
+    def test_limit_negative_five_returns_error(self):
+        """limit=-5 should return an error, not the last 5 results."""
+        from sktime_mcp.tools.describe_estimator import search_estimators_tool
+
+        result = search_estimators_tool("NaiveForecaster", limit=-5)
+
+        assert not result["success"]
+        assert result["error"] == "limit must be a positive integer."
+
+    def test_limit_valid_returns_results(self):
+        """A positive limit should work correctly and cap results."""
+        pytest.importorskip("sktime", reason="sktime not installed in this environment")
+        from sktime_mcp.tools.describe_estimator import search_estimators_tool
+
+        result = search_estimators_tool("Forecaster", limit=3)
+
+        assert result["success"]
+        assert "results" in result
+        assert len(result["results"]) <= 3
+        assert result["count"] <= 3
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #331

#### What does this implement/fix? Explain your changes.
`search_estimators_tool` in `describe_estimator.py` passed the `limit` 
parameter directly as a Python slice index with no validation, causing 
silent incorrect behavior:

- `limit=-1` silently returned the last result instead of an error
- `limit=-5` silently returned the last 5 results
- `limit=0` silently returned an empty list

This PR adds a validation guard at the top of `search_estimators_tool` 
before the registry is touched. Values less than 1 now return:
`{"success": False, "error": "limit must be a positive integer."}`

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies.

#### What should a reviewer concentrate their feedback on?
The validation guard in `describe_estimator.py` and the 4 new tests 
in `TestSearchEstimatorsLimit`.

#### PR checklist
- [x] I've added unit tests and made sure they pass locally.