### PR TITLE
Use training dataset for export_code fit example

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -277,6 +277,16 @@ class Executor:
         if not fit_result["success"]:
             return fit_result
 
+        # Record the training data source on the handle for later use (e.g. export_code defaults).
+        try:
+            handle_info = self._handle_manager.get_info(handle_id)
+            if dataset:
+                handle_info.metadata["training_dataset"] = dataset
+            elif data_handle:
+                handle_info.metadata["training_data_handle"] = data_handle
+        except Exception as e:  # pragma: no cover
+            logger.debug("Could not record training source metadata: %s", e)
+
         return self.predict(handle_id, fh=fh, X=X)
 
     async def fit_predict_async(
@@ -401,6 +411,16 @@ class Executor:
                     errors=[f"Fit failed: {fit_result.get('error')}"],
                 )
                 return fit_result
+
+            # Record the training data source on the handle for later use (e.g. export_code defaults).
+            try:
+                handle_info = self._handle_manager.get_info(handle_id)
+                if dataset:
+                    handle_info.metadata["training_dataset"] = dataset
+                elif data_handle:
+                    handle_info.metadata["training_data_handle"] = data_handle
+            except Exception as e:  # pragma: no cover
+                logger.debug("Could not record training source metadata: %s", e)
 
             # Step 3: Generate predictions
             self._job_manager.update_job(

--- a/src/sktime_mcp/tools/codegen.py
+++ b/src/sktime_mcp/tools/codegen.py
@@ -302,10 +302,12 @@ def export_code_tool(
 
     # Optionally add fit/predict example
     if include_fit_example:
+        effective_dataset = dataset or handle_info.metadata.get("training_dataset")
+
         # Resolve the dataset loader from demo datasets
         _demo_datasets = _get_demo_datasets()
-        if dataset and dataset in _demo_datasets:
-            module_path = _demo_datasets[dataset]
+        if effective_dataset and effective_dataset in _demo_datasets:
+            module_path = _demo_datasets[effective_dataset]
             module_parts = module_path.rsplit(".", 1)
             loader_module = module_parts[0]
             loader_func = module_parts[1]

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -253,6 +253,22 @@ class TestExportCodeTool:
         finally:
             self._cleanup_handle(handle)
 
+    def test_include_fit_example_uses_training_dataset_by_default(self):
+        """When handle metadata has training_dataset, use it as default for fit example."""
+        handle = self._create_handle()
+        try:
+            from sktime_mcp.runtime.handles import get_handle_manager
+
+            handle_info = get_handle_manager().get_info(handle)
+            handle_info.metadata["training_dataset"] = "sunspots"
+
+            result = export_code_tool(handle, include_fit_example=True)
+            assert result["success"]
+            assert "load_sunspots" in result["code"]
+            assert "load_airline" not in result["code"]
+        finally:
+            self._cleanup_handle(handle)
+
     def test_include_fit_example_false(self):
         """With include_fit_example=False, code should NOT contain fit example."""
         handle = self._create_handle()


### PR DESCRIPTION
Fixes #281.

- Record the demo dataset used in `fit_predict` / `fit_predict_async` on the handle metadata as `training_dataset`.
- When `export_code(..., include_fit_example=True)` is called with no explicit `dataset`, default to `training_dataset` before falling back to `airline`.
- Add a focused unit test for the new default behavior.

Notes: I could not run the test suite locally in this environment because only Python 3.9 is available here and the project uses Python 3.10+ type syntax; the changes are small and covered by an updated unit test in CI.