### PR TITLE
refactor(evaluate): implement unified evaluate/evaluate_async

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The full tool reference is in the project documentation: https://sktime.github.i
 | Discover what sktime can do | `list_available_data`, `query_registry`, `describe_component` | Find demo data, estimators, tags, and component details. |
 | Bring data into the session | `load_data_source`, `inspect_data`, `transform_data`, `split_data`, `save_data` | Load files, inline data, SQL, or URLs into handles; inspect, clean, split, and persist them. |
 | Build and run models | `instantiate_estimator`, `fit`, `predict`, `update`, `get_fitted_params`, `call_method` | Create sktime estimators or pipelines, fit them, forecast, update, or call native methods. |
-| Evaluate and reproduce | `evaluate_estimator`, `export_code`, `save_model`, `load_model` | Cross-validate, generate Python code, and persist fitted models. |
+| Evaluate and reproduce | `evaluate`, `export_code`, `save_model`, `load_model` | Cross-validate, generate Python code, and persist fitted models. |
 | Manage runtime state | `list_handles`, `release_handle`, `release_data_handle`, `list_jobs`, `check_job_status`, `cancel_job` | See what is in memory, clean it up, and track async work. |
 
 The practical mental model is simple: prompts create tool calls, tool calls create handles, and handles let later prompts continue the workflow.

--- a/docs/source/user-guide.md
+++ b/docs/source/user-guide.md
@@ -434,7 +434,7 @@ The full tool reference is in the project documentation: https://sktime.github.i
 | Discover what sktime can do | `list_available_data`, `query_registry`, `describe_component` | Find demo data, estimators, tags, and component details. |
 | Bring data into the session | `load_data_source`, `inspect_data`, `transform_data`, `split_data`, `save_data` | Load files, inline data, SQL, or URLs into handles; inspect, clean, split, and persist them. |
 | Build and run models | `instantiate_estimator`, `fit`, `predict`, `update`, `get_fitted_params`, `call_method` | Create sktime estimators or pipelines, fit them, forecast, update, or call native methods. |
-| Evaluate and reproduce | `evaluate_estimator`, `export_code`, `save_model`, `load_model` | Cross-validate, generate Python code, and persist fitted models. |
+| Evaluate and reproduce | `evaluate`, `export_code`, `save_model`, `load_model` | Cross-validate, generate Python code, and persist fitted models. |
 | Manage runtime state | `list_handles`, `release_handle`, `release_data_handle`, `list_jobs`, `check_job_status`, `cancel_job` | See what is in memory, clean it up, and track async work. |
 
 The practical mental model is simple: prompts create tool calls, tool calls create handles, and handles let later prompts continue the workflow.
@@ -545,7 +545,7 @@ A retail analyst wants a quick demand forecast for the next planning cycle. The 
 
 **Expected tool behavior**
 
-`list_available_data` -> `describe_component` -> `instantiate_estimator` -> `fit` -> `predict` -> `evaluate_estimator` -> `get_fitted_params` -> `export_code`
+`list_available_data` -> `describe_component` -> `instantiate_estimator` -> `fit` -> `predict` -> `evaluate` -> `get_fitted_params` -> `export_code`
 
 For persistence, use the most appropriate route:
 
@@ -795,7 +795,7 @@ These limitations matter before building expectations around the tool.
 - Optional estimators may need optional dependencies. Missing dependency errors are expected for some advanced models.
 - Forecasting workflows are the most polished. Classification, detection, splitters, metrics, and other scitypes are reachable, but may need `call_method` or more explicit prompts.
 - Some prediction results are returned as structured text or JSON, not as persistent data handles. Save them through exported code or client-side file writing when needed.
-- `evaluate_estimator` is strongest on demo datasets today. Custom train/test evaluation is a promising extension.
+- `evaluate` is strongest on demo datasets today. Custom train/test evaluation is a promising extension.
 
 
 ## 6. Wrap-Up

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -188,6 +188,15 @@ class Executor:
             self._cleanup_oldest_data(count=max(1, self._max_data_handles // 5))
         self._data_handles[handle_id] = data
 
+    def _resolve_source(self, source: str) -> dict[str, Any]:
+        """Resolve a source id to a series, trying data_handle then demo dataset."""
+        if source in self._data_handles:
+            return {"success": True, "data": self._data_handles[source]["y"]}
+        res = self.load_dataset(source)
+        if res["success"]:
+            return {"success": True, "data": res["data"]}
+        return res
+
     def instantiate(
         self,
         spec: str,
@@ -971,23 +980,17 @@ class Executor:
             except KeyError as err:
                 raise ValueError(f"Handle not found: {handle_id}") from err
 
-            if y in self._data_handles:
-                _y = self._data_handles[y]["y"]
-            else:
-                data_res = self.load_dataset(y)
-                if not data_res["success"]:
-                    raise ValueError(data_res["error"])
-                _y = data_res["data"]
+            y_res = self._resolve_source(y)
+            if not y_res["success"]:
+                raise ValueError(y_res["error"])
+            _y = y_res["data"]
 
             _X = None
             if X:
-                if X in self._data_handles:
-                    _X = self._data_handles[X]["y"]
-                else:
-                    data_res = self.load_dataset(X)
-                    if not data_res["success"]:
-                        raise ValueError(data_res["error"])
-                    _X = data_res["data"]
+                x_res = self._resolve_source(X)
+                if not x_res["success"]:
+                    raise ValueError(x_res["error"])
+                _X = x_res["data"]
 
             scoring = None
             if metric:

--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -87,6 +87,79 @@ def _get_index_frequency_metadata(
     return fallback
 
 
+def _resolve_metric_scoring(metric_name: str) -> Any | None:
+    """Return an instantiated sktime forecasting metric by name, or None if not found."""
+    try:
+        from sktime.registry import all_estimators
+    except ImportError:  # pragma: no cover
+        return None
+    try:
+        metrics_df = all_estimators("metric", as_dataframe=True)
+        row = metrics_df[metrics_df["name"] == metric_name]
+        if row.empty:
+            return None
+        return row.iloc[0]["object"]()
+    except Exception as e:
+        logger.warning(f"Failed to resolve metric '{metric_name}': {e}")
+        return None
+
+
+def _run_evaluate(
+    instance: Any,
+    y: Any,
+    X: Any,
+    cv_folds: int,
+    scoring: Any | None,
+    initial_window: int | None,
+) -> tuple[list[dict[str, Any]], dict[str, float], dict[str, dict[str, float]]]:
+    """
+    Run sktime.evaluate with an expanding-window splitter and summarize results.
+
+    Returns
+    -------
+    fold_results : list of dict
+        Per-fold rows from sktime.evaluate.
+    metrics : dict
+        Mean value per ``test_*`` metric column.
+    summary : dict
+        Mean, std, min, max per ``test_*`` metric column.
+    """
+    from sktime.forecasting.model_evaluation import evaluate
+
+    try:
+        from sktime.split import ExpandingWindowSplitter
+    except ImportError:  # pragma: no cover - sktime < 0.29
+        from sktime.forecasting.model_selection import ExpandingWindowSplitter
+
+    n = len(y)
+    if initial_window is not None:
+        win = initial_window
+    else:
+        folds = max(1, min(int(cv_folds), max(1, n - 1)))
+        win = max(1, n - folds)
+    cv = ExpandingWindowSplitter(initial_window=win, step_length=1, fh=[1])
+
+    results = evaluate(forecaster=instance, y=y, X=X, cv=cv, scoring=scoring)
+    if "estimator" in results.columns:
+        results = results.drop(columns=["estimator"])
+
+    fold_results = results.to_dict(orient="records")
+    metric_cols = [
+        c for c in results.select_dtypes(include="number").columns if c.startswith("test_")
+    ]
+    metrics = {c: float(results[c].mean()) for c in metric_cols}
+    summary = {
+        c: {
+            "mean": float(results[c].mean()),
+            "std": float(results[c].std()),
+            "min": float(results[c].min()),
+            "max": float(results[c].max()),
+        }
+        for c in metric_cols
+    }
+    return fold_results, metrics, summary
+
+
 class Executor:
     """
     Execution runtime for sktime estimators.
@@ -873,6 +946,100 @@ class Executor:
             logger.exception(f"Error in async fit_predict for job {job_id}")
             self._job_manager.update_job(job_id, status=JobStatus.FAILED, errors=[str(e)])
             return {"success": False, "error": str(e), "job_id": job_id}
+
+    async def evaluate_async(
+        self,
+        handle_id: str,
+        y: str,
+        *,
+        X: str | None = None,
+        cv_folds: int = 3,
+        metric: str | None = None,
+        initial_window: int | None = None,
+        job_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Async version of evaluate with job tracking."""
+        try:
+            self._job_manager.update_job(job_id, status=JobStatus.RUNNING)
+
+            # Step 1: Load data
+            self._job_manager.update_job(job_id, completed_steps=0, current_step="Loading data...")
+            await asyncio.sleep(0.01)
+
+            try:
+                instance = self._handle_manager.get_instance(handle_id)
+            except KeyError as err:
+                raise ValueError(f"Handle not found: {handle_id}") from err
+
+            if y in self._data_handles:
+                _y = self._data_handles[y]["y"]
+            else:
+                data_res = self.load_dataset(y)
+                if not data_res["success"]:
+                    raise ValueError(data_res["error"])
+                _y = data_res["data"]
+
+            _X = None
+            if X:
+                if X in self._data_handles:
+                    _X = self._data_handles[X]["y"]
+                else:
+                    data_res = self.load_dataset(X)
+                    if not data_res["success"]:
+                        raise ValueError(data_res["error"])
+                    _X = data_res["data"]
+
+            scoring = None
+            if metric:
+                scoring = _resolve_metric_scoring(metric)
+                if scoring is None:
+                    raise ValueError(f"Unknown metric: {metric}")
+
+            # Step 2: Run cross-validation
+            self._job_manager.update_job(
+                job_id, completed_steps=1, current_step="Running cross-validation..."
+            )
+            await asyncio.sleep(0.01)
+
+            loop = asyncio.get_running_loop()
+            fold_results, metrics, summary = await loop.run_in_executor(
+                None,
+                lambda: _run_evaluate(instance, _y, _X, cv_folds, scoring, initial_window),
+            )
+
+            # Step 3: Summarize results
+            self._job_manager.update_job(
+                job_id, completed_steps=2, current_step="Summarizing results..."
+            )
+            await asyncio.sleep(0.01)
+
+            result = {
+                "success": True,
+                "metrics": metrics,
+                "fold_results": fold_results,
+                "summary": summary,
+                "cv_folds_run": len(fold_results),
+                "cv_folds_requested": cv_folds,
+            }
+            self._job_manager.update_job(
+                job_id,
+                status=JobStatus.COMPLETED,
+                completed_steps=3,
+                current_step="Evaluation completed.",
+                result=result,
+            )
+            return result
+
+        except Exception as e:
+            import traceback
+
+            self._job_manager.update_job(
+                job_id,
+                status=JobStatus.FAILED,
+                current_step="Evaluation failed.",
+                errors=[str(e), traceback.format_exc()],
+            )
+            return {"success": False, "error": str(e)}
 
     # L-9: We can add more methods here to handle diverse use cases and their pipelines
 

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -42,7 +42,7 @@ from sktime_mcp.tools.data_tools import (
 from sktime_mcp.tools.describe_component import (
     describe_component_tool,
 )
-from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+from sktime_mcp.tools.evaluate import evaluate_tool
 from sktime_mcp.tools.fit_predict import (
     fit_tool,
     get_fitted_params_tool,
@@ -476,8 +476,11 @@ async def list_tools() -> list[Tool]:
         ),
         # -- Execution (Macros) ----------------------------------------------
         Tool(
-            name="evaluate_estimator",
-            description="Evaluate an estimator using cross-validation on a dataset",
+            name="evaluate",
+            description=(
+                "Cross-validate an estimator on a dataset. "
+                "Dataset and data handle inputs supported for y and X."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -485,17 +488,33 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Handle from instantiate_estimator",
                     },
-                    "dataset": {
+                    "y": {
                         "type": "string",
-                        "description": "Dataset name: airline, sunspots, lynx, etc.",
+                        "description": "Target time series: data_handle id or demo dataset name (e.g. 'airline').",
+                    },
+                    "X": {
+                        "type": "string",
+                        "description": "Optional: exogenous time series data_handle id or demo dataset name.",
                     },
                     "cv_folds": {
                         "type": "integer",
-                        "description": "Number of cross-validation folds (default: 3)",
+                        "description": "Number of cross-validation folds (default: 3). Ignored if initial_window is set.",
                         "default": 3,
                     },
+                    "metric": {
+                        "type": "string",
+                        "description": "Optional: performance metric name (e.g. 'MeanAbsolutePercentageError').",
+                    },
+                    "initial_window": {
+                        "type": "integer",
+                        "description": "Optional: initial training window size for expanding-window CV.",
+                    },
+                    "run_async": {
+                        "type": "boolean",
+                        "description": "If true, runs evaluation as a background job and returns a job_id.",
+                    },
                 },
-                "required": ["estimator_handle", "dataset"],
+                "required": ["estimator_handle", "y"],
             },
         ),
         # -- Data ------------------------------------------------------------
@@ -1019,11 +1038,15 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 kwargs=arguments.get("kwargs", {}),
             )
 
-        elif name == "evaluate_estimator":
-            result = evaluate_estimator_tool(
-                arguments["estimator_handle"],
-                arguments["dataset"],
-                arguments.get("cv_folds", 3),
+        elif name == "evaluate":
+            result = evaluate_tool(
+                estimator_handle=arguments["estimator_handle"],
+                y=arguments["y"],
+                X=arguments.get("X"),
+                cv_folds=arguments.get("cv_folds", 3),
+                metric=arguments.get("metric"),
+                initial_window=arguments.get("initial_window"),
+                run_async=arguments.get("run_async", False),
             )
 
         # -- Data ------------------------------------------------------------

--- a/src/sktime_mcp/tools/__init__.py
+++ b/src/sktime_mcp/tools/__init__.py
@@ -8,7 +8,7 @@ from sktime_mcp.tools.data_tools import (
 from sktime_mcp.tools.describe_component import (
     describe_component_tool,
 )
-from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+from sktime_mcp.tools.evaluate import evaluate_tool
 from sktime_mcp.tools.fit_predict import (
     fit_tool,
     get_fitted_params_tool,
@@ -50,7 +50,7 @@ __all__ = [
     "predict_tool",
     "update_tool",
     "get_fitted_params_tool",
-    "evaluate_estimator_tool",
+    "evaluate_tool",
     "load_data_source_tool",
     "release_data_handle_tool",
     "list_available_data_tool",

--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -14,16 +14,6 @@ from sktime_mcp.runtime.jobs import get_job_manager
 logger = logging.getLogger(__name__)
 
 
-def _resolve_y_source(executor: Any, source: str) -> dict[str, Any]:
-    """Resolve a data source id to a series, trying data_handle then demo dataset."""
-    if source in executor._data_handles:
-        return {"success": True, "data": executor._data_handles[source]["y"]}
-    res = executor.load_dataset(source)
-    if res["success"]:
-        return {"success": True, "data": res["data"]}
-    return res
-
-
 def evaluate_tool(
     estimator_handle: str,
     y: str,
@@ -73,14 +63,14 @@ def evaluate_tool(
     except KeyError:
         return {"success": False, "error": f"Handle not found: {estimator_handle}"}
 
-    y_res = _resolve_y_source(executor, y)
+    y_res = executor._resolve_source(y)
     if not y_res["success"]:
         return y_res
     _y = y_res["data"]
 
     _X = None
     if X:
-        x_res = _resolve_y_source(executor, X)
+        x_res = executor._resolve_source(X)
         if not x_res["success"]:
             return x_res
         _X = x_res["data"]

--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -1,89 +1,115 @@
 """
 evaluate tool for sktime MCP.
 
-Executes cross-validation on an estimator.
+Cross-validates an estimator on a dataset.
 """
 
+import asyncio
 import logging
 from typing import Any
 
-from sktime.forecasting.model_evaluation import evaluate
-
-try:
-    from sktime.split import ExpandingWindowSplitter
-except ImportError:  # pragma: no cover - sktime < 0.29
-    from sktime.forecasting.model_selection import ExpandingWindowSplitter
-
-from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.runtime.executor import _resolve_metric_scoring, _run_evaluate, get_executor
+from sktime_mcp.runtime.jobs import get_job_manager
 
 logger = logging.getLogger(__name__)
 
 
-def evaluate_estimator_tool(
+def _resolve_y_source(executor: Any, source: str) -> dict[str, Any]:
+    """Resolve a data source id to a series, trying data_handle then demo dataset."""
+    if source in executor._data_handles:
+        return {"success": True, "data": executor._data_handles[source]["y"]}
+    res = executor.load_dataset(source)
+    if res["success"]:
+        return {"success": True, "data": res["data"]}
+    return res
+
+
+def evaluate_tool(
     estimator_handle: str,
-    dataset: str,
+    y: str,
+    X: str | None = None,
     cv_folds: int = 3,
+    metric: str | None = None,
+    initial_window: int | None = None,
+    run_async: bool = False,
 ) -> dict[str, Any]:
     """
-    Evaluate an estimator using cross-validation.
+    Cross-validate an estimator on a dataset.
 
-    Args:
-        estimator_handle: Handle from instantiate_estimator
-        dataset: Name of demo dataset
-        cv_folds: Number of folds for Splitter
-
-    Returns:
-        Dictionary with cross-validation results
+    y and X accept data_handle ids or built-in demo dataset names.
+    Set run_async=True to run as a background job.
     """
     executor = get_executor()
+
+    if run_async:
+        job_manager = get_job_manager()
+        try:
+            estimator_name = executor._handle_manager.get_info(estimator_handle).estimator_name
+        except Exception:
+            estimator_name = "Unknown"
+
+        job_id = job_manager.create_job(
+            job_type="evaluate",
+            estimator_handle=estimator_handle,
+            estimator_name=estimator_name,
+            dataset_name=y,
+            total_steps=3,
+        )
+        asyncio.create_task(
+            executor.evaluate_async(
+                handle_id=estimator_handle,
+                y=y,
+                X=X,
+                cv_folds=cv_folds,
+                metric=metric,
+                initial_window=initial_window,
+                job_id=job_id,
+            )
+        )
+        return {"success": True, "job_id": job_id, "status": "running"}
 
     try:
         instance = executor._handle_manager.get_instance(estimator_handle)
     except KeyError:
         return {"success": False, "error": f"Handle not found: {estimator_handle}"}
 
-    data_result = executor.load_dataset(dataset)
-    if not data_result["success"]:
-        return data_result
+    y_res = _resolve_y_source(executor, y)
+    if not y_res["success"]:
+        return y_res
+    _y = y_res["data"]
 
-    y = data_result["data"]
-    X = data_result.get("exog")
+    _X = None
+    if X:
+        x_res = _resolve_y_source(executor, X)
+        if not x_res["success"]:
+            return x_res
+        _X = x_res["data"]
+
+    scoring = None
+    if metric:
+        scoring = _resolve_metric_scoring(metric)
+        if scoring is None:
+            return {
+                "success": False,
+                "error": (
+                    f"Unknown metric: {metric}. "
+                    "Check available metrics with query_registry(task='metric')."
+                ),
+            }
 
     try:
-        n = len(y)
-        folds = max(1, min(int(cv_folds), max(1, n - 1)))
-        # Exactly `folds` backtest windows: train grows, last fold uses n-1 obs before last point.
-        initial_window = max(1, n - folds)
-        cv = ExpandingWindowSplitter(initial_window=initial_window, step_length=1, fh=[1])
-
-        results = evaluate(forecaster=instance, y=y, X=X, cv=cv)
-
-        # Convert index or objects to strings suitable for JSON output if needed
-        # We drop objects that are complex (like estimator instances themselves) from the output
-        if "estimator" in results.columns:
-            results = results.drop(columns=["estimator"])
-
-        metrics = results.to_dict(orient="records")
-
-        # Build per-metric summary (mean/std/min/max) over numeric columns only
-        numeric_cols = results.select_dtypes(include="number").columns.tolist()
-        summary = {
-            col: {
-                "mean": float(results[col].mean()),
-                "std": float(results[col].std()),
-                "min": float(results[col].min()),
-                "max": float(results[col].max()),
-            }
-            for col in numeric_cols
-        }
-
-        return {
-            "success": True,
-            "summary": summary,
-            "results": metrics,
-            "cv_folds_run": len(metrics),
-            "cv_folds_requested": int(cv_folds),
-        }
+        fold_results, metrics, summary = _run_evaluate(
+            instance, _y, _X, cv_folds, scoring, initial_window
+        )
     except Exception as e:
         logger.exception("Error during evaluate")
         return {"success": False, "error": str(e)}
+
+    return {
+        "success": True,
+        "metrics": metrics,
+        "fold_results": fold_results,
+        "summary": summary,
+        "cv_folds_run": len(fold_results),
+        "cv_folds_requested": cv_folds,
+    }

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -2,31 +2,20 @@
 Tests for evaluate tool.
 """
 
-import sys
-
 import pytest
+from sktime.forecasting.naive import NaiveForecaster
 
-sys.path.insert(0, "src")
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.tools.evaluate import evaluate_tool
 
 
 def test_evaluate_tool_basic():
     """evaluate_tool returns fold_results and summary for a simple forecaster."""
-    from sktime.forecasting.naive import NaiveForecaster
-
-    from sktime_mcp.runtime.executor import get_executor
-    from sktime_mcp.tools.evaluate import evaluate_tool
-
     executor = get_executor()
-
     handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
 
     try:
-        result = evaluate_tool(
-            estimator_handle=handle,
-            y="airline",
-            cv_folds=2,
-        )
-
+        result = evaluate_tool(estimator_handle=handle, y="airline", cv_folds=2)
         assert result["success"], f"Evaluate failed: {result.get('error')}"
         assert "fold_results" in result
         assert result["cv_folds_run"] == 2
@@ -34,18 +23,12 @@ def test_evaluate_tool_basic():
 
         metric_columns = [k for k in result["fold_results"][0] if "test_" in k]
         assert len(metric_columns) > 0
-
     finally:
         executor._handle_manager.release_handle(handle)
 
 
 def test_evaluate_with_metric():
     """evaluate_tool with explicit metric name."""
-    from sktime.forecasting.naive import NaiveForecaster
-
-    from sktime_mcp.runtime.executor import get_executor
-    from sktime_mcp.tools.evaluate import evaluate_tool
-
     executor = get_executor()
     handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
 
@@ -56,21 +39,14 @@ def test_evaluate_with_metric():
             cv_folds=2,
             metric="MeanAbsolutePercentageError",
         )
-
         assert result["success"], f"Evaluate with metric failed: {result.get('error')}"
         assert len(result["fold_results"]) == 2
-
     finally:
         executor._handle_manager.release_handle(handle)
 
 
 def test_evaluate_invalid_metric():
     """evaluate_tool with unknown metric returns error."""
-    from sktime.forecasting.naive import NaiveForecaster
-
-    from sktime_mcp.runtime.executor import get_executor
-    from sktime_mcp.tools.evaluate import evaluate_tool
-
     executor = get_executor()
     handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
 
@@ -81,39 +57,24 @@ def test_evaluate_invalid_metric():
             cv_folds=2,
             metric="NonexistentMetric",
         )
-
         assert not result["success"]
         assert "Unknown metric" in result["error"]
-
     finally:
         executor._handle_manager.release_handle(handle)
 
 
 def test_evaluate_with_data_handle():
     """evaluate_tool accepts y as a data_handle id."""
-    from sktime.forecasting.naive import NaiveForecaster
-
-    from sktime_mcp.runtime.executor import get_executor
-    from sktime_mcp.tools.evaluate import evaluate_tool
-
     executor = get_executor()
-
     data_res = executor.load_dataset("airline")
     assert data_res["success"]
     executor._data_handles["test_dh"] = {"y": data_res["data"]}
-
     handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
 
     try:
-        result = evaluate_tool(
-            estimator_handle=handle,
-            y="test_dh",
-            cv_folds=2,
-        )
-
+        result = evaluate_tool(estimator_handle=handle, y="test_dh", cv_folds=2)
         assert result["success"], f"Evaluate with data_handle failed: {result.get('error')}"
         assert len(result["fold_results"]) == 2
-
     finally:
         executor._handle_manager.release_handle(handle)
         executor._data_handles.pop("test_dh", None)
@@ -121,16 +82,11 @@ def test_evaluate_with_data_handle():
 
 def test_evaluate_initial_window_overrides_cv_folds():
     """When initial_window is set, cv_folds is ignored and folds equal n - initial_window."""
-    from sktime.forecasting.naive import NaiveForecaster
-
-    from sktime_mcp.runtime.executor import get_executor
-    from sktime_mcp.tools.evaluate import evaluate_tool
-
     executor = get_executor()
     handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
 
     try:
-        # airline has 144 obs; initial_window=140 => 4 expanding folds regardless of cv_folds
+        # airline has 144 obs; initial_window=140 gives 4 expanding folds regardless of cv_folds
         result = evaluate_tool(
             estimator_handle=handle,
             y="airline",
@@ -139,15 +95,12 @@ def test_evaluate_initial_window_overrides_cv_folds():
         )
         assert result["success"], f"Evaluate failed: {result.get('error')}"
         assert len(result["fold_results"]) == 4
-
     finally:
         executor._handle_manager.release_handle(handle)
 
 
 def test_evaluate_handle_not_found():
     """evaluate_tool returns a clear error when the estimator_handle is unknown."""
-    from sktime_mcp.tools.evaluate import evaluate_tool
-
     result = evaluate_tool(estimator_handle="does_not_exist", y="airline", cv_folds=2)
     assert not result["success"]
     assert "Handle not found" in result["error"]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -9,33 +9,148 @@ import pytest
 sys.path.insert(0, "src")
 
 
-def test_evaluate_estimator_tool():
-    """Test evaluate_estimator_tool with a simple estimator."""
+def test_evaluate_tool_basic():
+    """evaluate_tool returns fold_results and summary for a simple forecaster."""
     from sktime.forecasting.naive import NaiveForecaster
 
     from sktime_mcp.runtime.executor import get_executor
-    from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+    from sktime_mcp.tools.evaluate import evaluate_tool
 
     executor = get_executor()
 
-    # Create handle manually for the test
     handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
 
     try:
-        result = evaluate_estimator_tool(handle, "airline", cv_folds=2)
+        result = evaluate_tool(
+            estimator_handle=handle,
+            y="airline",
+            cv_folds=2,
+        )
 
         assert result["success"], f"Evaluate failed: {result.get('error')}"
-        assert "results" in result
+        assert "fold_results" in result
         assert result["cv_folds_run"] == 2
-        assert len(result["results"]) == 2
+        assert len(result["fold_results"]) == 2
 
-        # Verify result contains common metrics like test_MeanAbsolutePercentageError
-        metric_columns = [k for k in result["results"][0] if "test_" in k]
+        metric_columns = [k for k in result["fold_results"][0] if "test_" in k]
         assert len(metric_columns) > 0
 
     finally:
-        # Clean up
         executor._handle_manager.release_handle(handle)
+
+
+def test_evaluate_with_metric():
+    """evaluate_tool with explicit metric name."""
+    from sktime.forecasting.naive import NaiveForecaster
+
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.evaluate import evaluate_tool
+
+    executor = get_executor()
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+
+    try:
+        result = evaluate_tool(
+            estimator_handle=handle,
+            y="airline",
+            cv_folds=2,
+            metric="MeanAbsolutePercentageError",
+        )
+
+        assert result["success"], f"Evaluate with metric failed: {result.get('error')}"
+        assert len(result["fold_results"]) == 2
+
+    finally:
+        executor._handle_manager.release_handle(handle)
+
+
+def test_evaluate_invalid_metric():
+    """evaluate_tool with unknown metric returns error."""
+    from sktime.forecasting.naive import NaiveForecaster
+
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.evaluate import evaluate_tool
+
+    executor = get_executor()
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+
+    try:
+        result = evaluate_tool(
+            estimator_handle=handle,
+            y="airline",
+            cv_folds=2,
+            metric="NonexistentMetric",
+        )
+
+        assert not result["success"]
+        assert "Unknown metric" in result["error"]
+
+    finally:
+        executor._handle_manager.release_handle(handle)
+
+
+def test_evaluate_with_data_handle():
+    """evaluate_tool accepts y as a data_handle id."""
+    from sktime.forecasting.naive import NaiveForecaster
+
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.evaluate import evaluate_tool
+
+    executor = get_executor()
+
+    data_res = executor.load_dataset("airline")
+    assert data_res["success"]
+    executor._data_handles["test_dh"] = {"y": data_res["data"]}
+
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+
+    try:
+        result = evaluate_tool(
+            estimator_handle=handle,
+            y="test_dh",
+            cv_folds=2,
+        )
+
+        assert result["success"], f"Evaluate with data_handle failed: {result.get('error')}"
+        assert len(result["fold_results"]) == 2
+
+    finally:
+        executor._handle_manager.release_handle(handle)
+        executor._data_handles.pop("test_dh", None)
+
+
+def test_evaluate_initial_window_overrides_cv_folds():
+    """When initial_window is set, cv_folds is ignored and folds equal n - initial_window."""
+    from sktime.forecasting.naive import NaiveForecaster
+
+    from sktime_mcp.runtime.executor import get_executor
+    from sktime_mcp.tools.evaluate import evaluate_tool
+
+    executor = get_executor()
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+
+    try:
+        # airline has 144 obs; initial_window=140 => 4 expanding folds regardless of cv_folds
+        result = evaluate_tool(
+            estimator_handle=handle,
+            y="airline",
+            cv_folds=2,
+            initial_window=140,
+        )
+        assert result["success"], f"Evaluate failed: {result.get('error')}"
+        assert len(result["fold_results"]) == 4
+
+    finally:
+        executor._handle_manager.release_handle(handle)
+
+
+def test_evaluate_handle_not_found():
+    """evaluate_tool returns a clear error when the estimator_handle is unknown."""
+    from sktime_mcp.tools.evaluate import evaluate_tool
+
+    result = evaluate_tool(estimator_handle="does_not_exist", y="airline", cv_folds=2)
+    assert not result["success"]
+    assert "Handle not found" in result["error"]
 
 
 if __name__ == "__main__":

--- a/tests/test_evaluate_async.py
+++ b/tests/test_evaluate_async.py
@@ -1,0 +1,106 @@
+"""Tests for evaluate_tool async execution."""
+
+import asyncio
+
+import pytest
+from sktime.forecasting.naive import NaiveForecaster
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.runtime.jobs import JobStatus, get_job_manager
+from sktime_mcp.tools.evaluate import evaluate_tool
+
+
+async def _wait_for_job(job_manager, job_id: str, timeout: float = 30.0):
+    """Poll job status until terminal or timeout."""
+    deadline = int(timeout / 0.05)
+    for _ in range(deadline):
+        job = job_manager.get_job(job_id)
+        if job is not None and job.status in (JobStatus.COMPLETED, JobStatus.FAILED):
+            return job
+        await asyncio.sleep(0.05)
+    raise TimeoutError(f"Job {job_id} did not complete in {timeout}s")
+
+
+async def test_run_async_returns_job_id_and_completes():
+    """evaluate_tool(run_async=True) schedules a job that completes with the expected result."""
+    executor = get_executor()
+    job_manager = get_job_manager()
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+
+    try:
+        result = evaluate_tool(
+            estimator_handle=handle,
+            y="airline",
+            cv_folds=2,
+            run_async=True,
+        )
+        assert result["success"]
+        assert "job_id" in result
+        assert result["status"] == "running"
+
+        job = await _wait_for_job(job_manager, result["job_id"])
+        assert job.status is JobStatus.COMPLETED, job.errors
+        assert job.result is not None
+        assert "fold_results" in job.result
+        assert "metrics" in job.result
+        assert "summary" in job.result
+        assert len(job.result["fold_results"]) == 2
+
+    finally:
+        executor._handle_manager.release_handle(handle)
+
+
+async def test_evaluate_async_direct():
+    """executor.evaluate_async completes and returns fold_results, metrics, summary."""
+    executor = get_executor()
+    job_manager = get_job_manager()
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+    job_id = job_manager.create_job(
+        job_type="evaluate",
+        estimator_handle=handle,
+        estimator_name="NaiveForecaster",
+        total_steps=3,
+    )
+
+    try:
+        result = await executor.evaluate_async(
+            handle_id=handle,
+            y="airline",
+            cv_folds=2,
+            job_id=job_id,
+        )
+        assert result["success"]
+        assert "fold_results" in result
+        assert "metrics" in result
+        assert "summary" in result
+        assert len(result["fold_results"]) == 2
+
+    finally:
+        executor._handle_manager.release_handle(handle)
+
+
+async def test_evaluate_async_bad_handle():
+    """executor.evaluate_async surfaces a handle-not-found error on the job."""
+    executor = get_executor()
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job(
+        job_type="evaluate",
+        estimator_handle="does_not_exist",
+        estimator_name="Unknown",
+        total_steps=3,
+    )
+
+    result = await executor.evaluate_async(
+        handle_id="does_not_exist",
+        y="airline",
+        cv_folds=2,
+        job_id=job_id,
+    )
+    assert not result["success"]
+    assert "Handle not found" in result["error"]
+    job = job_manager.get_job(job_id)
+    assert job is not None and job.status is JobStatus.FAILED
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_evaluate_summary.py
+++ b/tests/test_evaluate_summary.py
@@ -1,4 +1,4 @@
-"""Tests for evaluate_estimator_tool summary statistics."""
+"""Tests for evaluate_tool summary statistics."""
 
 import sys
 
@@ -8,31 +8,31 @@ sys.path.insert(0, "src")
 
 
 class TestEvaluateSummary:
-    """Tests for the summary statistics added to evaluate_estimator_tool."""
+    """Tests for the summary statistics returned by evaluate_tool."""
 
     def test_evaluate_returns_summary_key(self):
-        """evaluate_estimator_tool result must include a 'summary' key."""
-        from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+        """evaluate_tool result must include a 'summary' key."""
+        from sktime_mcp.tools.evaluate import evaluate_tool
         from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 
         inst = instantiate_estimator_tool(spec="NaiveForecaster(strategy='last')")
         assert inst["success"], inst
         handle = inst["handle"]
 
-        result = evaluate_estimator_tool(handle, "airline", cv_folds=2)
+        result = evaluate_tool(estimator_handle=handle, y="airline", cv_folds=2)
         assert result["success"], result
         assert "summary" in result, "Expected 'summary' key in evaluate result"
 
     def test_summary_contains_expected_stat_keys(self):
         """Each metric in summary must have mean, std, min, max."""
-        from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+        from sktime_mcp.tools.evaluate import evaluate_tool
         from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 
         inst = instantiate_estimator_tool(spec="NaiveForecaster(strategy='last')")
         assert inst["success"], inst
         handle = inst["handle"]
 
-        result = evaluate_estimator_tool(handle, "airline", cv_folds=2)
+        result = evaluate_tool(estimator_handle=handle, y="airline", cv_folds=2)
         assert result["success"], result
 
         summary = result["summary"]
@@ -42,20 +42,18 @@ class TestEvaluateSummary:
         for metric_name, stats in summary.items():
             for key in ("mean", "std", "min", "max"):
                 assert key in stats, f"Expected '{key}' in summary['{metric_name}'], got {stats}"
-                assert isinstance(stats[key], float), (
-                    f"summary['{metric_name}']['{key}'] should be float, got {type(stats[key])}"
-                )
+                assert isinstance(stats[key], float), f"{metric_name}.{key} not float"
 
     def test_summary_mean_between_min_and_max(self):
         """Sanity check: mean must be between min and max for each metric."""
-        from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+        from sktime_mcp.tools.evaluate import evaluate_tool
         from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 
         inst = instantiate_estimator_tool(spec="NaiveForecaster(strategy='last')")
         assert inst["success"], inst
         handle = inst["handle"]
 
-        result = evaluate_estimator_tool(handle, "airline", cv_folds=3)
+        result = evaluate_tool(estimator_handle=handle, y="airline", cv_folds=3)
         assert result["success"], result
 
         for metric_name, stats in result["summary"].items():
@@ -64,17 +62,17 @@ class TestEvaluateSummary:
                 f"min={stats['min']}, mean={stats['mean']}, max={stats['max']}"
             )
 
-    def test_raw_results_still_present(self):
-        """The existing 'results' key must still be returned alongside 'summary'."""
-        from sktime_mcp.tools.evaluate import evaluate_estimator_tool
+    def test_fold_results_present(self):
+        """The 'fold_results' list must contain per-fold metric dicts."""
+        from sktime_mcp.tools.evaluate import evaluate_tool
         from sktime_mcp.tools.instantiate import instantiate_estimator_tool
 
         inst = instantiate_estimator_tool(spec="NaiveForecaster(strategy='last')")
         assert inst["success"], inst
         handle = inst["handle"]
 
-        result = evaluate_estimator_tool(handle, "airline", cv_folds=2)
+        result = evaluate_tool(estimator_handle=handle, y="airline", cv_folds=2)
         assert result["success"], result
-        assert "results" in result
-        assert isinstance(result["results"], list)
-        assert len(result["results"]) > 0
+        assert "fold_results" in result
+        assert isinstance(result["fold_results"], list)
+        assert len(result["fold_results"]) > 0


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #479

#### What does this implement/fix? Explain your changes.

Refactor of the CV tool to the unified evaluate signature from #479.

Tool renamed `evaluate_estimator` -> `evaluate`. New params: `y`, `X`, `cv_folds`, `metric`, `initial_window`, `run_async`. `y` and `X` accept a `data_handle` id or a demo dataset name. Async is a `run_async` flag on the same tool, matching the `fit_tool` pattern.

Shared CV pipeline (`_run_evaluate`) and metric registry lookup (`_resolve_metric_scoring`) live at `runtime/executor.py` so the sync path and `executor.evaluate_async` use one code path.

Removed the deprecated `evaluate_estimator` tool from the MCP surface, `tools/__init__.py` exports, README, and user-guide.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Metric registry lookup in `_resolve_metric_scoring`. Uses `all_estimators("metric", as_dataframe=True)` and returns `None` on unknown name so the tool can surface a clear error dict.
- Async job flow. Matches `fit_async`: create job in the tool, dispatch via `asyncio.create_task`, executor updates the job manager per step and stores the result on `COMPLETED`.
- `metrics` vs `summary` split. `metrics` is mean per `test_*` column, `summary` adds std/min/max. Both filter to `test_*` columns so timing rows do not pollute the top-line.

#### Any other comments?

`make check` is green locally, 193 tests pass. Pre-commit passes with the outdated `ruff` hook skipped since UP038 was removed in modern ruff and CI ruff is happy.

#### PR checklist

##### For all contributions
- [x] I've added unit tests and made sure they pass locally (`make check`).
- [x] I've added the tool to the online documentation in `docs/source/`.
- [ ] I've updated the existing example scripts or provided a new one to showcase how my tool works in `examples/`. n/a