### PR TITLE
fix: repair failing tests on main after recent merges

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+sphinx>=7.0.0
+sphinx-rtd-theme>=2.0.0
+myst-parser>=2.0.0
+sphinx-autodoc-typehints>=1.24.0
+sktime>=0.24.0
+mcp>=1.0.0
+pandas>=1.5.0
+numpy>=1.21.0
+scikit-learn>=1.0.0
+statsmodels>=0.13.0
+pmdarima>=2.0.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -279,6 +279,7 @@ class TestTools:
 
         handle_manager = get_handle_manager()
         handle = handle_manager.create_handle("DummyEstimator", object())
+        handle_manager.mark_fitted(handle)
 
         try:
             result = save_model_tool(

--- a/tests/test_export_code_dataset_tracking.py
+++ b/tests/test_export_code_dataset_tracking.py
@@ -18,13 +18,13 @@ class TestExportCodeDatasetTracking:
         assert inst["success"], inst
         handle = inst["handle"]
 
-        result = fit_predict_tool(handle, "sunspots", horizon=3)
+        result = fit_predict_tool(handle, "lynx", horizon=3)
         assert result["success"], result
 
         hm = get_handle_manager()
         info = hm.get_info(handle)
-        assert info.metadata.get("training_dataset") == "sunspots", (
-            f"Expected 'sunspots' in handle metadata, got: {info.metadata}"
+        assert info.metadata.get("training_dataset") == "lynx", (
+            f"Expected 'lynx' in handle metadata, got: {info.metadata}"
         )
 
     def test_export_code_uses_training_dataset_by_default(self):
@@ -37,14 +37,14 @@ class TestExportCodeDatasetTracking:
         assert inst["success"], inst
         handle = inst["handle"]
 
-        fit_result = fit_predict_tool(handle, "sunspots", horizon=3)
+        fit_result = fit_predict_tool(handle, "lynx", horizon=3)
         assert fit_result["success"], fit_result
 
         code_result = export_code_tool(handle, include_fit_example=True)
         assert code_result["success"], code_result
 
         code = code_result["code"]
-        assert "sunspots" in code, f"Expected 'sunspots' to appear in exported code, got:\n{code}"
+        assert "lynx" in code, f"Expected 'lynx' to appear in exported code, got:\n{code}"
 
     def test_export_code_explicit_dataset_overrides_metadata(self):
         """An explicit dataset argument to export_code must take priority over metadata."""
@@ -56,10 +56,10 @@ class TestExportCodeDatasetTracking:
         assert inst["success"], inst
         handle = inst["handle"]
 
-        fit_result = fit_predict_tool(handle, "sunspots", horizon=3)
+        fit_result = fit_predict_tool(handle, "lynx", horizon=3)
         assert fit_result["success"], fit_result
 
-        # Explicitly request airline even though model was trained on sunspots
+        # Explicitly request airline even though model was trained on lynx
         code_result = export_code_tool(handle, include_fit_example=True, dataset="airline")
         assert code_result["success"], code_result
 


### PR DESCRIPTION
Mark save_model test handles as fitted to satisfy the fitted-check guard, and use lynx instead of sunspots which is no longer in sktime demo datasets.