### PR TITLE
FIX: support RangeIndex inputs in auto-formatting

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -42,6 +42,22 @@ def _discover_demo_datasets() -> dict:
 DEMO_DATASETS = _discover_demo_datasets()
 
 
+def _get_index_frequency_metadata(
+    index: pd.Index,
+    fallback: str | None = None,
+) -> str | None:
+    """Return a stable frequency label for metadata without assuming datetime-only indexes."""
+    if isinstance(index, (pd.DatetimeIndex, pd.PeriodIndex)):
+        freq = getattr(index, "freq", None)
+        if freq is not None:
+            return str(freq)
+        inferred = pd.infer_freq(index)
+        if inferred is not None:
+            return inferred
+
+    return fallback
+
+
 class Executor:
     """
     Execution runtime for sktime estimators.
@@ -772,6 +788,7 @@ class Executor:
             "missing_filled": 0,
             "gaps_filled": 0,
         }
+        original_frequency = data_info["metadata"].get("frequency")
 
         # 1. Remove duplicates
         if remove_duplicates and y.index.duplicated().any():
@@ -788,9 +805,9 @@ class Executor:
 
         # 3. Infer and set frequency
         if auto_infer_freq:
-            freq = y.index.freq
+            freq = getattr(y.index, "freq", None)
 
-            if freq is None:
+            if freq is None and isinstance(y.index, (pd.DatetimeIndex, pd.PeriodIndex)):
                 # Try to infer
                 freq = pd.infer_freq(y.index)
 
@@ -853,7 +870,10 @@ class Executor:
             "metadata": {
                 **data_info["metadata"],
                 "formatted": True,
-                "frequency": str(y.index.freq) if y.index.freq else changes_made.get("frequency"),
+                "frequency": _get_index_frequency_metadata(
+                    y.index,
+                    fallback=changes_made.get("frequency") or original_frequency,
+                ),
                 "rows": len(y),
                 "start_date": str(y.index.min()),
                 "end_date": str(y.index.max()),

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -68,6 +68,25 @@ class TestPandasAdapter:
 class TestExecutorDataIntegration:
     """Executor can load data sources and run fit_predict via data handles."""
 
+    def test_load_data_source_auto_format_supports_rangeindex(self, caplog):
+        """Integer-indexed data should not trip datetime-only auto-format logic."""
+        executor = get_executor()
+
+        config = {
+            "type": "pandas",
+            "data": {
+                "y": [1, 2, 3, 4],
+            },
+        }
+
+        with caplog.at_level("WARNING"):
+            result = executor.load_data_source(config)
+
+        assert result["success"]
+        assert result["formatted"] is True
+        assert result["metadata"]["frequency"] == "Integer"
+        assert "Auto-formatting failed" not in caplog.text
+
     def test_load_and_predict_with_data_handle(self):
         executor = get_executor()
 


### PR DESCRIPTION
## Summary
This fixes an internal auto-format failure for valid integer-indexed / `RangeIndex` time series.

Closes #390.

## Problem
`load_data_source` accepts integer-indexed pandas data, but the auto-format path assumes every index exposes datetime-like frequency metadata. With `RangeIndex`, that raised an internal `AttributeError` on `index.freq`, logged a warning, and fell back to the unformatted path.

## Changes
- guard frequency inspection so it only runs for datetime / period indexes
- preserve the existing `Integer` frequency metadata for non-datetime indexes
- add a regression test covering the integer-indexed pandas load path with auto-format enabled

## Verification
- `.venv/bin/ruff check src/sktime_mcp/runtime/executor.py tests/test_data_sources.py`
- `.venv/bin/ruff format --check src/sktime_mcp/runtime/executor.py tests/test_data_sources.py`
- `.venv/bin/pytest tests/test_data_sources.py -q`
- `.venv/bin/pytest -q`