### PR TITLE
feat: Add plotting data visualizations to sktime-mcp

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -69,6 +69,7 @@ from sktime_mcp.tools.save_data import save_data_tool
 from sktime_mcp.tools.save_model import save_model_tool
 from sktime_mcp.tools.split_data import split_data_tool
 from sktime_mcp.tools.transform_data import transform_data_tool
+from sktime_mcp.tools.plotting import plot_series_tool
 
 
 # ---------------------------------------------------------------------------
@@ -715,6 +716,38 @@ async def list_tools() -> list[Tool]:
                 "required": ["data_handle", "path"],
             },
         ),
+        # -- Visualization ---------------------------------------------------
+        Tool(
+            name="plot_series",
+            description=(
+                "Plot one or more time series natively. "
+                "Can save the plot to a specified path as a PNG file or return it as a base64 string."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "data_handles": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of data handle IDs to plot (e.g., train, test, forecasts).",
+                    },
+                    "labels": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional list of labels corresponding to each data handle.",
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Optional title for the plot.",
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Optional local file path to save the plot (e.g., '/tmp/plot.png'). If omitted, returns base64.",
+                    }
+                },
+                "required": ["data_handles"],
+            },
+        ),
         # -- Export / Persistence --------------------------------------------
         Tool(
             name="export_code",
@@ -984,6 +1017,15 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             from sktime_mcp.tools.format_tools import auto_format_on_load_tool
 
             result = auto_format_on_load_tool(arguments.get("enabled", True))
+
+        # -- Visualization ---------------------------------------------------
+        elif name == "plot_series":
+            result = plot_series_tool(
+                data_handles=arguments["data_handles"],
+                labels=arguments.get("labels"),
+                title=arguments.get("title"),
+                path=arguments.get("path"),
+            )
 
         # -- Export / Persistence --------------------------------------------
         elif name == "export_code":

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -743,7 +743,34 @@ async def list_tools() -> list[Tool]:
                     "path": {
                         "type": "string",
                         "description": "Optional local file path to save the plot (e.g., '/tmp/plot.png'). If omitted, returns base64.",
-                    }
+                    },
+                    "figsize": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "Figure size as [width, height] in inches (default: [12, 6]).",
+                    },
+                    "dpi": {
+                        "type": "integer",
+                        "description": "Resolution in dots per inch (default: 150).",
+                        "default": 150,
+                    },
+                    "markers": {
+                        "description": "Marker style(s) for data points (e.g., 'o', ['.', 'x']).",
+                    },
+                    "x_label": {
+                        "type": "string",
+                        "description": "Custom x-axis label.",
+                    },
+                    "y_label": {
+                        "type": "string",
+                        "description": "Custom y-axis label.",
+                    },
+                    "image_format": {
+                        "type": "string",
+                        "description": "Image output format: 'png' (default), 'svg', or 'webp'.",
+                        "enum": ["png", "svg", "webp"],
+                        "default": "png",
+                    },
                 },
                 "required": ["data_handles"],
             },
@@ -1025,6 +1052,12 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 labels=arguments.get("labels"),
                 title=arguments.get("title"),
                 path=arguments.get("path"),
+                figsize=arguments.get("figsize"),
+                dpi=arguments.get("dpi"),
+                markers=arguments.get("markers"),
+                x_label=arguments.get("x_label"),
+                y_label=arguments.get("y_label"),
+                image_format=arguments.get("image_format", "png"),
             )
 
         # -- Export / Persistence --------------------------------------------

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -29,6 +29,7 @@ from sktime_mcp.tools.job_tools import (
     list_jobs_tool,
 )
 from sktime_mcp.tools.list_available_data import list_available_data_tool
+from sktime_mcp.tools.plotting import plot_series_tool
 from sktime_mcp.tools.query_registry import (
     query_registry_tool,
 )
@@ -62,4 +63,5 @@ __all__ = [
     "check_job_status_tool",
     "list_jobs_tool",
     "cancel_job_tool",
+    "plot_series_tool",
 ]

--- a/src/sktime_mcp/tools/plotting.py
+++ b/src/sktime_mcp/tools/plotting.py
@@ -8,13 +8,9 @@ returning the result as a saved file or a base64-encoded image string.
 import base64
 import io
 import logging
-from typing import Any, List, Optional, Sequence, Tuple, Union
+from typing import Any
 
-import matplotlib
 import pandas as pd
-
-matplotlib.use("Agg")  # headless-safe backend, must be called before pyplot
-import matplotlib.pyplot as plt  # noqa: E402
 
 from sktime_mcp.runtime.executor import get_executor
 
@@ -39,7 +35,7 @@ def _resolve_series(
     return executor._data_handles[handle]["y"]
 
 
-def _coerce_indices(series_list: List) -> List:
+def _coerce_indices(series_list: list) -> list:
     """Coerce mixed PeriodIndex / DatetimeIndex / string Index to DatetimeIndex.
 
     Modifies the series **in-place** and returns the same list.
@@ -71,9 +67,9 @@ def _coerce_indices(series_list: List) -> List:
 
 
 def _reconcile_labels(
-    labels: Optional[List[str]],
+    labels: list[str] | None,
     n_series: int,
-) -> Optional[List[str]]:
+) -> list[str] | None:
     """Return a label list that exactly matches *n_series*.
 
     - If *labels* is ``None``, returns ``None`` (sktime will auto-label).
@@ -91,22 +87,20 @@ def _reconcile_labels(
         n_series,
     )
     if len(labels) < n_series:
-        return labels + [
-            f"Series {i}" for i in range(len(labels), n_series)
-        ]
+        return labels + [f"Series {i}" for i in range(len(labels), n_series)]
     return labels[:n_series]
 
 
 def plot_series_tool(
-    data_handles: List[str],
-    labels: Optional[List[str]] = None,
-    title: Optional[str] = None,
-    path: Optional[str] = None,
-    figsize: Optional[List[float]] = None,
-    dpi: Optional[int] = None,
-    markers: Optional[Union[str, List[str]]] = None,
-    x_label: Optional[str] = None,
-    y_label: Optional[str] = None,
+    data_handles: list[str],
+    labels: list[str] | None = None,
+    title: str | None = None,
+    path: str | None = None,
+    figsize: list[float] | None = None,
+    dpi: int | None = None,
+    markers: str | list[str] | None = None,
+    x_label: str | None = None,
+    y_label: str | None = None,
     image_format: str = "png",
 ) -> dict[str, Any]:
     """Plot one or more time series natively.
@@ -155,6 +149,10 @@ def plot_series_tool(
         }
 
     try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
         from sktime.utils.plotting import plot_series
     except ImportError:
         return {
@@ -215,9 +213,7 @@ def plot_series_tool(
         result: dict[str, Any] = {
             "success": True,
             "n_series": len(series_to_plot),
-            "labels_used": labels or [
-                f"Series {i}" for i in range(len(series_to_plot))
-            ],
+            "labels_used": labels or [f"Series {i}" for i in range(len(series_to_plot))],
             "figsize": list(effective_figsize),
             "dpi": effective_dpi,
             "image_format": fmt,

--- a/src/sktime_mcp/tools/plotting.py
+++ b/src/sktime_mcp/tools/plotting.py
@@ -1,20 +1,113 @@
+"""
+Visualization tool for sktime MCP.
+
+Plots one or more time series using sktime's native plotting utilities,
+returning the result as a saved file or a base64-encoded image string.
+"""
+
 import base64
 import io
 import logging
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+import matplotlib
 import pandas as pd
-from typing import Any, List, Optional
-import logging
-from typing import Any, List, Optional
+
+matplotlib.use("Agg")  # headless-safe backend, must be called before pyplot
+import matplotlib.pyplot as plt  # noqa: E402
 
 from sktime_mcp.runtime.executor import get_executor
 
 logger = logging.getLogger(__name__)
 
+# Default plot dimensions
+_DEFAULT_FIGSIZE = (12, 6)
+_DEFAULT_DPI = 150
+_SUPPORTED_FORMATS = {"png", "svg", "webp"}
+
+
+def _resolve_series(
+    handle: str,
+    executor: Any,
+) -> pd.Series | pd.DataFrame:
+    """Resolve a data handle to a pandas Series/DataFrame.
+
+    Raises KeyError if the handle is not found.
+    """
+    if handle not in executor._data_handles:
+        raise KeyError(handle)
+    return executor._data_handles[handle]["y"]
+
+
+def _coerce_indices(series_list: List) -> List:
+    """Coerce mixed PeriodIndex / DatetimeIndex / string Index to DatetimeIndex.
+
+    Modifies the series **in-place** and returns the same list.
+    """
+    has_period = any(isinstance(s.index, pd.PeriodIndex) for s in series_list)
+    has_datetime = any(isinstance(s.index, pd.DatetimeIndex) for s in series_list)
+    has_string = any(
+        type(s.index).__name__ == "Index" and pd.api.types.is_string_dtype(s.index)
+        for s in series_list
+    )
+
+    mixed = sum([has_period, has_datetime, has_string]) > 1
+    if not mixed:
+        return series_list
+
+    logger.info("Coercing mixed index types to DatetimeIndex for plotting")
+    for i, s in enumerate(series_list):
+        try:
+            if isinstance(s.index, pd.PeriodIndex):
+                series_list[i] = s.copy()
+                series_list[i].index = s.index.to_timestamp()
+            elif not isinstance(s.index, pd.DatetimeIndex):
+                series_list[i] = s.copy()
+                series_list[i].index = pd.to_datetime(s.index)
+        except Exception as e:
+            logger.warning("Failed to coerce index for series %d: %s", i, e)
+
+    return series_list
+
+
+def _reconcile_labels(
+    labels: Optional[List[str]],
+    n_series: int,
+) -> Optional[List[str]]:
+    """Return a label list that exactly matches *n_series*.
+
+    - If *labels* is ``None``, returns ``None`` (sktime will auto-label).
+    - If the lengths match, returns *labels* unchanged.
+    - If they differ, pads with ``"Series N"`` or truncates, and logs a warning.
+    """
+    if labels is None:
+        return None
+    if len(labels) == n_series:
+        return labels
+
+    logger.warning(
+        "Label count (%d) does not match series count (%d); adjusting.",
+        len(labels),
+        n_series,
+    )
+    if len(labels) < n_series:
+        return labels + [
+            f"Series {i}" for i in range(len(labels), n_series)
+        ]
+    return labels[:n_series]
+
+
 def plot_series_tool(
-    data_handles: List[str], 
-    labels: Optional[List[str]] = None, 
-    title: Optional[str] = None, 
-    path: Optional[str] = None
+    data_handles: List[str],
+    labels: Optional[List[str]] = None,
+    title: Optional[str] = None,
+    path: Optional[str] = None,
+    figsize: Optional[List[float]] = None,
+    dpi: Optional[int] = None,
+    markers: Optional[Union[str, List[str]]] = None,
+    x_label: Optional[str] = None,
+    y_label: Optional[str] = None,
+    image_format: str = "png",
 ) -> dict[str, Any]:
     """Plot one or more time series natively.
 
@@ -23,75 +116,129 @@ def plot_series_tool(
     data_handles : list of str
         List of data handle IDs to plot (e.g. train, test, forecasts).
     labels : list of str, optional
-        Labels for each series.
+        Labels for each series. If the count does not match the number
+        of data handles, it is silently padded or truncated.
     title : str, optional
         Title of the plot.
     path : str, optional
         Path to save the plot. If not provided, returns base64 encoded image.
+    figsize : list of float, optional
+        Figure size as ``[width, height]`` in inches. Default ``[12, 6]``.
+    dpi : int, optional
+        Resolution in dots per inch. Default ``150``.
+    markers : str or list of str, optional
+        Marker style(s) for data points (e.g. ``"o"``, ``[".", "x"]``).
+        Passed through to ``sktime.utils.plotting.plot_series``.
+    x_label : str, optional
+        Custom label for the x-axis.
+    y_label : str, optional
+        Custom label for the y-axis.
+    image_format : str, optional
+        Image output format: ``"png"`` (default), ``"svg"``, or ``"webp"``.
 
     Returns
     -------
     dict
-        Dictionary containing success status and path/base64 string.
+        Dictionary containing success status, path or base64 string,
+        and plot metadata (``n_series``, ``labels_used``, ``figsize``,
+        ``dpi``).
     """
+    # --- validate image format ---------------------------------------------
+    fmt = image_format.lower()
+    if fmt not in _SUPPORTED_FORMATS:
+        return {
+            "success": False,
+            "error": (
+                f"Unsupported image format '{image_format}'. "
+                f"Choose from: {sorted(_SUPPORTED_FORMATS)}"
+            ),
+        }
+
     try:
         from sktime.utils.plotting import plot_series
-        import matplotlib.pyplot as plt
     except ImportError:
-        return {"success": False, "error": "matplotlib and sktime plotting utils are required."}
+        return {
+            "success": False,
+            "error": "matplotlib and sktime plotting utils are required.",
+        }
 
     executor = get_executor()
-    
-    series_to_plot = []
-    
+
+    # --- resolve data handles -----------------------------------------------
+    series_to_plot: list = []
+    missing: list[str] = []
+
     for handle in data_handles:
-        if handle not in executor._data_handles:
-            return {"success": False, "error": f"Data handle '{handle}' not found."}
-        series = executor._data_handles[handle]["y"]
-        series_to_plot.append(series)
+        try:
+            series_to_plot.append(_resolve_series(handle, executor))
+        except KeyError:
+            missing.append(handle)
 
+    if missing:
+        return {
+            "success": False,
+            "error": f"Data handle(s) not found: {missing}",
+            "available_handles": list(executor._data_handles.keys()),
+        }
+
+    # --- prepare plotting args ---------------------------------------------
     try:
-        # sktime requires all series to have the same index type
-        # Check if we have a mix of PeriodIndex and DatetimeIndex
-        has_period = any(isinstance(s.index, pd.PeriodIndex) for s in series_to_plot)
-        has_datetime = any(isinstance(s.index, pd.DatetimeIndex) for s in series_to_plot)
-        has_string = any(type(s.index).__name__ == "Index" and pd.api.types.is_string_dtype(s.index) for s in series_to_plot)
-        
-        if (has_period and has_datetime) or (has_period and has_string) or (has_datetime and has_string):
-            # Coerce everything to DatetimeIndex for plotting
-            logger.info("Coercing mixed index types to DatetimeIndex for plotting")
-            for i in range(len(series_to_plot)):
-                try:
-                    if isinstance(series_to_plot[i].index, pd.PeriodIndex):
-                        series_to_plot[i].index = series_to_plot[i].index.to_timestamp()
-                    else:
-                        series_to_plot[i].index = pd.to_datetime(series_to_plot[i].index)
-                except Exception as e:
-                    logger.warning(f"Failed to coerce index for series {i}: {e}")
+        series_to_plot = _coerce_indices(series_to_plot)
+        labels = _reconcile_labels(labels, len(series_to_plot))
 
-        if labels and len(labels) != len(series_to_plot):
-            logger.warning("Length of labels does not match number of series.")
-            # Adjust labels or just pass it and let sktime handle, but it might crash
-            # Let's pass it anyway or truncate/extend it if we want to be safe.
-            # actually plot_series takes labels but it should match.
+        effective_figsize = tuple(figsize) if figsize else _DEFAULT_FIGSIZE
+        effective_dpi = dpi if dpi else _DEFAULT_DPI
 
-        fig, ax = plot_series(*series_to_plot, labels=labels)
+        # Build kwargs for plot_series
+        plot_kwargs: dict[str, Any] = {}
+        if markers is not None:
+            plot_kwargs["markers"] = markers
+
+        fig, ax = plot_series(
+            *series_to_plot,
+            labels=labels,
+            **plot_kwargs,
+        )
+
+        # Resize figure after creation (plot_series creates its own figure)
+        fig.set_size_inches(effective_figsize)
+        fig.set_dpi(effective_dpi)
+
         if title:
             ax.set_title(title)
-        
-        result = {"success": True}
+        if x_label:
+            ax.set_xlabel(x_label)
+        if y_label:
+            ax.set_ylabel(y_label)
+
+        # --- output ---------------------------------------------------------
+        result: dict[str, Any] = {
+            "success": True,
+            "n_series": len(series_to_plot),
+            "labels_used": labels or [
+                f"Series {i}" for i in range(len(series_to_plot))
+            ],
+            "figsize": list(effective_figsize),
+            "dpi": effective_dpi,
+            "image_format": fmt,
+        }
+
         if path:
-            fig.savefig(path, bbox_inches='tight')
+            fig.savefig(path, format=fmt, bbox_inches="tight", dpi=effective_dpi)
             result["path"] = path
         else:
             buf = io.BytesIO()
-            fig.savefig(buf, format="png", bbox_inches='tight')
+            fig.savefig(buf, format=fmt, bbox_inches="tight", dpi=effective_dpi)
             buf.seek(0)
-            img_base64 = base64.b64encode(buf.read()).decode("utf-8")
-            result["image_base64"] = img_base64
-            
+            result["image_base64"] = base64.b64encode(buf.read()).decode("utf-8")
+
         plt.close(fig)
         return result
+
     except Exception as e:
         logger.exception("Error plotting series")
-        return {"success": False, "error": str(e)}
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }

--- a/src/sktime_mcp/tools/plotting.py
+++ b/src/sktime_mcp/tools/plotting.py
@@ -1,0 +1,97 @@
+import base64
+import io
+import logging
+import pandas as pd
+from typing import Any, List, Optional
+import logging
+from typing import Any, List, Optional
+
+from sktime_mcp.runtime.executor import get_executor
+
+logger = logging.getLogger(__name__)
+
+def plot_series_tool(
+    data_handles: List[str], 
+    labels: Optional[List[str]] = None, 
+    title: Optional[str] = None, 
+    path: Optional[str] = None
+) -> dict[str, Any]:
+    """Plot one or more time series natively.
+
+    Parameters
+    ----------
+    data_handles : list of str
+        List of data handle IDs to plot (e.g. train, test, forecasts).
+    labels : list of str, optional
+        Labels for each series.
+    title : str, optional
+        Title of the plot.
+    path : str, optional
+        Path to save the plot. If not provided, returns base64 encoded image.
+
+    Returns
+    -------
+    dict
+        Dictionary containing success status and path/base64 string.
+    """
+    try:
+        from sktime.utils.plotting import plot_series
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return {"success": False, "error": "matplotlib and sktime plotting utils are required."}
+
+    executor = get_executor()
+    
+    series_to_plot = []
+    
+    for handle in data_handles:
+        if handle not in executor._data_handles:
+            return {"success": False, "error": f"Data handle '{handle}' not found."}
+        series = executor._data_handles[handle]["y"]
+        series_to_plot.append(series)
+
+    try:
+        # sktime requires all series to have the same index type
+        # Check if we have a mix of PeriodIndex and DatetimeIndex
+        has_period = any(isinstance(s.index, pd.PeriodIndex) for s in series_to_plot)
+        has_datetime = any(isinstance(s.index, pd.DatetimeIndex) for s in series_to_plot)
+        has_string = any(type(s.index).__name__ == "Index" and pd.api.types.is_string_dtype(s.index) for s in series_to_plot)
+        
+        if (has_period and has_datetime) or (has_period and has_string) or (has_datetime and has_string):
+            # Coerce everything to DatetimeIndex for plotting
+            logger.info("Coercing mixed index types to DatetimeIndex for plotting")
+            for i in range(len(series_to_plot)):
+                try:
+                    if isinstance(series_to_plot[i].index, pd.PeriodIndex):
+                        series_to_plot[i].index = series_to_plot[i].index.to_timestamp()
+                    else:
+                        series_to_plot[i].index = pd.to_datetime(series_to_plot[i].index)
+                except Exception as e:
+                    logger.warning(f"Failed to coerce index for series {i}: {e}")
+
+        if labels and len(labels) != len(series_to_plot):
+            logger.warning("Length of labels does not match number of series.")
+            # Adjust labels or just pass it and let sktime handle, but it might crash
+            # Let's pass it anyway or truncate/extend it if we want to be safe.
+            # actually plot_series takes labels but it should match.
+
+        fig, ax = plot_series(*series_to_plot, labels=labels)
+        if title:
+            ax.set_title(title)
+        
+        result = {"success": True}
+        if path:
+            fig.savefig(path, bbox_inches='tight')
+            result["path"] = path
+        else:
+            buf = io.BytesIO()
+            fig.savefig(buf, format="png", bbox_inches='tight')
+            buf.seek(0)
+            img_base64 = base64.b64encode(buf.read()).decode("utf-8")
+            result["image_base64"] = img_base64
+            
+        plt.close(fig)
+        return result
+    except Exception as e:
+        logger.exception("Error plotting series")
+        return {"success": False, "error": str(e)}

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,203 @@
+"""Tests for the plot_series_tool."""
+
+import base64
+import os
+import tempfile
+
+import pandas as pd
+import pytest
+
+from sktime_mcp.tools.plotting import (
+    _coerce_indices,
+    _reconcile_labels,
+    plot_series_tool,
+)
+from sktime_mcp.runtime.executor import get_executor
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_handles():
+    """Clear data handles before and after each test."""
+    executor = get_executor()
+    executor._data_handles.clear()
+    yield
+    executor._data_handles.clear()
+
+
+def _register_series(handle_id: str, series: pd.Series) -> None:
+    """Register a series under the given handle in the executor."""
+    executor = get_executor()
+    executor._data_handles[handle_id] = {"y": series}
+
+
+def _make_airline_like(n: int = 24) -> pd.Series:
+    """Create a small airline-like monthly series."""
+    idx = pd.date_range("2020-01", periods=n, freq="MS")
+    return pd.Series(range(100, 100 + n), index=idx, name="Passengers")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileLabels:
+    def test_none_returns_none(self):
+        assert _reconcile_labels(None, 3) is None
+
+    def test_matching_length(self):
+        labels = ["a", "b", "c"]
+        assert _reconcile_labels(labels, 3) == ["a", "b", "c"]
+
+    def test_too_few_labels_padded(self):
+        result = _reconcile_labels(["train"], 3)
+        assert len(result) == 3
+        assert result[0] == "train"
+        assert result[1] == "Series 1"
+        assert result[2] == "Series 2"
+
+    def test_too_many_labels_truncated(self):
+        result = _reconcile_labels(["a", "b", "c", "d"], 2)
+        assert result == ["a", "b"]
+
+
+class TestCoerceIndices:
+    def test_uniform_datetime_no_change(self):
+        s1 = _make_airline_like(12)
+        s2 = _make_airline_like(12)
+        result = _coerce_indices([s1, s2])
+        assert all(isinstance(s.index, pd.DatetimeIndex) for s in result)
+
+    def test_mixed_period_datetime_coerced(self):
+        dt_series = _make_airline_like(12)
+        period_series = dt_series.copy()
+        period_series.index = dt_series.index.to_period("M")
+        result = _coerce_indices([dt_series, period_series])
+        assert all(isinstance(s.index, pd.DatetimeIndex) for s in result)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — plot_series_tool
+# ---------------------------------------------------------------------------
+
+
+class TestPlotSeriesTool:
+    """Integration tests for the full plot_series_tool."""
+
+    def test_handle_not_found(self):
+        result = plot_series_tool(data_handles=["nonexistent"])
+        assert result["success"] is False
+        assert "not found" in result["error"]
+        assert "available_handles" in result
+
+    def test_unsupported_format(self):
+        _register_series("s1", _make_airline_like())
+        result = plot_series_tool(
+            data_handles=["s1"], image_format="bmp"
+        )
+        assert result["success"] is False
+        assert "Unsupported image format" in result["error"]
+
+    def test_single_series_base64(self):
+        _register_series("train", _make_airline_like())
+        result = plot_series_tool(data_handles=["train"])
+        assert result["success"] is True
+        assert "image_base64" in result
+        # Verify it's valid base64
+        raw = base64.b64decode(result["image_base64"])
+        assert len(raw) > 0
+
+    def test_single_series_metadata(self):
+        _register_series("train", _make_airline_like())
+        result = plot_series_tool(
+            data_handles=["train"],
+            title="Test Plot",
+            figsize=[8, 4],
+            dpi=100,
+        )
+        assert result["success"] is True
+        assert result["n_series"] == 1
+        assert result["figsize"] == [8, 4]
+        assert result["dpi"] == 100
+        assert result["image_format"] == "png"
+
+    def test_multiple_series(self):
+        _register_series("s1", _make_airline_like(12))
+        _register_series("s2", _make_airline_like(12))
+        result = plot_series_tool(
+            data_handles=["s1", "s2"],
+            labels=["Train", "Test"],
+        )
+        assert result["success"] is True
+        assert result["n_series"] == 2
+        assert result["labels_used"] == ["Train", "Test"]
+
+    def test_save_to_file(self):
+        _register_series("s1", _make_airline_like())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = os.path.join(tmpdir, "test_plot.png")
+            result = plot_series_tool(
+                data_handles=["s1"],
+                path=out_path,
+            )
+            assert result["success"] is True
+            assert result["path"] == out_path
+            assert os.path.exists(out_path)
+            assert os.path.getsize(out_path) > 0
+
+    def test_save_svg_format(self):
+        _register_series("s1", _make_airline_like())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = os.path.join(tmpdir, "test_plot.svg")
+            result = plot_series_tool(
+                data_handles=["s1"],
+                path=out_path,
+                image_format="svg",
+            )
+            assert result["success"] is True
+            assert result["image_format"] == "svg"
+
+    def test_label_mismatch_handled(self):
+        """Labels that don't match series count should not crash."""
+        _register_series("s1", _make_airline_like())
+        _register_series("s2", _make_airline_like())
+        # Fewer labels than series
+        result = plot_series_tool(
+            data_handles=["s1", "s2"],
+            labels=["Only One"],
+        )
+        assert result["success"] is True
+        assert len(result["labels_used"]) == 2
+
+    def test_custom_axis_labels(self):
+        _register_series("s1", _make_airline_like())
+        result = plot_series_tool(
+            data_handles=["s1"],
+            x_label="Date",
+            y_label="Passengers (thousands)",
+            title="Airline Traffic",
+        )
+        assert result["success"] is True
+
+    def test_markers_param(self):
+        _register_series("s1", _make_airline_like(12))
+        result = plot_series_tool(
+            data_handles=["s1"],
+            markers="o",
+        )
+        assert result["success"] is True
+
+    def test_mixed_handles_partial_missing(self):
+        """When some handles exist and some don't, report all missing."""
+        _register_series("real", _make_airline_like())
+        result = plot_series_tool(
+            data_handles=["real", "fake1", "fake2"]
+        )
+        assert result["success"] is False
+        assert "fake1" in result["error"]
+        assert "fake2" in result["error"]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime-mcp/blob/main/docs/source/dev-guide.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #498

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

This PR implements the `mcp_sktime_plot_series` visualization tool and hardens it for production use. It adds native time series plotting capabilities using `sktime.utils.plotting`, with robust error handling, full test coverage, and proper integration with the tool registry.

**Core functionality:**
- `plot_series_tool` — plots one or more time series (train, test, forecasts, etc.)
- Outputs as a saved PNG/SVG/WebP file **or** a base64-encoded string for MCP client rendering
- Automatic index coercion when plotting series with mixed `PeriodIndex` / `DatetimeIndex` types

**Bug fixes (v2):**
- Removed duplicate imports (`logging`, `typing` were imported twice)
- Added `matplotlib.use('Agg')` for headless/Docker/CI safety — prevents `_tkinter.TclError`
- Fixed label count mismatch crash — now gracefully pads or truncates labels instead of passing mismatched arrays to `plot_series` which would raise
- Error responses now include `available_handles` list (consistency with all other tools)
- Exception responses now include `error_type` for better diagnostics
- Tool is now properly exported from `tools/__init__.py`
- Added module-level docstring

**New parameters (v2):**
| Parameter | Type | Description |
|-----------|------|-------------|
| `figsize` | `[width, height]` | Figure size in inches (default: `[12, 6]`) |
| `dpi` | `int` | Resolution in dots per inch (default: `150`) |
| `markers` | `str` or `list` | Marker style(s) for data points (e.g., `"o"`, `[".", "x"]`) |
| `x_label` | `str` | Custom x-axis label |
| `y_label` | `str` | Custom y-axis label |
| `image_format` | `str` | Output format: `"png"`, `"svg"`, or `"webp"` |

**Enriched response:** success responses now return plot metadata (`n_series`, `labels_used`, `figsize`, `dpi`, `image_format`) for LLM context.

**Files changed:**
- `src/sktime_mcp/tools/plotting.py` — full rewrite with extracted helpers (`_resolve_series`, `_coerce_indices`, `_reconcile_labels`)
- `src/sktime_mcp/tools/__init__.py` — added import + `__all__` export
- `src/sktime_mcp/server.py` — expanded tool schema with new parameters + updated dispatcher
- `tests/test_plotting.py` — **new**, 17 tests

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package to keep external dependencies of the core sktime-mcp package to a minimum.
-->
No new hard dependencies. Uses `matplotlib` (already a transitive dependency of sktime) and `seaborn` (soft dependency of `sktime.utils.plotting.plot_series`).

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- [x] The rewritten `plot_series_tool` in `src/sktime_mcp/tools/plotting.py` — extracted helpers, headless backend, label reconciliation
- [x] Index coercion logic for mixed `PeriodIndex`/`DatetimeIndex`/string scenarios
- [x] Server schema additions for the 6 new parameters (`figsize`, `dpi`, `markers`, `x_label`, `y_label`, `image_format`)
- [x] Test coverage in `tests/test_plotting.py` (17 tests — unit + integration)

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
This enhancement greatly improves the data exploration and model evaluation workflow directly from the MCP interface. The v2 commit addresses code review findings: 5 bug fixes, 3 consistency improvements, and 6 new user-facing features — all covered by tests (17 passed, 185 total suite passed).

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added unit tests and made sure they pass locally (`make check`).
- [ ] I've added the tool to the online documentation in `docs/source/`.
- [ ] I've updated the existing example scripts or provided a new one to showcase how my tool works in `examples/`.

<!--
Thanks for contributing!
-->