### PR TITLE
Fix csv example tmp path

### DIFF
--- a/examples/csv_example.py
+++ b/examples/csv_example.py
@@ -5,6 +5,7 @@ This example demonstrates how to use the sktime-mcp data loading
 functionality with CSV files.
 """
 
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -20,7 +21,7 @@ sample_data = pd.DataFrame(
     }
 )
 
-csv_path = Path("/tmp/sample_sales_data.csv")
+csv_path = Path(tempfile.gettempdir()) / "sample_sales_data.csv"
 sample_data.to_csv(csv_path, index=False)
 print(f"Created sample CSV file: {csv_path}")
 print(f"File size: {csv_path.stat().st_size} bytes")
@@ -90,7 +91,7 @@ print("\n" + "=" * 60)
 print("Loading data from TSV file")
 print("=" * 60)
 
-tsv_path = Path("/tmp/sample_sales_data.tsv")
+tsv_path = Path(tempfile.gettempdir()) / "sample_sales_data.tsv"
 sample_data.to_csv(tsv_path, sep="\t", index=False)
 print(f"Created sample TSV file: {tsv_path}")
 


### PR DESCRIPTION
Fixes #447 

`csv_example.py` used hardcoded `/tmp/` paths which don't exist on Windows, causing an `OSError`. Replaced with `tempfile.gettempdir()` which works cross-platform.