### PR TITLE
fix: detect forecaster-chain as invalid in sequential pipeline validation

### DIFF
--- a/src/sktime_mcp/composition/validator.py
+++ b/src/sktime_mcp/composition/validator.py
@@ -259,6 +259,17 @@ class CompositionValidator:
         errors = []
         warnings = []
 
+        # Forecasters cannot be chained sequentially regardless of composition rules
+        if first.task == "forecasting" and second.task == "forecasting":
+            errors.append(
+                f"Cannot chain forecasters '{first.name}' → '{second.name}' directly. "
+                "Use an ensemble or multiplexer instead."
+            )
+            tag_errors, tag_warnings = self._check_tag_compatibility(first, second)
+            errors.extend(tag_errors)
+            warnings.extend(tag_warnings)
+            return False, errors, warnings
+
         # Find applicable rule
         applicable_rule = None
         for rule in self.COMPOSITION_RULES:
@@ -266,18 +277,14 @@ class CompositionValidator:
                 rule.source_task == first.task
                 and rule.target_task == second.task
                 and rule.position in ("before", "any")
+                and rule.composition_type != CompositionType.ENSEMBLE
             ):
                 applicable_rule = rule
                 break
 
         if applicable_rule is None:
             # No rule found - check if it's an obvious error
-            if first.task == second.task == "forecasting":
-                errors.append(
-                    f"Cannot chain forecasters '{first.name}' → '{second.name}' directly. "
-                    "Use an ensemble or multiplexer instead."
-                )
-            elif first.task in ("classification", "regression") and second.task != first.task:
+            if first.task in ("classification", "regression") and second.task != first.task:
                 errors.append(
                     f"Invalid composition: {first.task} '{first.name}' → {second.task} '{second.name}'"
                 )


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #445.

#### What does this implement/fix? Explain your changes.

**Root cause:** `COMPOSITION_RULES` contains an ENSEMBLE rule (`forecasting → forecasting`, `position="any"`) which matched the `NaiveForecaster → ExponentialSmoothing` pair during sequential pipeline validation. Because an applicable rule was found, the explicit forecaster-chain error check in `_check_pair_compatibility` was never reached, causing the validator to return `valid=True`.

**Fix in `src/sktime_mcp/composition/validator.py`:**

1. Added an early-return guard in `_check_pair_compatibility` for `forecasting → forecasting` pairs before the rule lookup. Two forecasters in a sequential pipeline are always invalid — ENSEMBLE composition is parallel, not sequential.

2. Added `and rule.composition_type != CompositionType.ENSEMBLE` to the rule-matching condition to make it explicit that ENSEMBLE-type rules should not be used to approve sequential pipeline pairs.

**Result:** `validate_pipeline(["NaiveForecaster", "ExponentialSmoothing"])` now correctly returns `valid=False` with the error:
> Cannot chain forecasters 'NaiveForecaster' → 'ExponentialSmoothing' directly. Use an ensemble or multiplexer instead.

This matches the `❌` icon and `# Invalid pipeline: Forecaster -> Forecaster` comment in `examples/01_forecasting_workflow.py` Step 5.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The early-return guard in `_check_pair_compatibility` (lines 262–271) — confirm that sequential forecaster chaining should always be invalid with no exceptions.
- The `CompositionType.ENSEMBLE` filter in the rule lookup — confirm that ENSEMBLE rules should never apply in a sequential pipeline context.

#### Any other comments?

No new dependencies. No API changes. The fix is purely internal to `_check_pair_compatibility`.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] I've added unit tests and made sure they pass locally.