### PR TITLE
Fix unhandled KeyboardInterrupt for graceful exit

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -6,6 +6,7 @@ that exposes sktime's registry and execution capabilities to LLMs.
 """
 
 import asyncio
+import sys
 import json
 import logging
 import os
@@ -830,9 +831,11 @@ async def run_server():
 
 def main():
     """Main entry point."""
-    logger.info("Starting sktime-mcp server...")
-    asyncio.run(run_server())
-
+    try:
+        asyncio.run(run_server())
+    except KeyboardInterrupt:
+        print("\nINFO: sktime-mcp server shut down gracefully.")
+        sys.exit(0)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR resolves the unhandled traceback issues when terminating the server via Ctrl+C. It wraps the main entry point in a try-except block to catch KeyboardInterrupt and exit silently, preventing I/O errors on closed stdio streams.

Fixes #394