### PR TITLE
  FIX: start event loop thread when fit_predict_async called outside MCP server context

### DIFF
--- a/examples/background_training_example.py
+++ b/examples/background_training_example.py
@@ -51,7 +51,7 @@ def main():
     print("✅ Training started!")
     print(f"   Job ID: {job_id}")
     print(f"   Estimator: {job_result['estimator']}")
-    print(f"   Dataset: {job_result['data_source']}")
+    print(f"   Dataset: {job_result.get('data_source') or job_result.get('dataset', 'unknown')}")
     print(f"   Horizon: {job_result['horizon']}")
 
     # Step 3: Monitor progress

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -217,6 +217,14 @@ def fit_predict_async_tool(
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
+    # If the event loop is not running (e.g. when called from a plain script
+    # rather than from within the MCP server), start it in a background thread
+    # so that run_coroutine_threadsafe has a live loop to schedule work on.
+    if not loop.is_running():
+        import threading
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+
     coro = executor.fit_predict_async(
         estimator_handle,
         dataset=dataset,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/sktime/sktime-mcp/blob/main/docs/source/dev-guide.md
-->

#### Reference Issues/PRs
Fixes #446 


#### What does this implement/fix? Explain your changes.
- Fixed background async training job stuck at 0% progress when fit_predict_async_tool is called outside the MCP server context. The event loop exists but is not running, so scheduled coroutines never execute. Fix starts a background thread to run the event loop when it is not already running.

- Fixed KeyError: 'data_source' in background_training_example.py by supporting both 'data_source' and 'dataset' keys for compatibility between PyPI and source versions.

#### Does your contribution introduce a new dependency? If yes, which one?
No. Uses only Python's built-in threading and asyncio modules.


#### What should a reviewer concentrate their feedback on?

- The threading fix in fit_predict.py: whether starting a daemon thread is the correct approach when the event loop is not running
- Whether this fix is safe to use within the MCP server context as well

#### Any other comments?
This bug was discovered while running the example scripts directly with `python examples/background_training_example.py`. The root cause is that fit_predict_async_tool uses run_coroutine_threadsafe(), which requires a running event loop. When called outside the MCP server, the loop exists but is not running, so coroutines are scheduled but never executed.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added unit tests and made sure they pass locally (`make check`).
- [ ] I've added the tool to the online documentation in `docs/source/`.
- [ ] I've updated the existing example scripts or provided a new one to showcase how my tool works in `examples/`.


<!--
Thanks for contributing!
-->
