### PR TITLE
fix: Inject standard libraries into craft globals to support callable parameters

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -121,8 +121,31 @@ class Executor:
     ) -> dict[str, Any]:
         """Instantiate an estimator or pipeline from a spec and return a handle."""
         from sktime.registry import craft
+        import sktime.registry._craft as _craft_module
+        import numpy as np
+        import pandas as pd
+        
+        # Temporarily patch all_estimators to inject standard libraries into craft's registry.
+        # This allows users to pass callables like `numpy.exp` into estimators
+        # like CurveFitForecaster via the craft spec.
+        original_all = _craft_module.all_estimators
+        def mock_all_estimators(*args, **kwargs):
+            results = original_all(*args, **kwargs)
+            # results is a list of tuples: [(name, class), ...]
+            # We append numpy and pandas so they enter the register dict!
+            results.append(("np", np))
+            results.append(("numpy", np))
+            results.append(("pd", pd))
+            results.append(("pandas", pd))
+            return results
+            
+        _craft_module.all_estimators = mock_all_estimators
         try:
-            instance = craft(spec)
+            try:
+                instance = craft(spec)
+            finally:
+                _craft_module.all_estimators = original_all
+                
             estimator_name = type(instance).__name__
             handle_id = self._handle_manager.create_handle(
                 estimator_name=estimator_name,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime-mcp/blob/main/docs/source/dev-guide.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #449   regarding callable parameters in the MCP JSON interface.

#### What does this implement/fix? Explain your changes.
This PR unlocks the ability for the `mcp_sktime_instantiate_estimator` tool to process raw mathematical callables in the `craft` spec string (e.g., `CurveFitForecaster(function=numpy.exp)`). 

Previously, this would throw a `NameError` because standard libraries were not available in `craft`'s evaluation scope. This introduces a monkey-patch into `executor.instantiate()` that dynamically injects `numpy` (as `np` and `numpy`) and `pandas` (as `pd` and `pandas`) into the `sktime.registry._craft.all_estimators` evaluation namespace before attempting to construct the object.

#### Does your contribution introduce a new dependency? If yes, which one?
No. `numpy` and `pandas` are already core dependencies of `sktime`.

#### What should a reviewer concentrate their feedback on?
- Verification of the monkey-patch hook on `_craft_module.all_estimators` to ensure it cleanly wraps and unwraps without lingering state effects across concurrent server requests.

#### Did you add any tests for the change?
Verified natively using live agentic end-to-end tests across `CurveFitForecaster`.

#### PR checklist
- [x] I have read the [contribution guide](https://github.com/sktime/sktime-mcp/blob/main/docs/source/dev-guide.md).
- [x] I have added documentation for my changes (where applicable).
- [x] I have successfully run tests locally to verify my changes.
