### PR TITLE
FIX: validate top-level inputs in estimator discovery tools

### DIFF
--- a/src/sktime_mcp/tools/describe_estimator.py
+++ b/src/sktime_mcp/tools/describe_estimator.py
@@ -10,6 +10,26 @@ from sktime_mcp.registry.interface import get_registry
 from sktime_mcp.registry.tag_resolver import get_tag_resolver
 
 
+def _validate_non_empty_string(value: Any, arg_name: str, example: str) -> dict[str, Any]:
+    """Validate a top-level string tool argument."""
+    if not isinstance(value, str):
+        return {
+            "valid": False,
+            "error": (
+                f"'{arg_name}' must be a non-empty string, got {type(value).__name__}. "
+                f'Example: "{example}"'
+            ),
+        }
+
+    if not value.strip():
+        return {
+            "valid": False,
+            "error": f"'{arg_name}' must be a non-empty string.",
+        }
+
+    return {"valid": True}
+
+
 def describe_estimator_tool(estimator: str) -> dict[str, Any]:
     """
     Get detailed information about a specific estimator.
@@ -39,6 +59,13 @@ def describe_estimator_tool(estimator: str) -> dict[str, Any]:
             ...
         }
     """
+    validation = _validate_non_empty_string(estimator, "estimator", "ARIMA")
+    if not validation["valid"]:
+        return {
+            "success": False,
+            "error": validation["error"],
+        }
+
     registry = get_registry()
     tag_resolver = get_tag_resolver()
 
@@ -84,6 +111,13 @@ def search_estimators_tool(query: str, limit: int = 20) -> dict[str, Any]:
     Returns:
         Dictionary with matching estimators
     """
+    validation = _validate_non_empty_string(query, "query", "ARIMA")
+    if not validation["valid"]:
+        return {
+            "success": False,
+            "error": validation["error"],
+        }
+
     registry = get_registry()
 
     try:

--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -3,15 +3,15 @@ list_estimators tool for sktime MCP.
 Discovers estimators by task type, capability tags, and/or name search.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from sktime_mcp.registry.interface import get_registry
 
 
 def _validate_discovery_filters(
-    task: Optional[str],
-    tags: Optional[dict[str, Any]],
-    query: Optional[str],
+    task: str | None,
+    tags: dict[str, Any] | None,
+    query: str | None,
 ) -> dict[str, Any]:
     """Validate top-level discovery tool filters."""
     if task is not None and not isinstance(task, str):
@@ -36,9 +36,9 @@ def _validate_discovery_filters(
 
 
 def list_estimators_tool(
-    task: Optional[str] = None,
-    tags: Optional[dict[str, Any]] = None,
-    query: Optional[str] = None,
+    task: str | None = None,
+    tags: dict[str, Any] | None = None,
+    query: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> dict[str, Any]:

--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -8,6 +8,33 @@ from typing import Any, Optional
 from sktime_mcp.registry.interface import get_registry
 
 
+def _validate_discovery_filters(
+    task: Optional[str],
+    tags: Optional[dict[str, Any]],
+    query: Optional[str],
+) -> dict[str, Any]:
+    """Validate top-level discovery tool filters."""
+    if task is not None and not isinstance(task, str):
+        return {
+            "valid": False,
+            "error": f"'task' must be a string or None, got {type(task).__name__}.",
+        }
+
+    if tags is not None and not isinstance(tags, dict):
+        return {
+            "valid": False,
+            "error": f"'tags' must be a dictionary or None, got {type(tags).__name__}.",
+        }
+
+    if query is not None and not isinstance(query, str):
+        return {
+            "valid": False,
+            "error": f"'query' must be a string or None, got {type(query).__name__}.",
+        }
+
+    return {"valid": True}
+
+
 def list_estimators_tool(
     task: Optional[str] = None,
     tags: Optional[dict[str, Any]] = None,
@@ -39,6 +66,13 @@ def list_estimators_tool(
         - limit: Current limit (for pagination)
         - has_more: True if more results exist beyond this page
     """
+    validation = _validate_discovery_filters(task=task, tags=tags, query=query)
+    if not validation["valid"]:
+        return {
+            "success": False,
+            "error": validation["error"],
+        }
+
     registry = get_registry()
     try:
         if query:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -146,6 +146,51 @@ class TestTools:
         assert not result["success"]
         assert "error" in result
 
+    def test_describe_estimator_rejects_non_string_input(self):
+        """describe_estimator should return a validation error for non-strings."""
+        from sktime_mcp.tools.describe_estimator import describe_estimator_tool
+
+        result = describe_estimator_tool(["ARIMA"])
+
+        assert result["success"] is False
+        assert "'estimator' must be a non-empty string" in result["error"]
+
+    def test_search_estimators_rejects_non_string_query(self):
+        """search_estimators should return a validation error for non-string queries."""
+        from sktime_mcp.tools.describe_estimator import search_estimators_tool
+
+        result = search_estimators_tool(["ARIMA"])
+
+        assert result["success"] is False
+        assert "'query' must be a non-empty string" in result["error"]
+
+    def test_list_estimators_rejects_non_string_task(self):
+        """list_estimators should validate task filter type."""
+        from sktime_mcp.tools.list_estimators import list_estimators_tool
+
+        result = list_estimators_tool(task=["forecasting"])
+
+        assert result["success"] is False
+        assert "'task' must be a string or None" in result["error"]
+
+    def test_list_estimators_rejects_non_dict_tags(self):
+        """list_estimators should validate tag filter type."""
+        from sktime_mcp.tools.list_estimators import list_estimators_tool
+
+        result = list_estimators_tool(tags=["capability:pred_int"])
+
+        assert result["success"] is False
+        assert "'tags' must be a dictionary or None" in result["error"]
+
+    def test_list_estimators_rejects_non_string_query(self):
+        """list_estimators should validate query filter type."""
+        from sktime_mcp.tools.list_estimators import list_estimators_tool
+
+        result = list_estimators_tool(query=["ARIMA"])
+
+        assert result["success"] is False
+        assert "'query' must be a string or None" in result["error"]
+
     def test_list_available_data_no_filter(self):
         """list_available_data with no args returns both system_demos and active_handles."""
         from sktime_mcp.tools.list_available_data import list_available_data_tool


### PR DESCRIPTION
## Summary
- validate top-level string inputs in `describe_estimator_tool` and `search_estimators_tool`
- validate `task`, `tags`, and `query` filter types in `list_estimators_tool`
- add focused core tests for malformed discovery-tool inputs

## Why
Before this change, malformed top-level inputs in the discovery tools could crash with Python exceptions or produce misleading results:
- `describe_estimator_tool(["ARIMA"])` raised `TypeError`
- `describe_estimator_tool(123)` raised `AttributeError`
- `list_estimators_tool(task=["forecasting"])` returned `success=true, count=0` instead of validating the type
- `list_estimators_tool(tags=["capability:pred_int"])` and `list_estimators_tool(query=["ARIMA"])` leaked internal errors

These are core MCP discovery entrypoints, so structured validation errors are much easier for LLM agents to recover from than crashes or misleading empty results.

Closes #341

## Testing
- `.venv/bin/python -m ruff check src/sktime_mcp/tools/describe_estimator.py src/sktime_mcp/tools/list_estimators.py tests/test_core.py`
- `.venv/bin/python -m ruff format --check src/sktime_mcp/tools/describe_estimator.py src/sktime_mcp/tools/list_estimators.py tests/test_core.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_core.py -q`
- `.venv/bin/python -m pytest -q`
