### PR TITLE
[BUG] Enforce forecasting demo dataset whitelist to fix tuple misinterpretation and discovery bugs

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -41,6 +41,16 @@ def _discover_demo_datasets() -> dict:
 
 DEMO_DATASETS = _discover_demo_datasets()
 
+# Hardcoded list of supported forecasting demo datasets
+FORECASTING_DEMO_DATASETS = {
+    "airline",
+    "shampoo_sales",
+    "lynx",
+    "macroeconomic",
+    "longley",
+    "PBS_dataset",
+    "uschange",
+}
 
 class Executor:
     """
@@ -91,7 +101,14 @@ class Executor:
             return {
                 "success": False,
                 "error": f"Unknown dataset: {name}",
-                "available": list(DEMO_DATASETS.keys()),
+                "available": list(FORECASTING_DEMO_DATASETS),
+            }
+
+        if name not in FORECASTING_DEMO_DATASETS:
+            return {
+                "success": False,
+                "error": f"Dataset '{name}' is not currently supported in high-level forecasting workflows.",
+                "available": list(FORECASTING_DEMO_DATASETS),
             }
 
         try:
@@ -529,7 +546,7 @@ class Executor:
 
     def list_datasets(self) -> list[str]:
         """List available demo datasets."""
-        return list(DEMO_DATASETS.keys())
+        return list(FORECASTING_DEMO_DATASETS)
 
     def load_data_source(self, config: dict[str, Any]) -> dict[str, Any]:
         """

--- a/src/sktime_mcp/tools/codegen.py
+++ b/src/sktime_mcp/tools/codegen.py
@@ -8,7 +8,7 @@ import keyword
 from typing import Any
 
 from sktime_mcp.registry.interface import get_registry
-from sktime_mcp.runtime.executor import DEMO_DATASETS
+from sktime_mcp.runtime.executor import DEMO_DATASETS, FORECASTING_DEMO_DATASETS
 from sktime_mcp.runtime.handles import get_handle_manager
 
 
@@ -253,8 +253,13 @@ def export_code_tool(
 
     # Optionally add fit/predict example
     if include_fit_example:
-        # Resolve the dataset loader from DEMO_DATASETS
-        if dataset and dataset in DEMO_DATASETS:
+        # Resolve the dataset loader from FORECASTING_DEMO_DATASETS
+        if dataset:
+            if dataset not in FORECASTING_DEMO_DATASETS:
+                return {
+                    "success": False,
+                    "error": f"Dataset '{dataset}' is not supported for generating fit examples. Must be a forecasting dataset.",
+                }
             module_path = DEMO_DATASETS[dataset]
             module_parts = module_path.rsplit(".", 1)
             loader_module = module_parts[0]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #382
Fixes #384
Fixes #388

#### What does this implement/fix? Explain your changes.

The MCP layer currently assumes all `sktime.datasets` are forecasting datasets, which breaks when LLM agents attempt to use tuple-based supervised datasets like `basic_motions`. This PR hardens the demo dataset API and resolves 3 related bugs:

1. **Discovery (#384):** Filters `list_available_data_tool(is_demo=True)` to only advertise known forecasting datasets.
2. **Loading (#382):** Safely rejects unsupported datasets in `load_dataset` to prevent backwards `y, X` assignment.
3. **Code Generation (#388):** Prevents `export_code_tool` from generating broken `fit` examples for non-forecasting datasets.

It implements this via a `FORECASTING_DEMO_DATASETS` constant whitelist in `executor.py`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Reviewers can verify the implementation of `FORECASTING_DEMO_DATASETS` in `executor.py` and ensure the fallback validations in `load_dataset` and `export_code_tool` handle exceptions gracefully without crashing the server.

#### Any other comments?
This is another piece of the ESoC 2026 stability push! It prevents agents from hallucinating code on datasets the workflow doesn't fully support yet.

#### PR checklist
- [x] I have read the [CONTRIBUTING](https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md) guide.
- [x] I have checked that my PR does not duplicate an existing PR.
- [x] I have checked that there is an existing issue for this PR, if applicable.
- [x] My code follows the project's coding standards.

