### PR TITLE
[BUG] Classification workflows are discoverable but not executable end-to-end

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -131,12 +131,16 @@ class Executor:
             return {"success": False, "error": f"Handle not found: {handle_id}"}
 
         try:
-            if fh is not None:
-                instance.fit(y, X=X, fh=fh)
-            elif X is not None:
-                instance.fit(y, X=X)
+            is_classifier = getattr(instance, "_estimator_type", None) == "classifier"
+            if is_classifier:
+                instance.fit(X, y)
             else:
-                instance.fit(y)
+                if fh is not None:
+                    instance.fit(y, X=X, fh=fh)
+                elif X is not None:
+                    instance.fit(y, X=X)
+                else:
+                    instance.fit(y)
 
             self._handle_manager.mark_fitted(handle_id)
             return {"success": True, "handle": handle_id, "fitted": True}
@@ -159,10 +163,14 @@ class Executor:
             return {"success": False, "error": "Estimator not fitted"}
 
         try:
-            if fh is None:
-                fh = list(range(1, 13))
+            is_classifier = getattr(instance, "_estimator_type", None) == "classifier"
+            if is_classifier:
+                predictions = instance.predict(X)
+            else:
+                if fh is None:
+                    fh = list(range(1, 13))
 
-            predictions = instance.predict(fh=fh, X=X) if X is not None else instance.predict(fh=fh)
+                predictions = instance.predict(fh=fh, X=X) if X is not None else instance.predict(fh=fh)
 
             if isinstance(predictions, pd.Series):
                 # Convert index to string to avoid JSON serialization issues with Period/DatetimeIndex


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #405

#### What does this implement/fix? Explain your changes.
Currently, agents can successfully discover classification estimators but fail when attempting to execute `fit_predict` because the executor blindly passes forecasting-specific arguments (like `fh`) to classifiers. 

This PR updates `executor.py` to check the `_estimator_type`. If it is a `"classifier"`, it safely routes the fitting and prediction logic to standard `(X, y)` parameters, omitting the incompatible `fh` argument.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies are introduced.

#### What should a reviewer concentrate their feedback on?
Reviewers can check the `fit` and `predict` methods in `executor.py` to ensure the classification routing logic covers all necessary edge cases.

#### Any other comments?
This is part of a larger ESoC stability push. I've separated this out into its own focused PR to make review as simple as possible.

#### PR checklist
- [x] I have read the [CONTRIBUTING](https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md) guide.
- [x] I have checked that my PR does not duplicate an existing PR.
- [x] I have checked that there is an existing issue for this PR, if applicable.
- [x] My code follows the project's coding standards.
