### PR TITLE
[FIX] validate input types in describe_estimator_tool and search_estimators_tool

### DIFF
--- a/src/sktime_mcp/tools/describe_estimator.py
+++ b/src/sktime_mcp/tools/describe_estimator.py
@@ -39,6 +39,15 @@ def describe_estimator_tool(estimator: str) -> dict[str, Any]:
             ...
         }
     """
+    if not isinstance(estimator, str) or not estimator.strip():
+        return {
+            "success": False,
+            "error": (
+                f"'estimator' must be a non-empty string, "
+                f"got {type(estimator).__name__!r}. example: \"ARIMA\""
+            ),
+        }
+
     registry = get_registry()
     tag_resolver = get_tag_resolver()
 
@@ -84,6 +93,15 @@ def search_estimators_tool(query: str, limit: int = 20) -> dict[str, Any]:
     Returns:
         Dictionary with matching estimators
     """
+    if not isinstance(query, str) or not query.strip():
+        return {
+            "success": False,
+            "error": (
+                f"'query' must be a non-empty string, "
+                f"got {type(query).__name__!r}. example: \"ARIMA\""
+            ),
+        }
+
     if limit < 1:
         return {
             "success": False,

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -16,6 +16,10 @@ from sktime_mcp.tools.instantiate import (
     instantiate_estimator_tool,
     instantiate_pipeline_tool,
 )
+from sktime_mcp.tools.describe_estimator import (
+    describe_estimator_tool,
+    search_estimators_tool,
+)
 
 
 class TestValidateParams:
@@ -131,6 +135,42 @@ class TestFitPredictValidation:
         result = predict_tool("fake_handle", horizon=invalid_horizon)
         assert result["success"] is False
         assert expected_error in result["error"]
+
+
+class TestDescribeEstimatorValidation:
+    """Tests for input validation in describe_estimator_tool and search_estimators_tool.
+    
+    Covers Issue #373.
+    """
+
+    @pytest.mark.parametrize(
+        ("invalid_input", "expected_error"),
+        [
+            (123, "non-empty string"),
+            (["ARIMA"], "non-empty string"),
+            ("", "non-empty string"),
+            ("   ", "non-empty string"),
+        ],
+    )
+    def test_invalid_estimator_input_rejected(self, invalid_input, expected_error):
+        result = describe_estimator_tool(invalid_input)
+        assert result["success"] is False
+        assert expected_error in result["error"]
+
+    @pytest.mark.parametrize(
+        ("invalid_input", "expected_error"),
+        [
+            (123, "non-empty string"),
+            (["ARIMA"], "non-empty string"),
+            ("", "non-empty string"),
+            ("   ", "non-empty string"),
+        ],
+    )
+    def test_invalid_query_input_rejected(self, invalid_input, expected_error):
+        result = search_estimators_tool(invalid_input)
+        assert result["success"] is False
+        assert expected_error in result["error"]
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #373

added input type validation in `describe_estimator_tool` and `search_estimators_tool`. non-string or empty string inputs now return `{"success": False, "error": "..."}` instead of raising unhandled exceptions like `AttributeError` or `TypeError`.

changes made:
- `describe_estimator_tool`: validate `estimator` is a non-empty string before any registry call
- `search_estimators_tool`: validate `query` is a non-empty string before any registry call
