### PR TITLE
feat: validate explicit target_column to prevent silent fallback

### DIFF
--- a/src/sktime_mcp/data/base.py
+++ b/src/sktime_mcp/data/base.py
@@ -74,7 +74,14 @@ class DataSourceAdapter(ABC):
         target_col = self.config.get("target_column")
         exog_cols = self.config.get("exog_columns", [])
 
-        if target_col and target_col in data.columns:
+        if target_col is not None and target_col not in data.columns:
+            available_columns = ", ".join(repr(col) for col in data.columns)
+            raise ValueError(
+                f"Target column {target_col!r} not found in data. "
+                f"Available columns: [{available_columns}]"
+            )
+
+        if target_col is not None:
             y = data[target_col]
 
             # Get exogenous variables if specified

--- a/tests/test_data_target_column_validation.py
+++ b/tests/test_data_target_column_validation.py
@@ -1,0 +1,53 @@
+"""Tests for explicit target column validation in data adapters."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from sktime_mcp.data.adapters.pandas_adapter import PandasAdapter
+from sktime_mcp.runtime.executor import Executor
+
+
+def test_to_sktime_format_rejects_missing_explicit_target_column():
+    """An explicit target_column typo should fail instead of silently using column 0."""
+    adapter = PandasAdapter(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+            },
+            "time_column": "date",
+            "target_column": "sales",
+        }
+    )
+    data = adapter.load()
+
+    with pytest.raises(ValueError, match="Target column 'sales' not found"):
+        adapter.to_sktime_format(data)
+
+
+def test_load_data_source_returns_error_for_missing_explicit_target_column():
+    """Executor should surface the missing target column as a structured tool error."""
+    executor = Executor()
+
+    result = executor.load_data_source(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+            },
+            "time_column": "date",
+            "target_column": "sales",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "Target column 'sales' not found" in result["error"]
+    assert "value" in result["error"]
+


### PR DESCRIPTION
## Summary

This PR fixes a silent data-contract issue in data source conversion.

Previously, if a user explicitly passed `target_column="sales"` but the loaded data did not contain a `sales` column, `to_sktime_format` silently fell back to the first available column. This could cause agents or users to forecast the wrong target without a clear error.

Now, explicit `target_column` values are validated before fallback logic is used. If the requested target column is missing, the adapter raises a clear `ValueError` listing the available columns. At the executor level, this is surfaced as a structured `success=False` response.

## Why this matters

For MCP/LLM workflows, explicit column mappings should be treated as contracts. Silently ignoring a requested target column can lead to wrong forecasts that look successful.

## Changes

- Validate explicit `target_column` in `DataSourceAdapter.to_sktime_format`
- Return a clear error when the requested target column is missing
- Add regression tests for:
  - direct adapter conversion
  - `Executor.load_data_source` structured error handling

## Validation

Manual checks passed:
- missing explicit target raises `ValueError`
- executor returns `success=False` with `error_type="ValueError"`
- valid explicit target still converts correctly
- `compileall` passes for changed files