### PR TITLE
[ENH] Agentic Iterative Evaluation: Add describe_data, score_on_holdout, and commit_estimator tools

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -916,6 +916,160 @@ class Executor:
             }
 
 
+
+    def _resolve_data(self, dataset: str | None, data_handle: str | None) -> dict:
+        if dataset and data_handle:
+            return {"success": False, "error": "Provide either 'dataset' or 'data_handle', not both."}
+        if data_handle is None and (not dataset or not str(dataset).strip()):
+            return {"success": False, "error": "Either 'dataset' or 'data_handle' is required."}
+            
+        if data_handle is not None:
+            if data_handle not in self._data_handles:
+                return {"success": False, "error": f"Unknown data handle: {data_handle}"}
+            data_info = self._data_handles[data_handle]
+            return {"success": True, "y": data_info["y"], "X": data_info.get("X")}
+        else:
+            load_result = self.load_dataset(dataset)
+            if not load_result["success"]:
+                return load_result
+            return {"success": True, "y": load_result["data"], "X": load_result.get("exog")}
+
+    def describe_data(self, dataset: str | None = None, data_handle: str | None = None) -> dict[str, Any]:
+        """Return fingerprinting statistics for a dataset."""
+        import pandas as pd
+        import numpy as np
+        
+        res = self._resolve_data(dataset, data_handle)
+        if not res["success"]: return res
+        
+        y = res["y"]
+        stats = {"success": True, "type": str(type(y).__name__)}
+        
+        if hasattr(y, "__len__"):
+            stats["length"] = len(y)
+        
+        if hasattr(y, "index") and hasattr(y.index, "freqstr"):
+            stats["frequency"] = y.index.freqstr
+            
+        if isinstance(y, pd.Series) or isinstance(y, pd.DataFrame):
+            stats["n_missing"] = int(y.isna().sum().sum() if isinstance(y, pd.DataFrame) else y.isna().sum())
+            try:
+                stats["mean"] = float(y.mean().iloc[0] if isinstance(y, pd.DataFrame) else y.mean())
+                stats["std"] = float(y.std().iloc[0] if isinstance(y, pd.DataFrame) else y.std())
+            except Exception:
+                pass
+                
+            # Quick trend slope proxy: fit a line to the first series
+            try:
+                if isinstance(y, pd.DataFrame):
+                    y_vals = y.iloc[:, 0].dropna().values
+                else:
+                    y_vals = y.dropna().values
+                    
+                if len(y_vals) > 1:
+                    x_vals = np.arange(len(y_vals))
+                    slope, _ = np.polyfit(x_vals, y_vals, 1)
+                    stats["trend_slope_per_step"] = float(slope)
+            except Exception:
+                pass
+                
+        return stats
+
+    def score_on_holdout(self, estimator_handle: str, dataset: str | None = None, data_handle: str | None = None, holdout_size: int = 12, metric: str = "MeanAbsoluteError") -> dict[str, Any]:
+        """Fit on train, score on holdout tail, return scalar metric."""
+        from sktime.split import temporal_train_test_split
+        from sktime.performance_metrics.forecasting import mean_absolute_error, mean_squared_error, mean_absolute_percentage_error
+        
+        res = self._resolve_data(dataset, data_handle)
+        if not res["success"]: return res
+        y = res["y"]
+        X = res["X"]
+        
+        if estimator_handle not in self._handles:
+            return {"success": False, "error": f"Unknown handle: {estimator_handle}"}
+            
+        est_info = self._handles[estimator_handle]
+        if est_info.task != "forecasting":
+            return {"success": False, "error": "score_on_holdout only supports forecasting tasks"}
+            
+        try:
+            from sktime_mcp.registry.interface import get_registry
+            registry = get_registry()
+            node = registry.get_estimator_by_name(est_info.estimator_name)
+            est_class = node.class_ref
+            model = est_class(**est_info.params)
+            
+            # Split
+            if X is not None:
+                y_train, y_test, X_train, X_test = temporal_train_test_split(y, X, test_size=holdout_size)
+            else:
+                y_train, y_test = temporal_train_test_split(y, test_size=holdout_size)
+                X_train, X_test = None, None
+                
+            # Fit
+            model.fit(y=y_train, X=X_train)
+            
+            # Predict
+            fh = list(range(1, holdout_size + 1))
+            y_pred = model.predict(fh=fh, X=X_test)
+            
+            # Score
+            if metric == "MeanSquaredError":
+                score = mean_squared_error(y_test, y_pred)
+            elif metric == "MeanAbsolutePercentageError":
+                score = mean_absolute_percentage_error(y_test, y_pred)
+            else:
+                score = mean_absolute_error(y_test, y_pred)
+                
+            return {
+                "success": True,
+                "estimator": est_info.estimator_name,
+                "metric": metric,
+                "score": float(score),
+                "holdout_size": holdout_size
+            }
+        except Exception as e:
+            import traceback
+            return {"success": False, "error": str(e), "traceback": traceback.format_exc()}
+
+    def commit_estimator(self, estimator_handle: str, dataset: str | None = None, data_handle: str | None = None, rationale: str | None = None) -> dict[str, Any]:
+        """Fit estimator on the FULL dataset and mark it as fitted in the handle manager."""
+        res = self._resolve_data(dataset, data_handle)
+        if not res["success"]: return res
+        y = res["y"]
+        X = res["X"]
+        
+        if estimator_handle not in self._handles:
+            return {"success": False, "error": f"Unknown handle: {estimator_handle}"}
+            
+        est_info = self._handles[estimator_handle]
+        
+        try:
+            # Recreate model
+            from sktime_mcp.registry.interface import get_registry
+            registry = get_registry()
+            node = registry.get_estimator_by_name(est_info.estimator_name)
+            est_class = node.class_ref
+            model = est_class(**est_info.params)
+            
+            # Fit on full data
+            model.fit(y=y, X=X)
+            
+            # Update handle state
+            est_info.fitted = True
+            est_info.instance = model
+            
+            return {
+                "success": True,
+                "message": f"Successfully committed {est_info.estimator_name}",
+                "handle": estimator_handle,
+                "rationale": rationale
+            }
+        except Exception as e:
+            import traceback
+            return {"success": False, "error": str(e), "traceback": traceback.format_exc()}
+
+
 _executor_instance: Executor | None = None
 
 

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -61,6 +61,7 @@ from sktime_mcp.tools.list_estimators import (
     list_estimators_tool,
 )
 from sktime_mcp.tools.save_model import save_model_tool
+from sktime_mcp.tools.agentic_iterative import describe_data_tool, score_on_holdout_tool, commit_estimator_tool
 
 # ---------------------------------------------------------------------------
 # Server configuration via environment variables
@@ -521,7 +522,47 @@ async def list_tools() -> list[Tool]:
                 "required": ["handle"],
             },
         ),
+                Tool(
+            name="commit_estimator",
+            description="Commit a forecaster by refitting on the full dataset.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {"type": "string", "description": "The handle of the estimator"},
+                    "dataset": {"type": "string", "description": "Dataset name"},
+                    "data_handle": {"type": "string", "description": "Loaded data handle"},
+                    "rationale": {"type": "string", "description": "Optional rationale"}
+                },
+                "required": ["estimator_handle"],
+            },
+        ),
         Tool(
+            name="score_on_holdout",
+            description="Score an estimator on a holdout tail.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "estimator_handle": {"type": "string", "description": "The handle of the estimator"},
+                    "dataset": {"type": "string", "description": "Dataset name"},
+                    "data_handle": {"type": "string", "description": "Loaded data handle"},
+                    "holdout_size": {"type": "integer", "description": "Holdout size", "default": 12},
+                    "metric": {"type": "string", "description": "Metric name", "default": "MeanAbsoluteError"}
+                },
+                "required": ["estimator_handle"],
+            },
+        ),
+        Tool(
+            name="describe_data",
+            description="Returns statistical fingerprint of a dataset.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "dataset": {"type": "string", "description": "Dataset name"},
+                    "data_handle": {"type": "string", "description": "Loaded data handle"}
+                },
+            },
+        ),
+Tool(
             name="save_model",
             description="Save an estimator/pipeline handle using sktime MLflow integration",
             inputSchema={
@@ -748,6 +789,30 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments.get("dataset"),
             )
 
+        elif name == "describe_data":
+            dataset = arguments.get("dataset")
+            data_handle = arguments.get("data_handle")
+            result = describe_data_tool(dataset, data_handle)
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
+            
+        elif name == "score_on_holdout":
+            result = score_on_holdout_tool(
+                arguments.get("estimator_handle"),
+                arguments.get("dataset"),
+                arguments.get("data_handle"),
+                arguments.get("holdout_size", 12),
+                arguments.get("metric", "MeanAbsoluteError")
+            )
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
+            
+        elif name == "commit_estimator":
+            result = commit_estimator_tool(
+                arguments.get("estimator_handle"),
+                arguments.get("dataset"),
+                arguments.get("data_handle"),
+                arguments.get("rationale")
+            )
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
         elif name == "save_model":
             result = save_model_tool(
                 arguments["estimator_handle"],

--- a/src/sktime_mcp/tools/agentic_iterative.py
+++ b/src/sktime_mcp/tools/agentic_iterative.py
@@ -1,0 +1,88 @@
+"""
+Agentic Iterative Evaluation Tools.
+Provides fine-grained tools for LLM agents to iteratively reason about data, test models on holdouts, and commit final winners.
+"""
+
+from typing import Any
+from sktime_mcp.runtime.executor import get_executor
+
+def describe_data_tool(dataset: str | None = None, data_handle: str | None = None) -> dict[str, Any]:
+    """
+    Fingerprint a dataset to help the agent reason about its characteristics before choosing an estimator.
+    Returns length, frequency, missingness, mean, std, and a trend slope proxy.
+    
+    Args:
+        dataset: Name of a builtin dataset (e.g. 'airline')
+        data_handle: ID of a loaded dataset (from load_data_source)
+        
+    Returns:
+        Dictionary with statistical summary of the data.
+    """
+    executor = get_executor()
+    try:
+        return executor.describe_data(dataset=dataset, data_handle=data_handle)
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+def score_on_holdout_tool(
+    estimator_handle: str,
+    dataset: str | None = None,
+    data_handle: str | None = None,
+    holdout_size: int = 12,
+    metric: str = "MeanAbsoluteError"
+) -> dict[str, Any]:
+    """
+    Evaluate a single estimator candidate quickly on a holdout tail.
+    Fits the model on the in-sample portion and scores it against the holdout.
+    
+    Args:
+        estimator_handle: The ID of the instantiated estimator
+        dataset: Builtin dataset name
+        data_handle: Loaded data handle ID
+        holdout_size: Number of steps to hold out at the end of the series
+        metric: Performance metric to use (default: 'MeanAbsoluteError')
+        
+    Returns:
+        Dictionary with the scalar score.
+    """
+    executor = get_executor()
+    try:
+        return executor.score_on_holdout(
+            estimator_handle=estimator_handle,
+            dataset=dataset,
+            data_handle=data_handle,
+            holdout_size=holdout_size,
+            metric=metric
+        )
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+def commit_estimator_tool(
+    estimator_handle: str,
+    dataset: str | None = None,
+    data_handle: str | None = None,
+    rationale: str | None = None
+) -> dict[str, Any]:
+    """
+    Commit an estimator as the final winner by refitting it on the entire historical dataset.
+    This prepares the handle for future 'predict_only' calls.
+    
+    Args:
+        estimator_handle: The ID of the instantiated estimator
+        dataset: Builtin dataset name
+        data_handle: Loaded data handle ID
+        rationale: Optional text explanation from the agent for why this model was chosen
+        
+    Returns:
+        Dictionary confirming the model was successfully fitted and committed.
+    """
+    executor = get_executor()
+    try:
+        return executor.commit_estimator(
+            estimator_handle=estimator_handle,
+            dataset=dataset,
+            data_handle=data_handle,
+            rationale=rationale
+        )
+    except Exception as e:
+        return {"success": False, "error": str(e)}


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #386

#### What does this implement/fix? Explain your changes.

This PR implements the missing tool surface required for LLM agents to execute iterative model-selection loops (ReAct patterns) efficiently. 

It introduces three highly targeted MCP tools in a new `agentic_iterative.py` module, backed by robust `executor.py` implementations:

1. **`describe_data`:** Gives the LLM a statistical fingerprint (length, frequency, missingness, mean, std, trend proxy) of a dataset *before* it selects candidate models.
2. 2. **`score_on_holdout`:** Allows fast, single-candidate evaluation on a temporal holdout tail without the overhead of full cross-validation.
3. 3. **`commit_estimator`:** Once the agent decides on a winner, this tool refits the model on the full historical dataset, sets `fitted=True` in the handle registry, and stores an optional agent rationale.
#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies.

#### What should a reviewer concentrate their feedback on?
Reviewers can check the `Executor` class in `src/sktime_mcp/runtime/executor.py` to ensure the `temporal_train_test_split` logic aligns with `sktime` best practices.

#### Any other comments?
This completely unlocks fully autonomous agentic research loops using `sktime-mcp`!

#### PR checklist
- [x] I have read the CONTRIBUTING guide.
- [ ] - [x] I have checked that my PR does not duplicate an existing PR.
- [ ] - [x] I have checked that there is an existing issue for this PR, if applicable.
- [ ] - [x] My code follows the project's coding standards.