### PR TITLE
FIX: validate cancel_job delete flag type

### DIFF
--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -100,6 +100,12 @@ def cancel_job_tool(job_id: str, delete: bool = False) -> dict[str, Any]:
     Returns:
         Dictionary with success status and message
     """
+    if not isinstance(delete, bool):
+        return {
+            "success": False,
+            "error": (f"Invalid delete type '{type(delete).__name__}'. Expected a boolean value."),
+        }
+
     job_manager = get_job_manager()
 
     job = job_manager.get_job(job_id)

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -144,6 +144,23 @@ def test_list_jobs_tool_rejects_non_string_status():
         assert "Invalid status type" in result["error"]
 
 
+def test_cancel_job_tool_rejects_non_boolean_delete():
+    """delete must be a real boolean, not a truthy string or integer."""
+    from sktime_mcp.tools.job_tools import cancel_job_tool
+
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job("fit_predict", "handle", "ARIMA")
+    job_manager.update_job(job_id, status=JobStatus.COMPLETED)
+
+    result = cancel_job_tool(job_id, delete="false")
+
+    assert result["success"] is False
+    assert result["error"] == "Invalid delete type 'str'. Expected a boolean value."
+    assert job_manager.get_job(job_id) is not None
+
+    job_manager.delete_job(job_id)
+
+
 def test_list_jobs_tool_accepts_case_insensitive_status():
     """Valid status strings should still work regardless of case."""
     from sktime_mcp.tools.job_tools import list_jobs_tool


### PR DESCRIPTION
Closes #359

## Summary
- validate the `delete` flag type in `cancel_job_tool`
- reject non-boolean values before any job record is removed
- add a regression test for `delete="false"`

## Problem
`cancel_job_tool` treats the `delete` parameter as a plain truthy/falsy value.
That means malformed MCP calls like:

```python
cancel_job_tool(job_id, delete="false")
```

still delete job records, because non-empty strings are truthy in Python.

I reproduced this on current code by creating a completed job and calling `cancel_job_tool(job_id, delete="false")`, which returned success and removed the job.

## Fix
Add a strict boolean validation guard near the start of `cancel_job_tool`:
- if `delete` is not a real `bool`, return a validation error
- do not delete anything in that case

## Tests
Added regression coverage to ensure:
- `cancel_job_tool(job_id, delete="false")` returns an error
- the job record remains present after the invalid call

## Verification
- `ruff check .`
- `ruff format --check .`
- `pytest -q`
