### PR TITLE
fix(registry): bump docstring truncation cap to 4000 chars (#335)

### DIFF
--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -12,6 +12,37 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Maximum characters of docstring to expose to LLMs in to_dict() output.
+# Earlier versions truncated at 500 chars, but sktime's numpydoc-style
+# docstrings put the "Parameters" section — the most useful information
+# for an agent reasoning about hyperparameters — past the first 500
+# chars in many estimators (issue #335). Bumping the cap to 4000 keeps
+# the response compact enough for an MCP tool result while preserving
+# the Parameters section for the vast majority of sktime estimators.
+_DOCSTRING_MAX_CHARS = 4000
+
+
+def _truncate_docstring(docstring: str | None) -> str | None:
+    """Return *docstring* truncated to a length that preserves the
+    Parameters section when possible.
+
+    The function:
+    - returns ``None`` for a missing docstring;
+    - returns the full docstring if it is already short enough;
+    - otherwise returns the first ``_DOCSTRING_MAX_CHARS`` characters,
+      with a trailing ellipsis when content was dropped.
+
+    Per #335 the cap is large enough to capture the numpydoc
+    ``Parameters`` block of every estimator we have looked at without
+    embedding the full docstring (which can run several pages on
+    composite forecasters).
+    """
+    if docstring is None:
+        return None
+    if len(docstring) <= _DOCSTRING_MAX_CHARS:
+        return docstring
+    return docstring[:_DOCSTRING_MAX_CHARS].rstrip() + "..."
+
 
 @dataclass
 class EstimatorNode:
@@ -47,9 +78,7 @@ class EstimatorNode:
             "module": self.module,
             "tags": self.tags,
             "hyperparameters": self.hyperparameters,
-            "docstring": (
-                self.docstring[:500] if self.docstring else None
-            ),  # L-1: Truncate docstring to 500 characters, we can also try summarization
+            "docstring": _truncate_docstring(self.docstring),
         }
 
     def to_summary(self) -> dict[str, Any]:

--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 # Maximum characters of docstring to expose to LLMs in to_dict() output.
 # Earlier versions truncated at 500 chars, but sktime's numpydoc-style
-# docstrings put the "Parameters" section — the most useful information
-# for an agent reasoning about hyperparameters — past the first 500
+# docstrings put the "Parameters" section, the most useful information
+# for an agent reasoning about hyperparameters, past the first 500
 # chars in many estimators (issue #335). Bumping the cap to 4000 keeps
 # the response compact enough for an MCP tool result while preserving
 # the Parameters section for the vast majority of sktime estimators.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -250,3 +250,48 @@ class TestTools:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestDocstringTruncation:
+    """Regression test for issue #335 — bump the docstring truncation
+    cap so the numpydoc ``Parameters`` section, which appears past
+    the first 500 chars in many sktime estimators, survives the
+    EstimatorNode.to_dict serialisation."""
+
+    def test_short_docstring_unchanged(self):
+        from sktime_mcp.registry.interface import _truncate_docstring
+
+        assert _truncate_docstring("hi") == "hi"
+
+    def test_none_passes_through(self):
+        from sktime_mcp.registry.interface import _truncate_docstring
+
+        assert _truncate_docstring(None) is None
+
+    def test_long_docstring_truncated_with_ellipsis(self):
+        from sktime_mcp.registry.interface import (
+            _DOCSTRING_MAX_CHARS,
+            _truncate_docstring,
+        )
+
+        long_doc = "x" * (_DOCSTRING_MAX_CHARS + 50)
+        out = _truncate_docstring(long_doc)
+        assert out is not None
+        assert out.endswith("...")
+        # Plain content (without ellipsis) is at most the cap.
+        assert len(out) - 3 <= _DOCSTRING_MAX_CHARS
+
+    def test_cap_preserves_parameters_section_past_500_chars(self):
+        """The whole point of #335: Parameters section appears past 500
+        chars in many sktime docstrings, and the new cap must keep it."""
+        from sktime_mcp.registry.interface import _truncate_docstring
+
+        intro = "x" * 600
+        doc = (
+            intro
+            + "\n\nParameters\n----------\nn_neighbors : int, default=5\n"
+        )
+        out = _truncate_docstring(doc)
+        assert out is not None
+        assert "Parameters" in out
+        assert "n_neighbors" in out

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -253,7 +253,7 @@ if __name__ == "__main__":
 
 
 class TestDocstringTruncation:
-    """Regression test for issue #335 — bump the docstring truncation
+    """Regression test for issue #335, bump the docstring truncation
     cap so the numpydoc ``Parameters`` section, which appears past
     the first 500 chars in many sktime estimators, survives the
     EstimatorNode.to_dict serialisation."""


### PR DESCRIPTION
Closes #335.

## What

`EstimatorNode.to_dict` truncated the estimator docstring at 500
characters before exposing it to the LLM. sktime's numpydoc-style
docstrings put the `Parameters` section, the most useful piece for
an agent reasoning about hyperparameters, past the first 500 chars
in many estimators (composite forecasters, classifiers with 10+
parameters, etc.), so the truncation hid exactly the content the LLM
needed to configure the model.

## Fix

Bump the cap to **4000 characters** via a new module-level constant
(`_DOCSTRING_MAX_CHARS`) and a helper (`_truncate_docstring`):

- short / `None` docstrings pass through unchanged
- longer ones get truncated to the cap with a trailing `...` marker
  so the consumer knows content was elided
- 4000 is large enough to keep the `Parameters` block of every
  sktime estimator I sampled while still keeping the MCP tool result
  reasonably compact

The issue suggested either bumping the limit or implementing a
"prioritize Parameters section" parser. I went with the simpler cap
bump since smarter parsing has a much larger surface (numpydoc /
Google-style / plain text variations); happy to follow up with a
section-aware truncator if you'd prefer that direction.

## Tests

`tests/test_core.py::TestDocstringTruncation`:
- `test_short_docstring_unchanged`
- `test_none_passes_through`
- `test_long_docstring_truncated_with_ellipsis`
- `test_cap_preserves_parameters_section_past_500_chars`, the
  #335 regression: docstring with a `Parameters` block starting at
  offset 600 must still surface after truncation.

## Verification

- `pytest tests/test_core.py::TestDocstringTruncation -v` → 4 passed.
- Reverting `_DOCSTRING_MAX_CHARS` to 500 makes the last subtest
  fail with `assert 'Parameters' in '<x...>'`, confirming the test
  catches the regression.