### PR TITLE
FIX: raise error for invalid explicit frequency in data adapters

### DIFF
--- a/src/sktime_mcp/data/adapters/file_adapter.py
+++ b/src/sktime_mcp/data/adapters/file_adapter.py
@@ -100,8 +100,10 @@ class FileAdapter(DataSourceAdapter):
         # Set frequency if specified
         freq = self.config.get("frequency")
         if freq:
-            with contextlib.suppress(Exception):
+            try:
                 df = df.asfreq(freq)
+            except Exception as e:
+                raise ValueError(f"Invalid frequency '{freq}': {e}") from e
 
         self._data = df
 

--- a/src/sktime_mcp/data/adapters/pandas_adapter.py
+++ b/src/sktime_mcp/data/adapters/pandas_adapter.py
@@ -5,7 +5,6 @@ Supports loading data from pandas DataFrames with automatic
 time index detection and validation.
 """
 
-import contextlib
 from typing import Any
 
 import pandas as pd
@@ -72,8 +71,10 @@ class PandasAdapter(DataSourceAdapter):
         # Infer or set frequency
         freq = self.config.get("frequency")
         if freq:
-            with contextlib.suppress(Exception):
+            try:
                 df = df.asfreq(freq)
+            except Exception as e:
+                raise ValueError(f"Invalid frequency '{freq}': {e}") from e
         elif isinstance(df.index, pd.DatetimeIndex) and df.index.freq is None:
             # Try to infer frequency
             inferred_freq = pd.infer_freq(df.index)

--- a/tests/test_data_frequency_validation.py
+++ b/tests/test_data_frequency_validation.py
@@ -1,0 +1,67 @@
+"""Tests for explicit frequency validation in data adapters."""
+
+from pathlib import Path
+
+import pytest
+
+from sktime_mcp.data.adapters.file_adapter import FileAdapter
+from sktime_mcp.data.adapters.pandas_adapter import PandasAdapter
+
+
+def test_pandas_adapter_rejects_invalid_explicit_frequency():
+    """Invalid user-provided frequency should fail instead of being ignored."""
+    adapter = PandasAdapter(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-02", "2020-01-03"],
+                "value": [1, 2, 3],
+            },
+            "time_column": "date",
+            "target_column": "value",
+            "frequency": "not_a_freq",
+        }
+    )
+
+    with pytest.raises(ValueError, match="Invalid frequency 'not_a_freq'"):
+        adapter.load()
+
+
+def test_file_adapter_rejects_invalid_explicit_frequency(tmp_path: Path):
+    """Invalid explicit frequency should fail for file-backed data too."""
+    path = tmp_path / "series.csv"
+    path.write_text("date,value\n2020-01-01,1\n2020-01-02,2\n2020-01-03,3\n")
+
+    adapter = FileAdapter(
+        {
+            "type": "file",
+            "path": str(path),
+            "time_column": "date",
+            "target_column": "value",
+            "frequency": "not_a_freq",
+        }
+    )
+
+    with pytest.raises(ValueError, match="Invalid frequency 'not_a_freq'"):
+        adapter.load()
+
+
+def test_pandas_adapter_applies_valid_explicit_frequency():
+    """Valid explicit frequency should still be applied normally."""
+    adapter = PandasAdapter(
+        {
+            "type": "pandas",
+            "data": {
+                "date": ["2020-01-01", "2020-01-03"],
+                "value": [1, 3],
+            },
+            "time_column": "date",
+            "target_column": "value",
+            "frequency": "D",
+        }
+    )
+
+    data = adapter.load()
+
+    assert len(data) == 3
+    assert data.index.freqstr == "D"


### PR DESCRIPTION
#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.
This PR fixes an issue where invalid explicit frequency values were being silently ignored in the data adapters.

Previously, if a user passed an invalid frequency like frequency="not_a_freq", the error raised by asfreq() was suppressed in both PandasAdapter and FileAdapter, and the data continued loading normally. This made it look like the requested frequency had been applied when it actually hadn’t.

With this change, both adapters now raise a clear ValueError when an invalid explicit frequency is provided. Valid frequency values continue to behave as expected.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Whether failing fast is the preferred behavior for invalid explicit frequency config.
Clarity of the error message.

#### Any other comments?
Validation:
- `python -m compileall src/sktime_mcp/data/adapters/pandas_adapter.py src/sktime_mcp/data/adapters/file_adapter.py tests/test_data_frequency_validation.py`
- Manual checks for invalid pandas/file frequencies and valid daily frequency passed.
