### PR TITLE
test: add horizon validation tests for fit_predict_tool and fit_predict_async_tool

### DIFF
--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -10,7 +10,11 @@ import pytest
 
 sys.path.insert(0, "src")
 
-from sktime_mcp.tools.fit_predict import predict_tool
+from sktime_mcp.tools.fit_predict import (
+    fit_predict_async_tool,
+    fit_predict_tool,
+    predict_tool,
+)
 from sktime_mcp.tools.instantiate import (
     _validate_params,
     instantiate_estimator_tool,
@@ -129,6 +133,56 @@ class TestFitPredictValidation:
     def test_predict_tool_horizon_string(self, invalid_horizon, expected_error):
         """Invalid horizons should be rejected with the correct error"""
         result = predict_tool("fake_handle", horizon=invalid_horizon)
+        assert result["success"] is False
+        assert expected_error in result["error"]
+
+
+class TestFitPredictToolHorizonValidation:
+    """Tests for horizon validation in fit_predict_tool.
+
+    Covers Issue #367: horizon parameter not validated in predict_tool,
+    fit_predict_tool, and fit_predict_async_tool.
+    """
+
+    @pytest.mark.parametrize(
+        "invalid_horizon, expected_error",
+        [
+            (0, "greater than 0"),
+            (-1, "greater than 0"),
+            (-100, "greater than 0"),
+            ("twelve", "must be an integer"),
+            (3.5, "must be an integer"),
+            (None, "must be an integer"),
+        ],
+    )
+    def test_fit_predict_tool_invalid_horizon_rejected(self, invalid_horizon, expected_error):
+        """fit_predict_tool must reject invalid horizon values."""
+        result = fit_predict_tool("fake_handle", dataset="airline", horizon=invalid_horizon)
+        assert result["success"] is False
+        assert expected_error in result["error"]
+
+
+class TestFitPredictAsyncToolHorizonValidation:
+    """Tests for horizon validation in fit_predict_async_tool.
+
+    Covers Issue #367: horizon parameter not validated in predict_tool,
+    fit_predict_tool, and fit_predict_async_tool.
+    """
+
+    @pytest.mark.parametrize(
+        "invalid_horizon, expected_error",
+        [
+            (0, "greater than 0"),
+            (-1, "greater than 0"),
+            (-100, "greater than 0"),
+            ("twelve", "must be an integer"),
+            (3.5, "must be an integer"),
+            (None, "must be an integer"),
+        ],
+    )
+    def test_fit_predict_async_tool_invalid_horizon_rejected(self, invalid_horizon, expected_error):
+        """fit_predict_async_tool must reject invalid horizon before job creation."""
+        result = fit_predict_async_tool("fake_handle", dataset="airline", horizon=invalid_horizon)
         assert result["success"] is False
         assert expected_error in result["error"]
 


### PR DESCRIPTION
## Summary
Closes #367 
## What this adds

`test_param_validation.py` currently only tests horizon validation for `predict_tool`. This PR adds the missing parametrized test classes for `fit_predict_tool` and `fit_predict_async_tool`, ensuring the `_validate_horizon` guard is explicitly covered for all three functions.

## Changes
- `tests/test_param_validation.py`:
-   - Added `TestFitPredictToolHorizonValidation` with 6 parametrized cases
-   - Added `TestFitPredictAsyncToolHorizonValidation` with 6 parametrized cases
-   - Updated imports to include `fit_predict_tool` and `fit_predict_async_tool`
Each test class covers:
- `horizon=0` -> rejected ("greater than 0")
- - `horizon=-1` -> rejected ("greater than 0")
- - `horizon=-100` -> rejected ("greater than 0")
- - `horizon="twelve"` -> rejected ("must be an integer")
- - `horizon=3.5` -> rejected ("must be an integer")
- - `horizon=None` -> rejected ("must be an integer")
## Test Results
34 passed, 0 failed