### PR TITLE
fix: propagate default target column warnings

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -32,6 +32,28 @@ DEMO_DATASETS = {
 }
 
 
+def _merge_adapter_validation_warnings(
+    validation_report: dict[str, Any],
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge warnings added during adapter conversion into validation output."""
+    metadata_validation = metadata.get("validation")
+    if not isinstance(metadata_validation, dict):
+        return validation_report
+
+    metadata_warnings = metadata_validation.get("warnings", [])
+    if not metadata_warnings:
+        return validation_report
+
+    merged = validation_report.copy()
+    existing_warnings = list(merged.get("warnings", []))
+    for warning in metadata_warnings:
+        if warning not in existing_warnings:
+            existing_warnings.append(warning)
+    merged["warnings"] = existing_warnings
+    return merged
+
+
 class Executor:
     """
     Execution runtime for sktime estimators.
@@ -497,6 +519,7 @@ class Executor:
 
             # Update metadata to reflect the target and used columns
             metadata = adapter.get_metadata().copy()
+            validation_report = _merge_adapter_validation_warnings(validation_report, metadata)
             metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
             if X is not None:
                 metadata["exog_columns"] = list(X.columns)
@@ -620,6 +643,7 @@ class Executor:
             y, X = adapter.to_sktime_format(data)
 
             metadata = adapter.get_metadata().copy()
+            validation_report = _merge_adapter_validation_warnings(validation_report, metadata)
             metadata["columns"] = [y.name if hasattr(y, "name") and y.name else "target"]
             if X is not None:
                 metadata["exog_columns"] = list(X.columns)

--- a/tests/test_data_validation_warnings.py
+++ b/tests/test_data_validation_warnings.py
@@ -1,0 +1,38 @@
+"""Tests for data validation warning propagation."""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from sktime_mcp.runtime.executor import Executor
+
+
+def _ambiguous_target_config():
+    return {
+        "type": "pandas",
+        "data": {
+            "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+            "value": [1, 2, 3],
+        },
+    }
+
+
+def test_load_data_source_propagates_default_target_warning():
+    """Default target warnings should appear in the top-level validation result."""
+    result = Executor().load_data_source(_ambiguous_target_config())
+
+    assert result["success"] is True
+    warnings = result["validation"]["warnings"]
+    assert any("Target column not specified" in warning for warning in warnings)
+
+
+def test_load_data_source_async_propagates_default_target_warning():
+    """Async load should expose the same default-target warning as sync load."""
+    result = asyncio.run(Executor().load_data_source_async(_ambiguous_target_config()))
+
+    assert result["success"] is True
+    warnings = result["validation"]["warnings"]
+    assert any("Target column not specified" in warning for warning in warnings)
+


### PR DESCRIPTION


#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.
This PR ensures that warnings generated during data conversion are surfaced in the top-level validation output.

Previously, if target_column was not provided, to_sktime_format would default to using the first column and store a warning inside the adapter metadata. However, this warning was not included in validation["warnings"], which is what downstream users (including agents) are expected to check.

With this change, any warnings generated during conversion are now propagated to the top-level validation report for both synchronous and asynchronous data loading. This makes the behavior more transparent and easier to debug.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Whether metadata-level conversion warnings should be merged into top-level validation
- Whether the helper location in `executor.py` is appropriate
- Test coverage for sync and async loading

#### Any other comments?
Added regression tests for sync and async `load_data_source` warning propagation.

Validation:
- `python -m compileall src/sktime_mcp/runtime/executor.py tests/test_data_validation_warnings.py`
- Manual sync and async checks confirm the default-target warning appears in `validation["warnings"]`

Note: local `pytest` exits with code `-1` before output in this environment, so I verified behavior directly.

#### PR checklist


##### For all contributions
- [ ] I've added myself to the list of contributors.
- [ ] Optionally, I've updated CODEOWNERS.
- [x] I've added unit tests and made sure they pass locally where possible.

For new estimators

- [x] Not applicable
