### PR TITLE
[ENH] Add structured config schemas and validation for load_data_source

### DIFF
--- a/src/sktime_mcp/tools/data_schemas.py
+++ b/src/sktime_mcp/tools/data_schemas.py
@@ -4,9 +4,9 @@ from typing import Any
 
 SCHEMAS = {
     "pandas": {
-        "required": ["type", "data", "time_column", "target_column"],
-        "optional": [],
-        "description": "Load from a pandas-compatible dict with date and value keys.",
+        "required": ["type", "data"],
+        "optional": ["time_column", "target_column", "exog_columns", "frequency"],
+        "description": "Load from a pandas-compatible dict or DataFrame.",
         "example": {
             "type": "pandas",
             "data": {"date": ["2020-01", "2020-02"], "value": [100, 200]},
@@ -15,9 +15,18 @@ SCHEMAS = {
         },
     },
     "sql": {
-        "required": ["type", "connection_string", "query", "time_column", "target_column"],
-        "optional": [],
-        "description": "Load from a SQL database using a connection string and query.",
+        "required": ["type"],
+        "one_of": [
+            ["connection_string"],
+            ["dialect", "database"],
+        ],
+        "query_one_of": [["query"], ["table"]],
+        "optional": [
+            "time_column", "target_column", "exog_columns",
+            "host", "port", "username", "password",
+            "filters", "parse_dates", "frequency",
+        ],
+        "description": "Load from a SQL database. Provide connection_string or dialect+database, and query or table.",
         "example": {
             "type": "sql",
             "connection_string": "postgresql://user:pass@host:5432/db",
@@ -27,25 +36,33 @@ SCHEMAS = {
         },
     },
     "file": {
-        "required": ["type", "path", "time_column", "target_column"],
-        "optional": ["sep", "encoding"],
-        "description": "Load from a local CSV or supported file path.",
+        "required": ["type", "path"],
+        "optional": [
+            "format", "time_column", "target_column", "exog_columns",
+            "csv_options", "excel_options", "parse_dates", "frequency",
+        ],
+        "description": "Load from a local CSV, Excel, or Parquet file.",
         "example": {
             "type": "file",
             "path": "/path/to/data.csv",
             "time_column": "date",
             "target_column": "value",
+            "csv_options": {"sep": ",", "encoding": "utf-8"},
         },
     },
     "url": {
-        "required": ["type", "url", "time_column", "target_column"],
-        "optional": ["sep", "encoding"],
-        "description": "Load from a remote URL pointing to a CSV or similar file.",
+        "required": ["type", "url"],
+        "optional": [
+            "format", "time_column", "target_column", "exog_columns",
+            "csv_options", "parse_dates", "frequency",
+        ],
+        "description": "Load from a remote URL pointing to a CSV, Excel, or Parquet file.",
         "example": {
             "type": "url",
             "url": "https://example.com/data.csv",
             "time_column": "date",
             "target_column": "value",
+            "csv_options": {"sep": ","},
         },
     },
 }
@@ -91,5 +108,26 @@ def validate_config(config: dict[str, Any]) -> dict[str, Any]:
             "error": f"Config for type '{source_type}' is missing: {missing}",
             "suggestion": schema["example"],
         }
+
+    # SQL conditional validation
+    if source_type == "sql":
+        has_connection = "connection_string" in config or (
+            "dialect" in config and "database" in config
+        )
+        if not has_connection:
+            return {
+                "valid": False,
+                "missing_fields": ["connection_string or dialect+database"],
+                "error": "SQL config must have 'connection_string' or both 'dialect' and 'database'",
+                "suggestion": schema["example"],
+            }
+        has_query = "query" in config or "table" in config
+        if not has_query:
+            return {
+                "valid": False,
+                "missing_fields": ["query or table"],
+                "error": "SQL config must have 'query' or 'table'",
+                "suggestion": schema["example"],
+            }
 
     return {"valid": True, "missing_fields": [], "error": None, "suggestion": None}

--- a/src/sktime_mcp/tools/data_schemas.py
+++ b/src/sktime_mcp/tools/data_schemas.py
@@ -1,0 +1,95 @@
+"""Structured config schemas for load_data_source by source type."""
+
+from typing import Any
+
+SCHEMAS = {
+    "pandas": {
+        "required": ["type", "data", "time_column", "target_column"],
+        "optional": [],
+        "description": "Load from a pandas-compatible dict with date and value keys.",
+        "example": {
+            "type": "pandas",
+            "data": {"date": ["2020-01", "2020-02"], "value": [100, 200]},
+            "time_column": "date",
+            "target_column": "value",
+        },
+    },
+    "sql": {
+        "required": ["type", "connection_string", "query", "time_column", "target_column"],
+        "optional": [],
+        "description": "Load from a SQL database using a connection string and query.",
+        "example": {
+            "type": "sql",
+            "connection_string": "postgresql://user:pass@host:5432/db",
+            "query": "SELECT date, value FROM sales",
+            "time_column": "date",
+            "target_column": "value",
+        },
+    },
+    "file": {
+        "required": ["type", "path", "time_column", "target_column"],
+        "optional": ["sep", "encoding"],
+        "description": "Load from a local CSV or supported file path.",
+        "example": {
+            "type": "file",
+            "path": "/path/to/data.csv",
+            "time_column": "date",
+            "target_column": "value",
+        },
+    },
+    "url": {
+        "required": ["type", "url", "time_column", "target_column"],
+        "optional": ["sep", "encoding"],
+        "description": "Load from a remote URL pointing to a CSV or similar file.",
+        "example": {
+            "type": "url",
+            "url": "https://example.com/data.csv",
+            "time_column": "date",
+            "target_column": "value",
+        },
+    },
+}
+
+
+def validate_config(config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Validate a load_data_source config against its source type schema.
+
+    Returns a dict with:
+    - valid: bool
+    - missing_fields: list of missing required fields
+    - suggestion: example config for the given type
+    - error: human-readable error message if invalid
+    """
+    source_type = config.get("type")
+
+    if not source_type:
+        return {
+            "valid": False,
+            "missing_fields": ["type"],
+            "error": "Missing required field 'type'. Must be one of: "
+            + ", ".join(SCHEMAS.keys()),
+            "suggestion": None,
+        }
+
+    if source_type not in SCHEMAS:
+        return {
+            "valid": False,
+            "missing_fields": [],
+            "error": f"Unknown source type '{source_type}'. "
+            f"Valid types are: {', '.join(SCHEMAS.keys())}",
+            "suggestion": None,
+        }
+
+    schema = SCHEMAS[source_type]
+    missing = [f for f in schema["required"] if f not in config]
+
+    if missing:
+        return {
+            "valid": False,
+            "missing_fields": missing,
+            "error": f"Config for type '{source_type}' is missing: {missing}",
+            "suggestion": schema["example"],
+        }
+
+    return {"valid": True, "missing_fields": [], "error": None, "suggestion": None}

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -66,7 +66,10 @@ def load_data_source_tool(config: dict[str, Any]) -> dict[str, Any]:
             "missing_fields": validation["missing_fields"],
             "suggestion": validation["suggestion"],
         }
-    return executor.load_data_source(config)
+    result = executor.load_data_source(config)
+    if "validation" not in result:
+        result["validation"] = validation
+    return result
 
 
 def list_data_sources_tool() -> dict[str, Any]:

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -57,6 +57,15 @@ def load_data_source_tool(config: dict[str, Any]) -> dict[str, Any]:
         ... })
     """
     executor = get_executor()
+    from sktime_mcp.tools.data_schemas import validate_config
+    validation = validate_config(config)
+    if not validation["valid"]:
+        return {
+            "success": False,
+            "error": validation["error"],
+            "missing_fields": validation["missing_fields"],
+            "suggestion": validation["suggestion"],
+        }
     return executor.load_data_source(config)
 
 

--- a/tests/test_data_schemas.py
+++ b/tests/test_data_schemas.py
@@ -1,0 +1,72 @@
+"""Tests for load_data_source config schema validation."""
+
+from sktime_mcp.tools.data_schemas import validate_config
+
+
+def test_missing_type():
+    result = validate_config({})
+    assert not result["valid"]
+    assert "type" in result["missing_fields"]
+
+
+def test_unknown_type():
+    result = validate_config({"type": "unknown"})
+    assert not result["valid"]
+    assert "unknown" in result["error"]
+
+
+def test_pandas_missing_data():
+    result = validate_config({"type": "pandas"})
+    assert not result["valid"]
+    assert "data" in result["missing_fields"]
+
+
+def test_pandas_valid():
+    result = validate_config({"type": "pandas", "data": {"value": [1, 2]}})
+    assert result["valid"]
+
+
+def test_file_missing_path():
+    result = validate_config({"type": "file"})
+    assert not result["valid"]
+    assert "path" in result["missing_fields"]
+
+
+def test_file_valid():
+    result = validate_config({"type": "file", "path": "/data.csv"})
+    assert result["valid"]
+
+
+def test_url_missing_url():
+    result = validate_config({"type": "url"})
+    assert not result["valid"]
+    assert "url" in result["missing_fields"]
+
+
+def test_sql_missing_connection():
+    result = validate_config({"type": "sql", "query": "SELECT 1"})
+    assert not result["valid"]
+
+
+def test_sql_missing_query():
+    result = validate_config({"type": "sql", "connection_string": "sqlite:///db"})
+    assert not result["valid"]
+
+
+def test_sql_valid_with_connection_string():
+    result = validate_config({
+        "type": "sql",
+        "connection_string": "sqlite:///db",
+        "query": "SELECT * FROM data",
+    })
+    assert result["valid"]
+
+
+def test_sql_valid_with_dialect():
+    result = validate_config({
+        "type": "sql",
+        "dialect": "postgresql",
+        "database": "mydb",
+        "table": "sales",
+    })
+    assert result["valid"]


### PR DESCRIPTION
Closes #350. Relates to #287.

## What this does
Adds `data_schemas.py` with explicit per-source-type schemas (pandas, sql, file, url) 
and a `validate_config` function that checks required fields before hitting the executor.

## Why
Agents currently receive no feedback when passing an invalid or incomplete config, 
causing silent failures. This returns a structured error with missing fields and 
an example config so agents can self-correct.