### PR TITLE
FIX: validate top-level argument types in instantiation tools

### DIFF
--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -99,6 +99,55 @@ def _validate_params(
     return {"valid": True, "warnings": warnings}
 
 
+def _validate_estimator_name(estimator: Any) -> dict[str, Any]:
+    """Validate the top-level estimator argument."""
+    if not isinstance(estimator, str):
+        return {
+            "valid": False,
+            "error": (
+                f"'estimator' must be a non-empty string, got {type(estimator).__name__}. "
+                'Example: "ARIMA"'
+            ),
+        }
+
+    if not estimator.strip():
+        return {
+            "valid": False,
+            "error": "'estimator' must be a non-empty string.",
+        }
+
+    return {"valid": True}
+
+
+def _validate_components(components: Any) -> dict[str, Any]:
+    """Validate the top-level pipeline components argument."""
+    if not isinstance(components, list):
+        return {
+            "valid": False,
+            "error": (
+                f"'components' must be a non-empty list of estimator names, "
+                f"got {type(components).__name__}."
+            ),
+        }
+
+    if not components:
+        return {
+            "valid": False,
+            "error": "Pipeline cannot be empty",
+        }
+
+    for i, component in enumerate(components):
+        if not isinstance(component, str) or not component.strip():
+            return {
+                "valid": False,
+                "error": (
+                    f"'components[{i}]' must be a non-empty string, got {type(component).__name__}."
+                ),
+            }
+
+    return {"valid": True}
+
+
 def instantiate_estimator_tool(
     estimator: str,
     params: Optional[dict[str, Any]] = None,
@@ -127,6 +176,13 @@ def instantiate_estimator_tool(
             "params": {"order": [1, 1, 1]}
         }
     """
+    estimator_validation = _validate_estimator_name(estimator)
+    if not estimator_validation["valid"]:
+        return {
+            "success": False,
+            "error": estimator_validation["error"],
+        }
+
     # validate params before passing to executor
     validation = _validate_params(params, estimator_name=estimator)
 
@@ -180,6 +236,13 @@ def instantiate_pipeline_tool(
         }
     """
     all_warnings = []
+
+    components_validation = _validate_components(components)
+    if not components_validation["valid"]:
+        return {
+            "success": False,
+            "error": components_validation["error"],
+        }
 
     # validate each params dict in params_list
     if params_list is not None:

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -11,6 +11,8 @@ import pytest
 sys.path.insert(0, "src")
 
 from sktime_mcp.tools.instantiate import (
+    _validate_components,
+    _validate_estimator_name,
     _validate_params,
     instantiate_estimator_tool,
     instantiate_pipeline_tool,
@@ -84,6 +86,34 @@ class TestValidateParams:
         assert "nonexistent_param_xyz" in result["warnings"][0]
 
 
+class TestValidateTopLevelInputs:
+    """Tests for top-level estimator/components validation helpers."""
+
+    def test_estimator_name_must_be_string(self):
+        """Estimator name should reject non-string values."""
+        result = _validate_estimator_name(["ARIMA"])
+        assert result["valid"] is False
+        assert "'estimator' must be a non-empty string" in result["error"]
+
+    def test_estimator_name_rejects_blank_string(self):
+        """Estimator name should reject blank strings."""
+        result = _validate_estimator_name("   ")
+        assert result["valid"] is False
+        assert "non-empty string" in result["error"]
+
+    def test_components_must_be_list(self):
+        """Components should reject non-list values."""
+        result = _validate_components("ARIMA")
+        assert result["valid"] is False
+        assert "'components' must be a non-empty list" in result["error"]
+
+    def test_components_reject_nested_non_string(self):
+        """Components should reject nested non-string entries."""
+        result = _validate_components(["ARIMA", ["NaiveForecaster"]])
+        assert result["valid"] is False
+        assert "components[1]" in result["error"]
+
+
 class TestInstantiateEstimatorValidation:
     """Tests for validation in the instantiate_estimator_tool."""
 
@@ -105,9 +135,27 @@ class TestInstantiateEstimatorValidation:
         assert result["success"] is False
         assert "Unsupported type" in result["error"]
 
+    def test_invalid_estimator_type_returns_error(self):
+        """Non-string estimator names should return success=False with error."""
+        result = instantiate_estimator_tool(["NaiveForecaster"])
+        assert result["success"] is False
+        assert "'estimator' must be a non-empty string" in result["error"]
+
 
 class TestPipelineParamsValidation:
     """Tests for validation in the instantiate_pipeline_tool."""
+
+    def test_pipeline_components_must_be_list(self):
+        """String components should return an explicit type validation error."""
+        result = instantiate_pipeline_tool("NaiveForecaster")
+        assert result["success"] is False
+        assert "'components' must be a non-empty list" in result["error"]
+
+    def test_pipeline_components_reject_non_string_entries(self):
+        """Nested non-string components should return success=False with error."""
+        result = instantiate_pipeline_tool(["NaiveForecaster", ["ARIMA"]])
+        assert result["success"] is False
+        assert "components[1]" in result["error"]
 
     def test_pipeline_invalid_params_list_type(self):
         """Non-list params_list should return error."""


### PR DESCRIPTION
## Summary
- validate that `instantiate_estimator_tool` receives a non-empty string estimator name
- validate that `instantiate_pipeline_tool` receives a non-empty list of non-empty string component names
- add focused tests for malformed top-level inputs

## Why
Before this change, malformed top-level inputs could crash the tool or produce misleading behavior:
- `instantiate_estimator_tool(["ARIMA"])` raised `TypeError`
- `instantiate_pipeline_tool("ARIMA")` treated the string as character-by-character components
- `instantiate_pipeline_tool(123)` raised `TypeError`

For MCP clients and LLM agents, structured validation errors are much easier to recover from than Python exceptions or confusing fallback behavior.

Closes #339

## Testing
- `.venv/bin/python -m ruff check src/sktime_mcp/tools/instantiate.py tests/test_param_validation.py`
- `.venv/bin/python -m ruff format --check src/sktime_mcp/tools/instantiate.py tests/test_param_validation.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_param_validation.py -q`
- `.venv/bin/python -m pytest -q`
