### PR TITLE
FIX: validate status type in list_jobs_tool

### DIFF
--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -56,6 +56,14 @@ def list_jobs_tool(
     # Convert status string to enum
     status_filter = None
     if status is not None:
+        if not isinstance(status, str):
+            return {
+                "success": False,
+                "error": (
+                    f"Invalid status type '{type(status).__name__}'. "
+                    "Expected one of: pending, running, completed, failed, cancelled"
+                ),
+            }
         try:
             status_filter = JobStatus(status.lower())
         except ValueError:

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -190,6 +190,32 @@ def test_cancel_job():
     job_manager.delete_job(job_id)
 
 
+def test_list_jobs_tool_rejects_non_string_status():
+    """Non-string status values should return validation errors, not crash."""
+    from sktime_mcp.tools.job_tools import list_jobs_tool
+
+    for bad_status in (True, 1, ["running"], {"status": "running"}):
+        result = list_jobs_tool(status=bad_status)
+        assert result["success"] is False
+        assert "Invalid status type" in result["error"]
+
+
+def test_list_jobs_tool_accepts_case_insensitive_status():
+    """Valid status strings should still work regardless of case."""
+    from sktime_mcp.tools.job_tools import list_jobs_tool
+
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job("fit_predict", "handle", "ARIMA")
+    job_manager.update_job(job_id, status=JobStatus.RUNNING)
+
+    result = list_jobs_tool(status="RUNNING")
+
+    assert result["success"] is True
+    assert any(job["job_id"] == job_id for job in result["jobs"])
+
+    job_manager.delete_job(job_id)
+
+
 def test_cleanup_old_jobs():
     """Test cleaning up old jobs."""
     job_manager = get_job_manager()


### PR DESCRIPTION
## Summary
- reject non-string `status` values in `list_jobs_tool` with a structured validation error
- keep existing case-insensitive handling for valid status strings
- add focused background job tests for both paths

## Why
Before this change, values like `true`, `1`, or `["running"]` crashed the tool with `AttributeError` because `.lower()` was called before validating the argument type. For MCP clients and LLM agents, a structured tool error is much easier to recover from than an exception.

Closes #333

## Testing
- `.venv/bin/python -m ruff check src/sktime_mcp/tools/job_tools.py tests/test_background_jobs.py`
- `.venv/bin/python -m ruff format --check src/sktime_mcp/tools/job_tools.py tests/test_background_jobs.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_background_jobs.py -q`
- `.venv/bin/python -m pytest -q`
