### PR TITLE
Fix: Increase docstring truncation limit to 2000 characters (Resolves #335)

### DIFF
--- a/src/sktime_mcp/registry/interface.py
+++ b/src/sktime_mcp/registry/interface.py
@@ -48,8 +48,8 @@ class EstimatorNode:
             "tags": self.tags,
             "hyperparameters": self.hyperparameters,
             "docstring": (
-                self.docstring[:500] if self.docstring else None
-            ),  # L-1: Truncate docstring to 500 characters, we can also try summarization
+                self.docstring[:2000] if self.docstring else None
+            ),  # L-1: Truncate docstring to 2000 characters, we can also try summarization
         }
 
     def to_summary(self) -> dict[str, Any]:


### PR DESCRIPTION
Fixes #335 by increasing the hardcoded docstring truncation limit from 500 to 2000 characters. This allows LLMs to retain critical parameter configuration information needed for reasoning about sktime estimators.