### PR TITLE
fix: add schema constraints to MCP tool definitions

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -160,10 +160,14 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "task": {
                         "type": "string",
-                        "description": (
-                            "Task type filter: forecasting, classification, "
-                            "regression, transformation, clustering"
-                        ),
+                        "description": "Task type filter",
+                        "enum": [
+                            "forecasting",
+                            "classification",
+                            "regression",
+                            "transformation",
+                            "clustering",
+                        ],
                     },
                     "tags": {
                         "type": "object",
@@ -370,6 +374,8 @@ async def list_tools() -> list[Tool]:
                         "type": "integer",
                         "description": "Number of cross-validation folds (default: 3)",
                         "default": 3,
+                        "minimum": 1,
+                        "maximum": 10,
                     },
                 },
                 "required": ["estimator_handle", "dataset"],

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,46 @@
+"""
+Tests for MCP tool input schema constraints.
+
+Verifies:
+- task parameter in list_estimators has an enum
+- cv_folds in evaluate_estimator has minimum and maximum bounds
+"""
+
+import pytest
+from sktime_mcp.server import list_tools
+
+# requires: pytest-asyncio
+
+
+class TestSchemaConstraints:
+
+    @pytest.fixture
+    async def tools(self):
+        return {t.name: t for t in await list_tools()}
+
+    @pytest.mark.asyncio
+    async def test_list_estimators_task_has_enum(self, tools):
+        assert "list_estimators" in tools
+
+        task_param = tools["list_estimators"].inputSchema["properties"]["task"]
+        assert "enum" in task_param, (
+            "task parameter must have enum to guide LLM clients"
+        )
+        assert len(task_param["enum"]) > 0, "enum must not be empty"
+        assert "forecasting" in task_param["enum"]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_estimator_cv_folds_has_bounds(self, tools):
+        assert "evaluate_estimator" in tools
+
+        cv_folds = (
+            tools["evaluate_estimator"].inputSchema["properties"]["cv_folds"]
+        )
+        assert "minimum" in cv_folds, "cv_folds must have a minimum"
+        assert "maximum" in cv_folds, "cv_folds must have a maximum"
+        assert cv_folds["minimum"] >= 1, "minimum must be at least 1"
+        assert cv_folds["maximum"] > cv_folds["minimum"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #407

#### What does this implement/fix? Explain your changes.
Two small schema additions to `server.py`:

- Added `enum` to the `task` parameter in `list_estimators` — without 
  this, LLM clients have no way to know what values are valid and tend 
  to guess wrong
- Added `minimum: 1` and `maximum: 10` to `cv_folds` in 
  `evaluate_estimator` — currently nothing stops a client from passing 
  0 or a negative number

Both are missing constraints I noticed while reading through the tool 
definitions. Small changes but they make the tools noticeably easier 
to use correctly from an LLM client.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether the enum values I picked for `task` are complete — I based 
  them on the sktime docs but may have missed some
- Whether 1–10 is a sensible range for `cv_folds` or if the upper 
  bound should be higher/removed

#### Any other comments?
Happy to extend this to other parameters if the approach looks good 
to you — there are a few other places where bounds or enums would help.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the list of contributors.
- [x] I've added unit tests and made sure they pass locally.