### PR TITLE
docs: reference suggest_pipeline tool status

### DIFF
--- a/docs/source/implementation.md
+++ b/docs/source/implementation.md
@@ -90,7 +90,7 @@ The codebase is organized into **5 main layers**:
    
 2. **`@server.list_tools()`**: Registers all available MCP tools
    - Returns tool schemas (name, description, input schema)
-   - Tools: `list_estimators`, `describe_estimator`, `instantiate_estimator`, `instantiate_pipeline`, `fit_predict`, `validate_pipeline`, `list_available_data`, `get_available_tags`
+   - Tools: `list_estimators`, `describe_estimator`, `instantiate_estimator`, `instantiate_pipeline`, `fit_predict`, `validate_pipeline`, `suggest_pipeline` (proposed in `sktime/sktime-mcp#288`, implemented in PR `#301`), `list_available_data`, `get_available_tags`
 
 3. **`@server.call_tool(name, arguments)`**: Routes tool calls to implementations
    - Validates arguments


### PR DESCRIPTION
## Summary\n- Updates docs to mention the suggest_pipeline MCP tool, as proposed in #288 and implemented in #301.\n\n## Context\nIssue #288 was opened after noticing suggest_pipeline was listed as planned but not exposed. There is already an implementation PR (#301). This PR is a small docs follow-up so the code explanation page reflects the current status.\n\n## Related\n- #288\n- #301\n

Made with [Cursor](https://cursor.com)