### PR TITLE
FIX: reject non-forecasting demo datasets in load_dataset

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -42,6 +42,16 @@ def _discover_demo_datasets() -> dict:
 DEMO_DATASETS = _discover_demo_datasets()
 
 
+def _looks_like_non_forecasting_xy_tuple(data: tuple[Any, ...]) -> bool:
+    """Heuristically detect supervised `(X, y)` demo datasets exposed via auto-discovery."""
+    if len(data) < 2:
+        return False
+
+    first, second = data[0], data[1]
+
+    return isinstance(first, pd.DataFrame) and not isinstance(second, (pd.DataFrame, pd.Series))
+
+
 class Executor:
     """
     Execution runtime for sktime estimators.
@@ -102,6 +112,15 @@ class Executor:
             data = loader()
 
             if isinstance(data, tuple):
+                if _looks_like_non_forecasting_xy_tuple(data):
+                    return {
+                        "success": False,
+                        "error": (
+                            f"Dataset '{name}' appears to be a supervised/non-forecasting demo "
+                            "dataset returned as (X, y). The current high-level workflows only "
+                            "support forecasting-style demo datasets."
+                        ),
+                    }
                 y, X = data[0], data[1] if len(data) > 1 else None
             else:
                 y, X = data, None

--- a/tests/test_executor_load_dataset.py
+++ b/tests/test_executor_load_dataset.py
@@ -1,0 +1,30 @@
+"""Tests for demo dataset loading semantics in the executor."""
+
+import sys
+
+sys.path.insert(0, "src")
+
+
+def test_load_dataset_keeps_forecasting_demo_supported():
+    """Forecasting demo datasets should still load successfully."""
+    from sktime_mcp.runtime.executor import Executor
+
+    executor = Executor()
+    result = executor.load_dataset("airline")
+
+    assert result["success"] is True
+    assert "data" in result
+
+
+def test_load_dataset_rejects_non_forecasting_supervised_demo():
+    """Auto-discovered supervised demo datasets should fail fast with a clear error."""
+    from sktime_mcp.runtime.executor import DEMO_DATASETS, Executor
+
+    assert "basic_motions" in DEMO_DATASETS
+
+    executor = Executor()
+    result = executor.load_dataset("basic_motions")
+
+    assert result["success"] is False
+    assert "supervised/non-forecasting" in result["error"]
+    assert "(X, y)" in result["error"]


### PR DESCRIPTION
## Summary
- detect auto-discovered supervised demo datasets returned as `(X, y)`
- fail fast with a clear error instead of surfacing class labels as forecasting `exog`
- add focused regression coverage for supported forecasting demos and rejected non-forecasting demos

## Why
`Executor.load_dataset()` currently assumes tuple-returning demo loaders use forecasting semantics `(y, X)`. Because demo loaders are auto-discovered from all `sktime.datasets.load_*` functions, non-forecasting datasets like `basic_motions` are also exposed. Those loaders return feature data and class labels, which the runtime currently misinterprets as forecasting `data` and `exog`.

## Testing
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_executor_load_dataset.py -q`
- `.venv/bin/pytest -q`

Closes #382
