### PR TITLE
FIX: validate formatting control flag types

### DIFF
--- a/src/sktime_mcp/tools/format_tools.py
+++ b/src/sktime_mcp/tools/format_tools.py
@@ -9,6 +9,17 @@ from typing import Any
 from sktime_mcp.runtime.executor import get_executor
 
 
+def _validate_boolean_flag(flag_name: str, value: Any) -> dict[str, Any] | None:
+    """Return a structured error when a formatting control flag is not boolean."""
+    if isinstance(value, bool):
+        return None
+
+    return {
+        "success": False,
+        "error": (f"Invalid {flag_name} type '{type(value).__name__}'. Expected a boolean value."),
+    }
+
+
 def format_time_series_tool(
     data_handle: str,
     auto_infer_freq: bool = True,
@@ -46,6 +57,15 @@ def format_time_series_tool(
     """
     executor = get_executor()
 
+    for flag_name, value in (
+        ("auto_infer_freq", auto_infer_freq),
+        ("fill_missing", fill_missing),
+        ("remove_duplicates", remove_duplicates),
+    ):
+        error = _validate_boolean_flag(flag_name, value)
+        if error is not None:
+            return error
+
     try:
         # Delegate to executor
         return executor.format_data_handle(
@@ -77,6 +97,10 @@ def auto_format_on_load_tool(enabled: bool = True) -> dict[str, Any]:
         Dictionary with success status and current setting
     """
     executor = get_executor()
+
+    error = _validate_boolean_flag("enabled", enabled)
+    if error is not None:
+        return error
 
     # Store setting in executor
     if not hasattr(executor, "_auto_format_enabled"):

--- a/tests/test_format_tools.py
+++ b/tests/test_format_tools.py
@@ -1,0 +1,108 @@
+"""Tests for formatting tool input validation."""
+
+import sys
+
+import pandas as pd
+
+sys.path.insert(0, "src")
+
+
+def test_format_time_series_rejects_non_boolean_control_flags():
+    """Truthiness-based string flags should be rejected before formatting starts."""
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.format_tools import format_time_series_tool
+
+    executor = get_executor()
+    data_handle = "data_format_validation"
+    executor._data_handles[data_handle] = {
+        "y": pd.Series(
+            [1, None, 3], index=pd.to_datetime(["2024-01-01", "2024-01-01", "2024-01-02"])
+        ),
+        "X": None,
+        "metadata": {},
+        "validation": {},
+        "config": {},
+    }
+
+    try:
+        result = format_time_series_tool(
+            data_handle,
+            auto_infer_freq=True,
+            fill_missing=False,
+            remove_duplicates="false",
+        )
+    finally:
+        executor._data_handles.pop(data_handle, None)
+
+    assert result["success"] is False
+    assert result["error"] == "Invalid remove_duplicates type 'str'. Expected a boolean value."
+
+
+def test_format_time_series_rejects_non_boolean_fill_missing():
+    """Non-boolean fill_missing should not silently trigger data filling."""
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.format_tools import format_time_series_tool
+
+    executor = get_executor()
+    data_handle = "data_fill_validation"
+    executor._data_handles[data_handle] = {
+        "y": pd.Series(
+            [1, None, 3], index=pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"])
+        ),
+        "X": None,
+        "metadata": {},
+        "validation": {},
+        "config": {},
+    }
+
+    try:
+        result = format_time_series_tool(
+            data_handle,
+            auto_infer_freq=False,
+            fill_missing="false",
+            remove_duplicates=False,
+        )
+    finally:
+        executor._data_handles.pop(data_handle, None)
+
+    assert result["success"] is False
+    assert result["error"] == "Invalid fill_missing type 'str'. Expected a boolean value."
+
+
+def test_format_time_series_rejects_non_boolean_auto_infer_freq():
+    """Non-boolean auto_infer_freq should fail before inference logic runs."""
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.format_tools import format_time_series_tool
+
+    executor = get_executor()
+    data_handle = "data_freq_validation"
+    executor._data_handles[data_handle] = {
+        "y": pd.Series([1, 2], index=pd.to_datetime(["2024-01-01", "2024-01-03"])),
+        "X": None,
+        "metadata": {},
+        "validation": {},
+        "config": {},
+    }
+
+    try:
+        result = format_time_series_tool(
+            data_handle,
+            auto_infer_freq="false",
+            fill_missing=False,
+            remove_duplicates=False,
+        )
+    finally:
+        executor._data_handles.pop(data_handle, None)
+
+    assert result["success"] is False
+    assert result["error"] == "Invalid auto_infer_freq type 'str'. Expected a boolean value."
+
+
+def test_auto_format_on_load_rejects_non_boolean_enabled():
+    """auto_format_on_load should reject stringified booleans."""
+    from sktime_mcp.tools.format_tools import auto_format_on_load_tool
+
+    result = auto_format_on_load_tool("false")
+
+    assert result["success"] is False
+    assert result["error"] == "Invalid enabled type 'str'. Expected a boolean value."


### PR DESCRIPTION
## Summary
- reject non-boolean `auto_infer_freq`, `fill_missing`, and `remove_duplicates` values in `format_time_series_tool`
- reject non-boolean `enabled` values in `auto_format_on_load_tool`
- add focused regression tests for each validation path

## Why
Formatting tools currently rely on Python truthiness. Values like `"false"` can silently remove duplicates, fill missing values, or produce confusing success messages instead of returning a structured validation error.

## Testing
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_format_tools.py -q`
- `.venv/bin/pytest -q`

Closes #362
