### PR TITLE
FIX: filter unsupported demo datasets from discovery

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -40,6 +40,38 @@ def _discover_demo_datasets() -> dict:
 
 
 DEMO_DATASETS = _discover_demo_datasets()
+_SUPPORTED_DEMO_DATASETS: list[str] | None = None
+
+
+def _is_supported_demo_dataset(name: str, module_path: str) -> bool:
+    """Return whether a discovered demo dataset matches current forecasting-oriented support."""
+    try:
+        parts = module_path.rsplit(".", 1)
+        module = __import__(parts[0], fromlist=[parts[1]])
+        loader = getattr(module, parts[1])
+        signature = inspect.signature(loader)
+    except Exception:
+        logger.warning(
+            "Skipping demo dataset '%s' because its loader could not be inspected.", name
+        )
+        return False
+
+    # sktime supervised/classification/regression demo loaders typically expose return_X_y.
+    return "return_X_y" not in signature.parameters
+
+
+def _get_supported_demo_datasets() -> list[str]:
+    """Lazily filter discovered demo datasets to supported forecasting-compatible loaders."""
+    global _SUPPORTED_DEMO_DATASETS
+
+    if _SUPPORTED_DEMO_DATASETS is None:
+        _SUPPORTED_DEMO_DATASETS = [
+            name
+            for name, module_path in DEMO_DATASETS.items()
+            if _is_supported_demo_dataset(name, module_path)
+        ]
+
+    return _SUPPORTED_DEMO_DATASETS.copy()
 
 
 class Executor:
@@ -91,7 +123,7 @@ class Executor:
             return {
                 "success": False,
                 "error": f"Unknown dataset: {name}",
-                "available": list(DEMO_DATASETS.keys()),
+                "available": self.list_datasets(),
             }
 
         try:
@@ -529,7 +561,7 @@ class Executor:
 
     def list_datasets(self) -> list[str]:
         """List available demo datasets."""
-        return list(DEMO_DATASETS.keys())
+        return _get_supported_demo_datasets()
 
     def load_data_source(self, config: dict[str, Any]) -> dict[str, Any]:
         """

--- a/tests/test_demo_dataset_discovery.py
+++ b/tests/test_demo_dataset_discovery.py
@@ -1,0 +1,31 @@
+"""Tests for supported demo dataset discovery."""
+
+import sys
+
+sys.path.insert(0, "src")
+
+
+def test_list_datasets_excludes_non_forecasting_supervised_demos():
+    """Supervised `(X, y)` demo datasets should not be advertised as supported demos."""
+    from sktime_mcp.runtime.executor import Executor
+
+    executor = Executor()
+    datasets = executor.list_datasets()
+
+    assert "airline" in datasets
+    assert "basic_motions" not in datasets
+    assert "arrow_head" not in datasets
+    assert "gunpoint" not in datasets
+
+
+def test_list_available_data_demos_only_excludes_unsupported_datasets():
+    """The MCP-facing demo discovery tool should inherit the filtered dataset list."""
+    from sktime_mcp.tools.list_available_data import list_available_data_tool
+
+    result = list_available_data_tool(is_demo=True)
+
+    assert result["success"] is True
+    assert "airline" in result["system_demos"]
+    assert "basic_motions" not in result["system_demos"]
+    assert "arrow_head" not in result["system_demos"]
+    assert "gunpoint" not in result["system_demos"]


### PR DESCRIPTION
## Summary
- filter auto-discovered demo datasets to forecasting-compatible loaders in `Executor.list_datasets()`
- stop advertising supervised `(X, y)` demo datasets like `basic_motions`, `arrow_head`, and `gunpoint`
- add focused regression tests for executor-level and MCP-facing demo discovery

## Why
The runtime currently advertises all `sktime.datasets.load_*` functions as demo datasets. That includes supervised/classification loaders that are not usable in the current forecasting-oriented high-level workflow, which makes MCP discovery misleading.

## Notes
This PR keeps its scope to **discovery filtering** only. Runtime load-time handling for unsupported datasets is separate.

## Testing
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_demo_dataset_discovery.py -q`
- `.venv/bin/pytest -q`

Closes #384
