### PR TITLE
Feature/merge validate pipeline

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -33,7 +33,6 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
-from sktime_mcp.composition.validator import get_composition_validator
 from sktime_mcp.config import settings
 from sktime_mcp.tools.classify import (
     fit_predict_classification_tool,
@@ -327,21 +326,6 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["handle"],
-            },
-        ),
-        Tool(
-            name="validate_pipeline",
-            description="Check if a pipeline composition is valid",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "components": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "List of estimator names in pipeline order",
-                    },
-                },
-                "required": ["components"],
             },
         ),
         # -- Execution -------------------------------------------------------
@@ -812,12 +796,6 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 arguments["dataset"],
                 arguments.get("cv_folds", 3),
             )
-
-        elif name == "validate_pipeline":
-            validator = get_composition_validator()
-            validation = validator.validate_pipeline(arguments["components"])
-            result = validation.to_dict()
-            result["success"] = result["valid"]
 
         # -- Data ------------------------------------------------------------
         elif name == "list_available_data":

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -111,6 +111,14 @@ class TestPipelineParamsValidation:
         assert result["success"] is False
         assert "Unsupported type" in result["error"]
 
+    def test_pipeline_composition_check(self):
+        """Invalid pipeline composition (e.g. chaining forecasters) should fail validation."""
+        result = instantiate_pipeline_tool(["NaiveForecaster", "ExponentialSmoothing"])
+        assert result["success"] is False
+        assert "Invalid pipeline composition" in result["error"]
+        assert "validation_errors" in result
+        assert len(result["validation_errors"]) > 0
+
 
 class TestFitPredictValidation:
     """Tests for parameter validation in fit_predict tools."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime-mcp/blob/main/docs/source/dev-guide.md
-->

#### Reference Issues/PRs

**Independence:** This PR is rebased on latest `main` and does **not** depend on any other open PR. It can be merged on its own.

> **Note:** If #472 merges first, the standalone `instantiate_pipeline` MCP tool will already be removed. This PR still removes the `validate_pipeline` tool and ensures composition validation runs during pipeline instantiation.

#### What does this implement/fix? Explain your changes.

Removes the standalone `validate_pipeline` MCP tool. Pipeline composition validation already runs inside `executor.instantiate_pipeline`, so calling `instantiate_pipeline` (or `instantiate_estimator` with `components` after #472) automatically validates before registering a handle.

**Changes:**
- Removed `validate_pipeline` tool schema and routing from `server.py`
- Added `test_pipeline_composition_check` in `tests/test_param_validation.py` — invalid compositions (e.g. chaining forecasters) return `success: False` with validation diagnostics

**Files changed (2):**
- `src/sktime_mcp/server.py`
- `tests/test_param_validation.py`

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Confirm `validate_pipeline` is no longer registered as an MCP tool
- Verify invalid pipeline instantiation fails with `validation_errors` in the response

#### Any other comments

Rebased on latest `main` (1 commit, +8 / −22). **182 tests** pass under `make check`.

#### PR checklist

##### For all contributions
- [x] I've added unit tests and made sure they pass locally (`make check`).
