### PR TITLE
FIX: validate list_available_data is_demo input

### DIFF
--- a/src/sktime_mcp/tools/list_available_data.py
+++ b/src/sktime_mcp/tools/list_available_data.py
@@ -25,6 +25,15 @@ def list_available_data_tool(is_demo: bool | None = None) -> dict[str, Any]:
     """
     executor = get_executor()
 
+    if is_demo is not None and not isinstance(is_demo, bool):
+        return {
+            "success": False,
+            "error": (
+                f"Invalid is_demo type '{type(is_demo).__name__}'. "
+                "Expected a boolean value or None."
+            ),
+        }
+
     system_demos = []
     active_handles = []
 

--- a/tests/test_list_available_data.py
+++ b/tests/test_list_available_data.py
@@ -1,0 +1,47 @@
+"""Tests for list_available_data tool validation."""
+
+import sys
+
+sys.path.insert(0, "src")
+
+
+def test_list_available_data_rejects_string_is_demo():
+    """Stringified booleans should not return misleading empty results."""
+    from sktime_mcp.tools.list_available_data import list_available_data_tool
+
+    result = list_available_data_tool("false")
+
+    assert result["success"] is False
+    assert result["error"] == "Invalid is_demo type 'str'. Expected a boolean value or None."
+
+
+def test_list_available_data_rejects_numeric_is_demo():
+    """Numeric values should be rejected instead of being treated as filters."""
+    from sktime_mcp.tools.list_available_data import list_available_data_tool
+
+    result = list_available_data_tool(1)
+
+    assert result["success"] is False
+    assert result["error"] == "Invalid is_demo type 'int'. Expected a boolean value or None."
+
+
+def test_list_available_data_rejects_container_is_demo():
+    """Container types should also fail validation cleanly."""
+    from sktime_mcp.tools.list_available_data import list_available_data_tool
+
+    result = list_available_data_tool([])
+
+    assert result["success"] is False
+    assert result["error"] == "Invalid is_demo type 'list'. Expected a boolean value or None."
+
+
+def test_list_available_data_valid_none_still_returns_data():
+    """The valid default path should remain unchanged."""
+    from sktime_mcp.tools.list_available_data import list_available_data_tool
+
+    result = list_available_data_tool()
+
+    assert result["success"] is True
+    assert "system_demos" in result
+    assert "active_handles" in result
+    assert "total" in result


### PR DESCRIPTION
## Summary
- reject non-boolean `is_demo` values in `list_available_data_tool`
- return structured validation errors instead of misleading empty success responses
- add focused regression tests for invalid and valid `is_demo` paths

## Why
`list_available_data_tool` currently accepts malformed values like `"false"`, `1`, or `[]` and returns `success=True` with empty results. That behavior is misleading for MCP clients and LLM agents because it implies that no data exists instead of surfacing invalid input.

## Testing
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_list_available_data.py -q`
- `.venv/bin/pytest -q`

Closes #364
