### PR TITLE
fix: convert numpy types to Python native in predictions

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -166,13 +166,23 @@ class Executor:
 
             if isinstance(predictions, pd.Series):
                 # Convert index to string to avoid JSON serialization issues with Period/DatetimeIndex
+                # Convert values to native Python floats to avoid numpy.float64 serialization issues
                 predictions_copy = predictions.copy()
                 predictions_copy.index = predictions_copy.index.astype(str)
-                result = predictions_copy.to_dict()
+                result = {
+                    str(k): float(v) if hasattr(v, "dtype") else v
+                    for k, v in predictions_copy.items()
+                }
             elif isinstance(predictions, pd.DataFrame):
+                # Convert index to string and values to native Python types
                 predictions_copy = predictions.copy()
                 predictions_copy.index = predictions_copy.index.astype(str)
-                result = predictions_copy.to_dict(orient="list")
+                raw_dict = predictions_copy.to_dict(orient="list")
+                # Convert numpy values in each list to native Python floats
+                result = {
+                    k: [float(v) if hasattr(v, "dtype") else v for v in lst]
+                    for k, lst in raw_dict.items()
+                }
             else:
                 result = predictions.tolist() if hasattr(predictions, "tolist") else predictions
 

--- a/tests/test_numpy_serialization.py
+++ b/tests/test_numpy_serialization.py
@@ -1,0 +1,54 @@
+"""
+Tests that fit_predict returns JSON-serializable native Python types.
+
+Fixes: numpy.float64 values caused json.dumps() to fail in MCP responses.
+"""
+
+import json
+
+import pytest
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.runtime.handles import get_handle_manager
+
+
+class TestNumpySerialization:
+
+    def test_predictions_are_json_serializable(self):
+        executor = get_executor()
+        handle_manager = get_handle_manager()
+
+        inst_result = executor.instantiate("NaiveForecaster", {"strategy": "last"})
+        assert inst_result["success"], f"Failed to instantiate: {inst_result}"
+        handle = inst_result["handle"]
+
+        try:
+            result = executor.fit_predict(handle, "airline", horizon=6)
+            assert result["success"], f"fit_predict failed: {result.get('error')}"
+
+            predictions = result["predictions"]
+            assert len(predictions) > 0
+
+            # Must not raise TypeError (before fix this failed)
+            try:
+                json_output = json.dumps(predictions)
+                assert isinstance(json_output, str)
+            except TypeError as e:
+                pytest.fail(f"Predictions are not JSON serializable: {e}")
+
+            # Values must be native Python types, not numpy scalars
+            for key, value in predictions.items():
+                assert type(value) in (int, float), (
+                    f"Value {key}={value} is {type(value).__name__}, "
+                    f"expected int or float"
+                )
+                assert not hasattr(value, "dtype"), (
+                    f"Value {key}={value} is a numpy type, "
+                    f"should be native Python"
+                )
+        finally:
+            handle_manager.release_handle(handle)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
#### Reference Issues/PRs
<!-- Uncomment if you created an issue first -->
Fixes #401 

#### What does this implement/fix? Explain your changes.

Fixes an issue where [fit_predict](cci:1://file:///z:/Open%20Source/European%20Summer%20of%20Code/Batch%202/skitime/sktime-mcp/src/sktime_mcp/runtime/executor.py:196:4-234:50) returned `numpy.float64` values, which caused JSON serialization failures in MCP responses.

Changes in [executor.py](cci:7://file:///z:/Open%20Source/European%20Summer%20of%20Code/Batch%202/skitime/sktime-mcp/src/sktime_mcp/runtime/executor.py:0:0-0:0):
- `pd.Series`: Convert values using `float(v) if hasattr(v, "dtype")` 
- `pd.DataFrame`: Convert nested values with list comprehension
- Uses `hasattr(v, "dtype")` to detect numpy types without importing numpy

#### Does your contribution introduce a new dependency?
No.

#### What should a reviewer concentrate their feedback on?
- Whether using `hasattr(v, "dtype")` is the right approach for detecting numpy types
- If the `float()` conversion handles all edge cases correctly

#### Any other comments?
Added [test_numpy_serialization.py](cci:7://file:///z:/Open%20Source/European%20Summer%20of%20Code/Batch%202/skitime/sktime-mcp/tests/test_numpy_serialization.py:0:0-0:0) verifying predictions are JSON serializable.

#### PR checklist
- [x] I've added unit tests and made sure they pass locally
- [ ] I've added myself to the list of contributors 