### PR TITLE
fix: raise error for missing explicit exogenous columns

### DIFF
--- a/src/sktime_mcp/data/base.py
+++ b/src/sktime_mcp/data/base.py
@@ -79,8 +79,15 @@ class DataSourceAdapter(ABC):
 
             # Get exogenous variables if specified
             if exog_cols:
-                valid_exog_cols = [col for col in exog_cols if col in data.columns]
-                X = data[valid_exog_cols] if valid_exog_cols else None
+                missing_exog_cols = [col for col in exog_cols if col not in data.columns]
+                if missing_exog_cols:
+                    available_columns = ", ".join(repr(col) for col in data.columns)
+                    raise ValueError(
+                        f"Exogenous column(s) not found in data: {missing_exog_cols!r}. "
+                        f"Available columns: [{available_columns}]"
+                    )
+
+                X = data[exog_cols]
             else:
                 # Use all columns except target as exogenous
                 other_cols = [col for col in data.columns if col != target_col]

--- a/tests/test_data_exog_column_validation.py
+++ b/tests/test_data_exog_column_validation.py
@@ -1,0 +1,82 @@
+"""Tests for explicit exogenous column validation in data adapters."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from sktime_mcp.data.adapters.pandas_adapter import PandasAdapter
+from sktime_mcp.runtime.executor import Executor
+
+
+def test_to_sktime_format_rejects_missing_explicit_exog_column():
+    """Explicit exog_columns should fail if any requested column is absent."""
+    adapter = PandasAdapter(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+                "promo": [0, 1, 0],
+            },
+            "time_column": "date",
+            "target_column": "value",
+            "exog_columns": ["promo", "holiday"],
+        }
+    )
+    data = adapter.load()
+
+    with pytest.raises(ValueError, match="Exogenous column\\(s\\) not found"):
+        adapter.to_sktime_format(data)
+
+
+def test_load_data_source_returns_error_for_missing_explicit_exog_column():
+    """Executor should surface missing exog columns as a structured tool error."""
+    executor = Executor()
+
+    result = executor.load_data_source(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+                "promo": [0, 1, 0],
+            },
+            "time_column": "date",
+            "target_column": "value",
+            "exog_columns": ["promo", "holiday"],
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "Exogenous column(s) not found" in result["error"]
+    assert "holiday" in result["error"]
+    assert "promo" in result["error"]
+
+
+def test_to_sktime_format_keeps_all_valid_explicit_exog_columns():
+    """Valid exog_columns should be preserved exactly when all columns exist."""
+    adapter = PandasAdapter(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+                "promo": [0, 1, 0],
+                "price": [10, 11, 12],
+            },
+            "time_column": "date",
+            "target_column": "value",
+            "exog_columns": ["promo", "price"],
+        }
+    )
+    data = adapter.load()
+
+    y, X = adapter.to_sktime_format(data)
+
+    assert y.name == "value"
+    assert list(X.columns) == ["promo", "price"]
+


### PR DESCRIPTION
## Reference Issues/PRs
N/A

## What does this implement/fix? Explain your changes.
This PR fixes silent dropping of explicitly requested exogenous columns during data conversion.

Previously, if a config specified `exog_columns=["promo", "holiday"]` but only `promo` existed in the loaded data, `to_sktime_format` would silently use the available column and ignore the missing one. This could mislead users or LLM agents into thinking all requested covariates were used.

This PR updates `DataSourceAdapter.to_sktime_format` to validate explicit `exog_columns` before constructing `X`. If any requested exogenous column is missing, it raises a clear `ValueError` listing the missing columns and available columns. When all requested columns exist, their order is preserved exactly.

## Does your contribution introduce a new dependency? If yes, which one?
No.

## What should a reviewer concentrate their feedback on?
- Whether missing explicit `exog_columns` should fail fast rather than warn
- Clarity of the error message returned to users and agents
- Whether the validation belongs in `DataSourceAdapter.to_sktime_format`

## Any other comments?
This is a small data-contract safety fix for custom data workflows. It helps prevent agents from making forecasting decisions under the false assumption that missing exogenous variables were used.

Validation:
- `python -m compileall src/sktime_mcp/data/base.py tests/test_data_exog_column_validation.py`
- Manual check: missing `holiday` in `exog_columns` raises a clear `ValueError`
- Manual check: `Executor.load_data_source` returns `success=False` with `error_type="ValueError"`
- Manual check: valid explicit exogenous columns are preserved in order

## PR checklist
For all contributions
- [x] I've added myself to the list of contributors.
- [ ] Optionally, I've updated CODEOWNERS.
- [x] I've added unit tests and made sure they pass locally where possible.

For new estimators
- [x] Not applicable
