### PR TITLE
FIX: reject boolean pagination values in discovery and job tools

### DIFF
--- a/src/sktime_mcp/tools/describe_estimator.py
+++ b/src/sktime_mcp/tools/describe_estimator.py
@@ -84,7 +84,7 @@ def search_estimators_tool(query: str, limit: int = 20) -> dict[str, Any]:
     Returns:
         Dictionary with matching estimators
     """
-    if limit < 1:
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
         return {
             "success": False,
             "error": "limit must be a positive integer.",

--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -72,7 +72,7 @@ def list_jobs_tool(
                 "error": f"Invalid status '{status}'. Valid values: pending, running, completed, failed, cancelled",
             }
 
-    if limit < 1:
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
         return {
             "success": False,
             "error": "limit must be a positive integer.",

--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -78,13 +78,13 @@ def list_estimators_tool(
 
         total = len(estimators)
 
-        if offset < 0:
+        if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
             return {
                 "success": False,
                 "error": "offset must be a non-negative integer.",
             }
 
-        if limit < 1:
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
             return {
                 "success": False,
                 "error": "limit must be a positive integer.",

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -160,6 +160,16 @@ def test_list_jobs_tool_accepts_case_insensitive_status():
     job_manager.delete_job(job_id)
 
 
+def test_list_jobs_tool_rejects_boolean_limit():
+    """limit=True should be rejected, not treated as 1."""
+    from sktime_mcp.tools.job_tools import list_jobs_tool
+
+    result = list_jobs_tool(limit=True)
+
+    assert result["success"] is False
+    assert result["error"] == "limit must be a positive integer."
+
+
 def test_cleanup_old_jobs():
     """Test cleaning up old jobs."""
     job_manager = get_job_manager()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -259,6 +259,15 @@ class TestTools:
 class TestSearchEstimatorsLimit:
     """Tests for the limit parameter validation in search_estimators_tool."""
 
+    def test_limit_true_returns_error(self):
+        """limit=True should be rejected, not treated as 1."""
+        from sktime_mcp.tools.describe_estimator import search_estimators_tool
+
+        result = search_estimators_tool("NaiveForecaster", limit=True)
+
+        assert not result["success"]
+        assert result["error"] == "limit must be a positive integer."
+
     def test_limit_zero_returns_error(self):
         """limit=0 should return an error, not an empty list."""
         from sktime_mcp.tools.describe_estimator import search_estimators_tool
@@ -297,6 +306,28 @@ class TestSearchEstimatorsLimit:
         assert "results" in result
         assert len(result["results"]) <= 3
         assert result["count"] <= 3
+
+
+class TestListEstimatorsPaginationValidation:
+    """Tests for pagination validation in list_estimators_tool."""
+
+    def test_limit_true_returns_error(self):
+        """limit=True should be rejected, not treated as 1."""
+        from sktime_mcp.tools.list_estimators import list_estimators_tool
+
+        result = list_estimators_tool(limit=True)
+
+        assert not result["success"]
+        assert result["error"] == "limit must be a positive integer."
+
+    def test_offset_true_returns_error(self):
+        """offset=True should be rejected, not treated as 1."""
+        from sktime_mcp.tools.list_estimators import list_estimators_tool
+
+        result = list_estimators_tool(limit=2, offset=True)
+
+        assert not result["success"]
+        assert result["error"] == "offset must be a non-negative integer."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #356

## Summary
- reject boolean `limit` values in `search_estimators_tool`
- reject boolean `limit` and `offset` values in `list_estimators_tool`
- reject boolean `limit` values in `list_jobs_tool`
- add focused regression tests for the bool cases

## Problem
These tools validated pagination parameters with numeric comparisons like `limit < 1`, which lets Python boolean values through because `bool` is a subclass of `int`.

Before this change:

```python
search_estimators_tool("NaiveForecaster", limit=True)
# success=True, behaves like limit=1

list_estimators_tool(limit=True)
# success=True, returns one estimator and echoes "limit": True

list_estimators_tool(limit=2, offset=True)
# success=True, behaves like offset=1

list_jobs_tool(limit=True)
# success=True
```

For MCP/JSON tools, `true`/`false` should not silently become pagination values.

## Fix
Use strict integer validation for pagination parameters by rejecting `bool` before the existing range checks.

## Tests
Added regression coverage for:
- `search_estimators_tool(..., limit=True)`
- `list_estimators_tool(limit=True)`
- `list_estimators_tool(limit=2, offset=True)`
- `list_jobs_tool(limit=True)`

## Verification
- `ruff check .`
- `ruff format --check .`
- `pytest -q`
