### PR TITLE
[ENH] Add diagnose_residuals_tool for statistical agent reasoning

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -37,7 +37,7 @@ from sktime_mcp.tools.data_tools import (
     release_data_handle_tool,
 )
 from sktime_mcp.tools.describe_estimator import describe_estimator_tool
-from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+from sktime_mcp.tools.evaluate import evaluate_estimator_tool, diagnose_residuals_tool
 from sktime_mcp.tools.fit_predict import (
     fit_predict_async_tool,
     fit_predict_tool,
@@ -375,6 +375,24 @@ async def list_tools() -> list[Tool]:
                 "required": ["estimator_handle", "dataset"],
             },
         ),
+        Tool(
+            name="diagnose_residuals_tool",
+            description="Diagnose model failures by calculating statistical metrics (MAE, RMSE, Mean Bias) on residuals.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "predictions": {
+                        "type": ["object", "array"],
+                        "description": "Forecasted values (dict or list)",
+                    },
+                    "actuals": {
+                        "type": ["object", "array"],
+                        "description": "Actual observed values (dict or list)",
+                    },
+                },
+                "required": ["predictions", "actuals"],
+            },
+        ),
         # -- Data ------------------------------------------------------------
         Tool(
             name="list_available_data",
@@ -693,6 +711,12 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["estimator_handle"],
                 arguments["dataset"],
                 arguments.get("cv_folds", 3),
+            )
+
+        elif name == "diagnose_residuals_tool":
+            result = diagnose_residuals_tool(
+                predictions=arguments["predictions"],
+                actuals=arguments["actuals"],
             )
 
         elif name == "validate_pipeline":

--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -7,6 +7,7 @@ Executes cross-validation on an estimator.
 import logging
 from typing import Any
 
+import numpy as np
 from sktime.forecasting.model_evaluation import evaluate
 
 try:
@@ -73,4 +74,63 @@ def evaluate_estimator_tool(
         }
     except Exception as e:
         logger.exception("Error during evaluate")
+        return {"success": False, "error": str(e)}
+
+
+def diagnose_residuals_tool(
+    predictions: dict[str, Any] | list[float],
+    actuals: dict[str, Any] | list[float],
+) -> dict[str, Any]:
+    """
+    Diagnose residuals by comparing predictions and actuals.
+
+    Args:
+        predictions: Forecasted values.
+        actuals: Actual observed values.
+
+    Returns:
+        Dictionary with statistical metrics (MAE, RMSE, Bias).
+    """
+    try:
+        def extract_values(data):
+            if isinstance(data, dict):
+                # Handle nested dicts or flat dicts
+                try:
+                    return np.array(list(data.values()), dtype=float)
+                except ValueError:
+                    return np.array([float(v) for v in data.values() if isinstance(v, (int, float))])
+            return np.array(data, dtype=float)
+
+        y_pred = extract_values(predictions)
+        y_true = extract_values(actuals)
+
+        if len(y_pred) != len(y_true):
+            return {
+                "success": False,
+                "error": f"Length mismatch: predictions ({len(y_pred)}) vs actuals ({len(y_true)})",
+            }
+
+        residuals = y_true - y_pred
+        mae = float(np.mean(np.abs(residuals)))
+        mse = float(np.mean(residuals ** 2))
+        rmse = float(np.sqrt(mse))
+        bias = float(np.mean(residuals))
+
+        return {
+            "success": True,
+            "metrics": {
+                "MAE": mae,
+                "RMSE": rmse,
+                "Mean_Bias": bias,
+            },
+            "residuals": [float(r) for r in residuals],
+            "diagnosis": (
+                f"The model has a mean bias of {bias:.4f}. "
+                f"A positive bias means the model under-predicts on average, "
+                f"while a negative bias means it over-predicts. "
+                f"Average absolute error (MAE) is {mae:.4f}."
+            )
+        }
+    except Exception as e:
+        logger.exception("Error during diagnose_residuals")
         return {"success": False, "error": str(e)}


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #400

#### What does this implement/fix? Explain your changes.

This PR implements the `diagnose_residuals_tool` to give LLM agents explicit statistical reasoning capabilities when diagnosing model failures. 

Currently, agents struggle to quantitatively assess prediction errors from raw arrays. This new tool allows agents to pass in predictions and actuals, and it returns:
1. **Statistical Metrics:** Computes Mean Absolute Error (MAE), Root Mean Squared Error (RMSE), and Mean Bias.
2. **Textual Diagnosis:** Generates a human-readable summary of the bias direction (e.g., "A positive bias means the model under-predicts on average") to heavily guide the LLM's reasoning engine toward correct conclusions.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies are introduced. The tool strictly relies on `numpy`, which is already a core dependency of the project.

#### What should a reviewer concentrate their feedback on?

Reviewers can verify the extraction logic in `src/sktime_mcp/tools/evaluate.py`. The tool includes robust fallback mechanisms to safely extract numerical arrays regardless of whether the agent passes in flat lists or JSON-serialized dictionaries (which commonly occurs during agent interactions).

#### Any other comments?

This PR is part of a larger effort to improve the MCP server's stability and agentic discoverability for ESoC 2026. I initially bundled this with several other fixes, but have broken it out into this focused PR based on maintainer feedback to make reviews easier!

#### PR checklist

- [x] I have read the [CONTRIBUTING](https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md) guide.
- [x] I have checked that my PR does not duplicate an existing PR.
- [x] I have checked that there is an existing issue for this PR, if applicable.
- [x] My code follows the project's coding standards.
