### PR TITLE
initial tests for docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Version control
+.git
+.github
+
+# Python caches
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+
+# Virtual environments
+.venv
+venv
+env
+
+# IDE / editor
+.vscode
+.idea
+*.swp
+*.swo
+
+# Build artifacts
+dist/
+*.egg-info
+build/
+
+# Documentation
+docs/_build/
+docs/build/
+
+# Project-specific ignores
+mcp_server.log
+.ignore/
+TODO.md
+.pre-commit-config.yaml
+.readthedocs.yaml
+
+# Docker (prevent recursive context)
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+# =============================================================================
+# Dockerfile for sktime-mcp
+#
+# Multi-stage build:
+#   1. Builder  – installs build tools and Python dependencies
+#   2. Runtime  – slim image with only the installed packages
+#
+# Usage:
+#   docker build -t sktime-mcp .
+#   docker run -i sktime-mcp                  # stdio transport (default)
+#   docker run -i -e SKTIME_MCP_LOG_LEVEL=DEBUG sktime-mcp
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: Builder
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim AS builder
+
+# Avoid interactive prompts during package install
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install minimal build dependencies required by some scientific packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        gfortran \
+        libopenblas-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy only dependency-related files first to maximise Docker layer caching
+COPY pyproject.toml README.md LICENSE ./
+COPY src/ src/
+
+# Install the project in production mode (no dev/test extras)
+RUN pip install --no-cache-dir --prefix=/install .
+
+# ---------------------------------------------------------------------------
+# Stage 2: Runtime
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim AS runtime
+
+# Runtime library needed by numpy/scipy linked against OpenBLAS
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libopenblas0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy installed Python packages from the builder stage
+COPY --from=builder /install /usr/local
+
+# Create a non-root user for security
+RUN useradd --create-home --shell /bin/bash mcp
+USER mcp
+WORKDIR /home/mcp
+
+# Environment defaults (overridable at runtime)
+ENV SKTIME_MCP_LOG_LEVEL=WARNING
+ENV PYTHONUNBUFFERED=1
+
+# Health-check: verify the package is importable
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python -c "import sktime_mcp; print('ok')" || exit 1
+
+# MCP servers communicate over stdio, so the entrypoint is the CLI command
+ENTRYPOINT ["sktime-mcp"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
-.PHONY: check test lint format help format-fix install-hooks
+.PHONY: check test lint format help format-fix install-hooks docker-build docker-run
 
 help:
 	@echo "Available commands:"
-	@echo "  make check      - Run all CI checks (format check, lint, test)"
-	@echo "  make lint       - Run ruff linter"
-	@echo "  make format     - Run ruff format checker (check only)"
-	@echo "  make test       - Run pytest"
-	@echo "  make format-fix - Auto-fix formatting and fixable lint issues"
+	@echo "  make check        - Run all CI checks (format check, lint, test)"
+	@echo "  make lint         - Run ruff linter"
+	@echo "  make format       - Run ruff format checker (check only)"
+	@echo "  make test         - Run pytest"
+	@echo "  make format-fix   - Auto-fix formatting and fixable lint issues"
+	@echo "  make docker-build - Build the Docker image"
+	@echo "  make docker-run   - Run the MCP server in Docker (stdio)"
 
 check: format lint test
 
@@ -26,3 +28,9 @@ format-fix:
 install-hooks:
 	pip install pre-commit
 	pre-commit install
+
+docker-build:
+	docker build -t sktime-mcp .
+
+docker-run: docker-build
+	docker run -i --rm sktime-mcp

--- a/README.md
+++ b/README.md
@@ -51,6 +51,47 @@ git clone https://github.com/sktime/sktime-mcp
 cd sktime-mcp
 python3 -m pip install -e ".[dev]"
 ```
+
+### 🐳 Docker
+
+Run without installing anything locally (only Docker required):
+
+```bash
+# Build the image
+docker build -t sktime-mcp .
+
+# Run the MCP server (stdio transport)
+docker run -i sktime-mcp
+```
+
+Or use Docker Compose:
+
+```bash
+docker compose build
+docker compose run sktime-mcp
+```
+
+**Claude Desktop** — use Docker as the MCP server command:
+
+```json
+{
+  "mcpServers": {
+    "sktime": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "sktime-mcp"]
+    }
+  }
+}
+```
+
+Environment variables can be passed at runtime:
+
+```bash
+docker run -i -e SKTIME_MCP_LOG_LEVEL=DEBUG sktime-mcp
+```
+
+For a more detailed first-time setup flow, including MCP server verification and troubleshooting, see [Beginner Setup](#-beginner-setup-firsttime-users).
+
 ## 🧭 Beginner Setup (First‑Time Users)
 
 If you are new to sktime‑mcp or to MCP‑based workflows, this section provides a minimal starting point to help you verify that your setup is working correctly.
@@ -1062,7 +1103,10 @@ sktime-mcp/
 │   └── tools/              # MCP tool implementations
 ├── docs/                   # Sphinx documentation source
 ├── examples/               # Usage examples
-└── tests/                  # Test suite
+├── tests/                  # Test suite
+├── Dockerfile              # Multi-stage container build
+├── docker-compose.yml      # Compose service definition
+└── .dockerignore           # Docker build context filter
 ```
 
 ## 🧪 Running Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     image: sktime-mcp:latest
     container_name: sktime-mcp
 
-    # stdin_open + tty are required for stdio-based MCP transport
+    # Keep stdin open, but avoid allocating a pseudo-TTY so MCP gets raw JSON-RPC over stdio.
     stdin_open: true
     tty: false  # MCP JSON-RPC needs raw stdin, not a pseudo-TTY
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 #   docker compose run sktime-mcp # run with stdio (interactive, for MCP clients)
 #
 # Notes:
-#   - MCP uses stdio transport, so `docker compose run` (with TTY) is the
+#   - MCP uses stdio transport, so `docker compose run` with stdin attached is the
 #     correct invocation rather than `docker compose up` (which is for daemons).
 #   - The models volume persists saved models across container restarts.
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Docker Compose for sktime-mcp
+#
+# Usage:
+#   docker compose build          # build the image
+#   docker compose run sktime-mcp # run with stdio (interactive, for MCP clients)
+#
+# Notes:
+#   - MCP uses stdio transport, so `docker compose run` (with TTY) is the
+#     correct invocation rather than `docker compose up` (which is for daemons).
+#   - The models volume persists saved models across container restarts.
+# =============================================================================
+
+services:
+  sktime-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: sktime-mcp:latest
+    container_name: sktime-mcp
+
+    # stdin_open + tty are required for stdio-based MCP transport
+    stdin_open: true
+    tty: false  # MCP JSON-RPC needs raw stdin, not a pseudo-TTY
+
+    environment:
+      - SKTIME_MCP_LOG_LEVEL=${SKTIME_MCP_LOG_LEVEL:-WARNING}
+      - SKTIME_MCP_AUTO_FORMAT=${SKTIME_MCP_AUTO_FORMAT:-true}
+      - SKTIME_MCP_JOB_MAX_AGE_HOURS=${SKTIME_MCP_JOB_MAX_AGE_HOURS:-24}
+      - SKTIME_MCP_JOB_CLEANUP_INTERVAL=${SKTIME_MCP_JOB_CLEANUP_INTERVAL:-3600}
+
+    volumes:
+      # Persist saved models outside the container
+      - sktime-models:/home/mcp/models
+
+volumes:
+  sktime-models:
+    driver: local


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #444 <!-- add issue number if applicable -->. Adds Docker containerization support for sktime-mcp.

#### What does this implement/fix? Explain your changes.

Adds end-to-end Docker support for running sktime-mcp without any local Python setup. This includes:

**New files:**
- **`Dockerfile`** - Multi-stage build (builder → slim runtime). The builder stage installs build tools (`build-essential`, `gfortran`, `libopenblas-dev`) and all Python dependencies, then only the installed packages are copied into a minimal `python:3.12-slim` runtime image. Runs as a non-root `mcp` user for security.
- **`.dockerignore`** - Filters out `.git`, `__pycache__`, `.venv`, `docs/_build`, and other dev artifacts to keep the build context small (~456KB).
- **`docker-compose.yml`** - Service definition with configurable environment variables (`SKTIME_MCP_LOG_LEVEL`, `SKTIME_MCP_AUTO_FORMAT`, etc.) and a named `sktime-models` volume for persisting saved models across container restarts.

**Modified files:**
- **`README.md`** - Added a 🐳 Docker section under Installation with build/run/compose commands and a Claude Desktop JSON config example for Docker-based MCP. Updated the project structure tree to include the new files.
- **`Makefile`** - Added `make docker-build` and `make docker-run` convenience targets.

#### Does your contribution introduce a new dependency? If yes, which one?

No new Python dependencies. Docker is the only external requirement, and it is optional - existing pip-based installation is unaffected.

#### What should a reviewer concentrate their feedback on?

- The multi-stage Dockerfile approach - builder installs `build-essential`/`gfortran`/`libopenblas-dev` for compiling numpy/scipy, but only `libopenblas0` is carried into the runtime image. Is this the right trade-off vs. a single-stage build?
- The `docker-compose.yml` uses `stdin_open: true` with `tty: false` - this is intentional since MCP JSON-RPC needs raw stdin, not a pseudo-TTY. Worth confirming this works across Docker versions.
- Claude Desktop config in README uses `"command": "docker"` with `"args": ["run", "-i", "--rm", "sktime-mcp"]` - reviewers familiar with MCP client setups should verify this pattern.

#### Any other comments?

Verified end-to-end locally:
- ✅ `docker build` completes successfully (~81s)
- ✅ All package imports work inside the container (`sktime-mcp v0.1.0`, `sktime`, `mcp`)
- ✅ MCP `initialize` JSON-RPC handshake succeeds
- ✅ `tools/list` returns all 22 registered tools

#### PR checklist

##### For all contributions
- [ ] I've added unit tests and made sure they pass locally (`make check`).
- [ ] I've added the tool to the online documentation in `docs/source/`.
- [ ] I've updated the existing example scripts or provided a new one to showcase how my tool works in `examples/`.