### PR TITLE
FIX: reject boolean horizon values in forecasting tools

### DIFF
--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -19,7 +19,7 @@ def _validate_horizon(horizon: int) -> dict[str, Any]:
     Checks if the horizon parameter is greater than 0 or not
     """
     warnings = []
-    if not isinstance(horizon, int):
+    if isinstance(horizon, bool) or not isinstance(horizon, int):
         return {
             "valid": False,
             "error": (

--- a/tests/test_async_custom_data.py
+++ b/tests/test_async_custom_data.py
@@ -186,6 +186,40 @@ class TestSyncCustomData:
             == "Either 'dataset' (e.g. 'airline') or 'data_handle' (from load_data_source) is required."
         )
 
+    def test_sync_rejects_boolean_horizon(self):
+        """Boolean horizon values should be rejected before execution."""
+        from sktime_mcp.tools.fit_predict import fit_predict_tool
+
+        result = fit_predict_tool(
+            estimator_handle="fake_handle",
+            dataset="airline",
+            horizon=True,
+        )
+
+        assert not result["success"]
+        assert (
+            result["error"] == "'horizon' must be an integer, got bool. Example: {\"horizon\": 12}"
+        )
+
+
+class TestAsyncHorizonValidation:
+    """Tests for horizon validation parity in async forecasting tools."""
+
+    def test_async_rejects_boolean_horizon(self):
+        """Boolean horizon values should be rejected before job scheduling."""
+        from sktime_mcp.tools.fit_predict import fit_predict_async_tool
+
+        result = fit_predict_async_tool(
+            estimator_handle="fake_handle",
+            dataset="airline",
+            horizon=True,
+        )
+
+        assert not result["success"]
+        assert (
+            result["error"] == "'horizon' must be an integer, got bool. Example: {\"horizon\": 12}"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -119,6 +119,8 @@ class TestFitPredictValidation:
         "invalid_horizon, expected_error",
         [
             ("five", "must be an integer"),
+            (True, "must be an integer"),
+            (False, "must be an integer"),
             (0, "greater than 0"),
             (-3, "greater than 0"),
             (None, "must be an integer"),


### PR DESCRIPTION
Closes #348

## Summary
- reject `True`/`False` in the shared horizon validator used by forecasting tools
- keep error messaging consistent with other non-integer horizon inputs
- add focused regression tests for sync, async, and predict entrypoints

## Problem
`fit_predict_tool` and `fit_predict_async_tool` accepted boolean horizon values because Python treats `bool` as a subclass of `int`.

Before this change:

```python
fit_predict_tool(handle, "airline", horizon=True)
```

returned success and behaved like a 1-step forecast.

Similarly:

```python
fit_predict_async_tool(handle, dataset="airline", horizon=True)
```

scheduled a background job with `horizon=True`.

For MCP/JSON tool use, that is a bad contract: `true`/`false` should not silently become valid forecast horizons.

## Fix
The shared `_validate_horizon()` helper now treats `bool` as invalid, so all forecasting entrypoints reject it consistently.

## Tests
Added regression coverage for:
- `predict_tool(..., horizon=True)`
- `predict_tool(..., horizon=False)`
- `fit_predict_tool(..., horizon=True)`
- `fit_predict_async_tool(..., horizon=True)`

## Verification
- `ruff check .`
- `ruff format --check .`
- `pytest -q`
