### PR TITLE
fix: propagate conversion warnings and implement strict exogenous validation

### DIFF
--- a/src/sktime_mcp/data/base.py
+++ b/src/sktime_mcp/data/base.py
@@ -79,8 +79,15 @@ class DataSourceAdapter(ABC):
 
             # Get exogenous variables if specified
             if exog_cols:
-                valid_exog_cols = [col for col in exog_cols if col in data.columns]
-                X = data[valid_exog_cols] if valid_exog_cols else None
+                missing_exog_cols = [col for col in exog_cols if col not in data.columns]
+                if missing_exog_cols:
+                    available_columns = ", ".join(repr(col) for col in data.columns)
+                    raise ValueError(
+                        f"Exogenous column(s) not found in data: {missing_exog_cols!r}. "
+                        f"Available columns: [{available_columns}]"
+                    )
+
+                X = data[exog_cols]
             else:
                 # Use all columns except target as exogenous
                 other_cols = [col for col in data.columns if col != target_col]

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -42,6 +42,28 @@ def _discover_demo_datasets() -> dict:
 DEMO_DATASETS = _discover_demo_datasets()
 
 
+def _merge_adapter_validation_warnings(
+    validation_report: dict[str, Any],
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge warnings added during adapter conversion into validation output."""
+    metadata_validation = metadata.get("validation")
+    if not isinstance(metadata_validation, dict):
+        return validation_report
+
+    metadata_warnings = metadata_validation.get("warnings", [])
+    if not metadata_warnings:
+        return validation_report
+
+    merged = validation_report.copy()
+    existing_warnings = list(merged.get("warnings", []))
+    for warning in metadata_warnings:
+        if warning not in existing_warnings:
+            existing_warnings.append(warning)
+    merged["warnings"] = existing_warnings
+    return merged
+
+
 class Executor:
     """
     Execution runtime for sktime estimators.
@@ -524,6 +546,7 @@ class Executor:
 
             # Update metadata to reflect the target and used columns
             metadata = adapter.get_metadata().copy()
+            validation_report = _merge_adapter_validation_warnings(validation_report, metadata)
             metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
             if X is not None:
                 metadata["exog_columns"] = list(X.columns)
@@ -647,6 +670,7 @@ class Executor:
             y, X = adapter.to_sktime_format(data)
 
             metadata = adapter.get_metadata().copy()
+            validation_report = _merge_adapter_validation_warnings(validation_report, metadata)
             metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
             if X is not None:
                 metadata["exog_columns"] = list(X.columns)

--- a/tests/test_data_exog_column_validation.py
+++ b/tests/test_data_exog_column_validation.py
@@ -1,0 +1,82 @@
+"""Tests for explicit exogenous column validation in data adapters."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from sktime_mcp.data.adapters.pandas_adapter import PandasAdapter
+from sktime_mcp.runtime.executor import Executor
+
+
+def test_to_sktime_format_rejects_missing_explicit_exog_column():
+    """Explicit exog_columns should fail if any requested column is absent."""
+    adapter = PandasAdapter(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+                "promo": [0, 1, 0],
+            },
+            "time_column": "date",
+            "target_column": "value",
+            "exog_columns": ["promo", "holiday"],
+        }
+    )
+    data = adapter.load()
+
+    with pytest.raises(ValueError, match="Exogenous column\\(s\\) not found"):
+        adapter.to_sktime_format(data)
+
+
+def test_load_data_source_returns_error_for_missing_explicit_exog_column():
+    """Executor should surface missing exog columns as a structured tool error."""
+    executor = Executor()
+
+    result = executor.load_data_source(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+                "promo": [0, 1, 0],
+            },
+            "time_column": "date",
+            "target_column": "value",
+            "exog_columns": ["promo", "holiday"],
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "Exogenous column(s) not found" in result["error"]
+    assert "holiday" in result["error"]
+    assert "promo" in result["error"]
+
+
+def test_to_sktime_format_keeps_all_valid_explicit_exog_columns():
+    """Valid exog_columns should be preserved exactly when all columns exist."""
+    adapter = PandasAdapter(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+                "promo": [0, 1, 0],
+                "price": [10, 11, 12],
+            },
+            "time_column": "date",
+            "target_column": "value",
+            "exog_columns": ["promo", "price"],
+        }
+    )
+    data = adapter.load()
+
+    y, X = adapter.to_sktime_format(data)
+
+    assert y.name == "value"
+    assert list(X.columns) == ["promo", "price"]
+

--- a/tests/test_data_validation_warnings.py
+++ b/tests/test_data_validation_warnings.py
@@ -1,0 +1,38 @@
+"""Tests for data validation warning propagation."""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from sktime_mcp.runtime.executor import Executor
+
+
+def _ambiguous_target_config():
+    return {
+        "type": "pandas",
+        "data": {
+            "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+            "value": [1, 2, 3],
+        },
+    }
+
+
+def test_load_data_source_propagates_default_target_warning():
+    """Default target warnings should appear in the top-level validation result."""
+    result = Executor().load_data_source(_ambiguous_target_config())
+
+    assert result["success"] is True
+    warnings = result["validation"]["warnings"]
+    assert any("Target column not specified" in warning for warning in warnings)
+
+
+def test_load_data_source_async_propagates_default_target_warning():
+    """Async load should expose the same default-target warning as sync load."""
+    result = asyncio.run(Executor().load_data_source_async(_ambiguous_target_config()))
+
+    assert result["success"] is True
+    warnings = result["validation"]["warnings"]
+    assert any("Target column not specified" in warning for warning in warnings)
+


### PR DESCRIPTION


#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.
This PR ensures that warnings generated during data conversion are surfaced in the top-level validation output.

Previously, if target_column was not provided, to_sktime_format would default to using the first column and store a warning inside the adapter metadata. However, this warning was not included in validation["warnings"], which is what downstream users (including agents) are expected to check.

With this change, any warnings generated during conversion are now propagated to the top-level validation report for both synchronous and asynchronous data loading. This makes the behavior more transparent and easier to debug.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether metadata-level conversion warnings should be merged into top-level validation
- Whether the helper location in `executor.py` is appropriate
- Test coverage for sync and async loading

#### Any other comments?
Added regression tests for sync and async `load_data_source` warning propagation.

Validation:
- `python -m compileall src/sktime_mcp/runtime/executor.py tests/test_data_validation_warnings.py`
- Manual sync and async checks confirm the default-target warning appears in `validation["warnings"]`

Note: local `pytest` exits with code `-1` before output in this environment, so I verified behavior directly.

#### PR checklist


##### For all contributions
- [ ] I've added myself to the list of contributors.
- [ ] Optionally, I've updated CODEOWNERS.
- [x] I've added unit tests and made sure they pass locally where possible.

For new estimators

- [x] Not applicable
