### PR TITLE
fix: add plotting dependencies and fix format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "uvicorn>=0.22.0",
     "sse-starlette>=1.6.1",
     "mlflow>=2.0",
+    "matplotlib>=3.3.0",
+    "seaborn>=0.11.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -97,9 +97,7 @@ class TestPlotSeriesTool:
 
     def test_unsupported_format(self):
         _register_series("s1", _make_airline_like())
-        result = plot_series_tool(
-            data_handles=["s1"], image_format="bmp"
-        )
+        result = plot_series_tool(data_handles=["s1"], image_format="bmp")
         assert result["success"] is False
         assert "Unsupported image format" in result["error"]
 
@@ -195,9 +193,7 @@ class TestPlotSeriesTool:
     def test_mixed_handles_partial_missing(self):
         """When some handles exist and some don't, report all missing."""
         _register_series("real", _make_airline_like())
-        result = plot_series_tool(
-            data_handles=["real", "fake1", "fake2"]
-        )
+        result = plot_series_tool(data_handles=["real", "fake1", "fake2"])
         assert result["success"] is False
         assert "fake1" in result["error"]
         assert "fake2" in result["error"]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime-mcp/blob/main/docs/source/developer/contributing.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
-->
N/A

#### What does this implement/fix? Explain your changes.
This PR resolves two issues that were causing the CI pipeline to fail on `main`:
1. **Missing plot dependencies:** The newly introduced `plot_series_tool` uses `sktime`'s internal plotting utilities, which have soft dependencies on `seaborn` and `matplotlib`. These were previously missing, causing `ModuleNotFoundError` during the test suite execution in GitHub Actions.
2. **Formatting failure:** Fixes a `ruff format --check .` failure in `tests/test_plotting.py` by applying the formatter to the file.

#### Does your contribution introduce a new dependency? If yes, which one?
Yes, it introduces `matplotlib` and `seaborn` as hard dependencies in `pyproject.toml` to ensure the "batteries-included" `sktime-mcp` server can handle plotting workflows out of the box without requiring manual installs by the user.

#### What should a reviewer concentrate their feedback on?
- Confirming that adding `matplotlib` and `seaborn` as default dependencies aligns with the project's dependency strategy for the MCP server.

#### Any other comments?
This fix gets the `main` branch tests back to passing/green.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added unit tests and made sure they pass locally (`make check`). *(Tests were already added; ensured they now pass).*
- [ ] I've added the tool to the online documentation in `docs/source/`. *(N/A)*
- [ ] I've updated the existing example scripts or provided a new one to showcase how my tool works in `examples/`. *(N/A)*
