### PR TITLE
[FIX] : Add substring fallback for tag suggestions in list_estimators

### DIFF
--- a/src/sktime_mcp/tools/list_estimators.py
+++ b/src/sktime_mcp/tools/list_estimators.py
@@ -9,6 +9,15 @@ from typing import Any
 from sktime_mcp.registry.interface import get_registry
 
 
+def _suggest_tag(key: str, valid_tag_keys: set) -> list:
+    """Suggest valid tag keys for an invalid key using difflib and substring fallback."""
+    close = difflib.get_close_matches(key, valid_tag_keys, n=2, cutoff=0.6)
+    if close:
+        return close
+    # fallback: substring match e.g. "pred_int" -> "capability:pred_int"
+    return [t for t in valid_tag_keys if key in t]
+
+
 def list_estimators_tool(
     task: str | None = None,
     tags: dict[str, Any] | None = None,
@@ -23,7 +32,9 @@ def list_estimators_tool(
     are applied on top.
 
     Args:
-        task: Filter by task type. Options: "forecasting", "classification", "regression", "transformation", "clustering", "detection"
+        task: Filter by task type. Options: "forecasting", "classification",
+            "regression", "transformation", "clustering", "detection",
+            "parameter_estimation", "splitting", "network"
         tags: Filter by capability tags. Example: {"capability:pred_int": True}
         query: Search by name or description (substring, case-insensitive).
         limit: Maximum number of results to return (default: 50)
@@ -45,7 +56,9 @@ def list_estimators_tool(
         if task is not None:
             valid_tasks = registry.get_available_tasks()
             if task not in valid_tasks:
-                suggestions = difflib.get_close_matches(task, valid_tasks, n=3, cutoff=0.6)
+                suggestions = difflib.get_close_matches(
+                    task, valid_tasks, n=3, cutoff=0.6
+                )
                 return {
                     "success": False,
                     "error": f"Invalid task: '{task}'. Valid options: {valid_tasks}."
@@ -58,13 +71,14 @@ def list_estimators_tool(
             invalid_keys = [k for k in tags if k not in valid_tag_keys]
             if invalid_keys:
                 suggestions = {
-                    k: difflib.get_close_matches(k, valid_tag_keys, n=1, cutoff=0.6)
-                    for k in invalid_keys
+                    k: _suggest_tag(k, valid_tag_keys) for k in invalid_keys
                 }
                 return {
                     "success": False,
                     "error": f"Invalid tag key(s): {invalid_keys}. Use get_available_tags to see valid keys.",
-                    "suggestions": {k: v[0] if v else None for k, v in suggestions.items()},
+                    "suggestions": {
+                        k: v if v else None for k, v in suggestions.items()
+                    },
                 }
 
         if query:

--- a/tests/test_list_estimators.py
+++ b/tests/test_list_estimators.py
@@ -1,0 +1,50 @@
+"""
+Tests for list_estimators_tool input validation.
+"""
+import pytest
+from sktime_mcp.tools.list_estimators import list_estimators_tool
+
+
+def test_invalid_task_returns_error():
+    result = list_estimators_tool(task="forcasting")
+    assert result["success"] is False
+    assert "forcasting" in result["error"]
+    assert "forecasting" in result["error"]
+
+
+def test_invalid_task_suggests_close_match():
+    result = list_estimators_tool(task="forcasting")
+    assert result["success"] is False
+    assert "forecasting" in result["error"]
+
+
+def test_invalid_tag_returns_error():
+    result = list_estimators_tool(tags={"pred_int": True})
+    assert result["success"] is False
+    assert "pred_int" in result["error"]
+
+
+def test_invalid_tag_suggests_substring_match():
+    result = list_estimators_tool(tags={"pred_int": True})
+    assert result["success"] is False
+    suggestions = result["suggestions"]["pred_int"]
+    assert suggestions is not None
+    assert "capability:pred_int" in suggestions
+
+
+def test_valid_task_returns_success():
+    """Task validation passes - registry load issues are environment-specific."""
+    result = list_estimators_tool(task="forecasting")
+    assert "Invalid task" not in result.get("error", "")
+
+
+def test_valid_tag_returns_success():
+    """Tag validation passes - registry load issues are environment-specific."""
+    result = list_estimators_tool(tags={"capability:pred_int": True})
+    assert "Invalid tag" not in result.get("error", "")
+
+
+def test_no_filters_does_not_raise():
+    """No filters should not cause a validation error."""
+    result = list_estimators_tool()
+    assert "Invalid task" not in result.get("error", "")


### PR DESCRIPTION
#### Reference Issues/PRs
Related to #35 (early adopter feedback - tag suggestion returning None for partial key matches)

#### What does this implement/fix?

When an invalid tag key like `pred_int` is passed to `list_estimators_tool`, the existing code returns `suggestions: None` even though `capability:pred_int` exists in the registry.

**Root cause:** `difflib.get_close_matches` scores `pred_int` vs `capability:pred_int` below the 0.6 cutoff because the `capability:` prefix makes them too dissimilar.

**Before:**
```python
list_estimators_tool(tags={"pred_int": True})
# {'success': False, 'suggestions': {'pred_int': None}}
```

**After:**
```python
list_estimators_tool(tags={"pred_int": True})
# {'success': False, 'suggestions': {'pred_int': ['capability:pred_int', 'capability:pred_int:insample']}}
```

**Fix:** adds a `_suggest_tag` helper that first tries difflib, then falls back to substring matching when difflib finds nothing.

Also fixes the docstring which listed only 6 of 9 valid task types (missing `parameter_estimation`, `splitting`, `network`).

#### Does your contribution introduce a new dependency? If yes, which one?
No. Uses only `difflib` from the Python standard library, which was already imported.

#### What should a reviewer concentrate their feedback on?
- The `_suggest_tag` helper in `src/sktime_mcp/tools/list_estimators.py` and whether the substring fallback logic is sound
- The 7 new tests in `tests/test_list_estimators.py` covering invalid task errors, invalid tag errors, substring suggestions, and valid inputs passing cleanly

#### Any other comments?
Discovered while doing early adopter testing as part of #35.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the list of contributors.
- [ ] Optionally, I've updated sktime's CODEOWNERS to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.