### PR TITLE
test: add regression coverage for server startup imports

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -18,7 +18,6 @@ from mcp.types import TextContent, Tool
 from sktime_mcp.composition.validator import get_composition_validator
 from sktime_mcp.tools.codegen import export_code_tool
 from sktime_mcp.tools.data_tools import (
-    fit_predict_tool,
     load_data_source_async_tool,
     load_data_source_tool,
     release_data_handle_tool,
@@ -27,6 +26,7 @@ from sktime_mcp.tools.describe_estimator import describe_estimator_tool
 from sktime_mcp.tools.evaluate import evaluate_estimator_tool
 from sktime_mcp.tools.fit_predict import (
     fit_predict_async_tool,
+    fit_predict_tool,
 )
 from sktime_mcp.tools.format_tools import format_time_series_tool
 from sktime_mcp.tools.instantiate import (

--- a/tests/test_server_startup.py
+++ b/tests/test_server_startup.py
@@ -1,0 +1,35 @@
+"""
+Tests to ensure the MCP server starts up correctly and all tool imports are valid.
+This protects against regressions where tool exports are renamed or removed
+but the server module is not updated.
+"""
+
+import asyncio
+
+import pytest
+
+
+def test_server_import_success():
+    """Test that importing the server module succeeds without any ImportErrors."""
+    import sktime_mcp.server as mcp_server
+
+    assert hasattr(mcp_server, "server")
+    assert mcp_server.server.name == "sktime-mcp"
+
+
+def test_server_tools_registration():
+    """Test that the list_tools endpoint returns expected tools."""
+    import sktime_mcp.server as mcp_server
+
+    tools = asyncio.run(mcp_server.list_tools())
+    assert len(tools) > 0, "Server should register at least one tool"
+
+    tool_names = [tool.name for tool in tools]
+    expected_tools = [
+        "list_estimators",
+        "instantiate_estimator",
+        "fit_predict",
+        "load_data_source",
+    ]
+    for expected in expected_tools:
+        assert expected in tool_names, f"Expected tool {expected} not found in registered tools"


### PR DESCRIPTION
## Problem
A recent issue caused the MCP server to fail at startup due to a broken tool import (`cannot import name 'fit_predict_tool' from sktime_mcp.tools.data_tools`). This happens when tools are refactored, renamed, or moved, but the main `server.py` file is not updated to reflect those changes.

## Solution
This PR does two things:
1. Includes the fix for the broken `fit_predict_tool` import in `server.py`.
2. Adds `tests/test_server_startup.py` to act as a fast, isolated regression guard. 
   - `test_server_import_success`: verifies `import sktime_mcp.server` succeeds without any `ImportError`.
   - `test_server_tools_registration`: validates that the underlying MCP server object properly initializes and has critical expected tools registered (e.g., `fit_predict`, `load_data_source`).

## Testing
- Verified locally. All tests pass, including the new smoke tests.
- These tests are deterministic and run in milliseconds.
