### PR TITLE
fix: map NaN/Inf to null in sanitize_for_json

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -95,7 +95,11 @@ def sanitize_for_json(obj):
         if isinstance(obj, np.integer):
             return int(obj)
         if isinstance(obj, np.floating):
-            return float(obj)
+            f = float(obj)
+            # JSON has no representation for NaN/Inf — map to null.
+            if f != f or f == float("inf") or f == float("-inf"):
+                return None
+            return f
         if isinstance(obj, np.bool_):
             return bool(obj)
         if isinstance(obj, np.ndarray):

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -135,5 +135,19 @@ class TestEdgeCases:
         assert sanitize_for_json({}) == {}
 
     def test_nan(self):
-        result = sanitize_for_json(np.float64("nan"))
-        json.dumps(result, default=str)
+        # NaN/Inf have no JSON representation; map to null so json.dumps
+        # works without the default=str escape hatch.
+        assert sanitize_for_json(np.float64("nan")) is None
+        json.dumps(sanitize_for_json(np.float64("nan")))
+
+    def test_inf(self):
+        assert sanitize_for_json(np.float64("inf")) is None
+        assert sanitize_for_json(np.float64("-inf")) is None
+        json.dumps(sanitize_for_json(np.float64("inf")))
+
+    def test_nan_in_dict(self):
+        # Realistic case: a metric dict containing a NaN value must be
+        # JSON-serializable without raising.
+        result = sanitize_for_json({"score": np.float64("nan"), "n": 10})
+        json.dumps(result)
+        assert result == {"score": None, "n": 10}


### PR DESCRIPTION
Follow-up to #198 (merged today).

## Bug

The merged `sanitize_for_json` returns `float(obj)` for `np.floating`, which produces `nan`/`inf` when the input is `np.float64('nan')` or `np.float64('inf')`. Strict JSON has no representation for these:

```python
>>> import json, numpy as np
>>> from sktime_mcp.server import sanitize_for_json
>>> json.dumps({'x': sanitize_for_json(np.float64('nan'))}, allow_nan=False)
ValueError: Out of range float values are not JSON compliant
```

Even with default `allow_nan=True`, the output `{"x": NaN}` is **invalid JSON** per RFC 8259 — strict consumers (most JSON-RPC parsers, including the one MCP uses over stdio) reject it.

## When this bites

Real cases that produce NaN/Inf in tool responses:
- All-NaN input columns → NaN means/stds in describe-style outputs
- Empty CV folds → `inf` MASE
- Division-by-zero in metric computations

## Fix

Map NaN and Inf to `None` (JSON `null`) inside the `np.floating` branch. Five-line change.

## Tests

Strengthens the existing `test_nan` (which previously only verified `json.dumps(..., default=str)` worked — i.e. the escape hatch, not the contract). Adds `test_inf` and `test_nan_in_dict` for realistic usage.