### PR TITLE
feat: add offset pagination to list_jobs

### DIFF
--- a/src/sktime_mcp/runtime/jobs.py
+++ b/src/sktime_mcp/runtime/jobs.py
@@ -246,16 +246,21 @@ class JobManager:
         self,
         status: JobStatus | None = None,
         limit: int | None = None,
+        offset: int = 0,
     ) -> list[JobInfo]:
         """
-        List all jobs, optionally filtered by status.
+        List jobs, optionally filtered by status, with offset/limit pagination.
+
+        Jobs are ordered newest-first, then ``offset`` items are skipped and up
+        to ``limit`` are returned. Use ``count_jobs`` for the total page count.
 
         Args:
             status: Filter by status (None = all jobs)
-            limit: Maximum number of jobs to return
+            limit: Maximum number of jobs to return (None = no limit)
+            offset: Number of jobs to skip from the start of the ordered list
 
         Returns:
-            List of JobInfo objects
+            List of JobInfo objects for the requested page
         """
         with self.lock:
             jobs = list(self.jobs.values())
@@ -267,11 +272,20 @@ class JobManager:
             # Sort by creation time (newest first)
             jobs.sort(key=lambda j: j.created_at, reverse=True)
 
-            # Apply limit
+            # Apply pagination: skip `offset`, then take up to `limit`
+            if offset:
+                jobs = jobs[offset:]
             if limit is not None:
                 jobs = jobs[:limit]
 
             return jobs
+
+    def count_jobs(self, status: JobStatus | None = None) -> int:
+        """Return the total number of jobs matching an optional status filter."""
+        with self.lock:
+            if status is None:
+                return len(self.jobs)
+            return sum(1 for j in self.jobs.values() if j.status == status)
 
     def cancel_job(self, job_id: str) -> bool:
         """

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -898,8 +898,13 @@ async def list_tools() -> list[Tool]:
                     },
                     "limit": {
                         "type": "integer",
-                        "description": "Maximum number of jobs to return (default: 20)",
+                        "description": "Maximum number of jobs to return per page (default: 20)",
                         "default": 20,
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Number of jobs to skip for pagination (default: 0)",
+                        "default": 0,
                     },
                 },
             },
@@ -1150,6 +1155,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             result = list_jobs_tool(
                 arguments.get("status"),
                 arguments.get("limit", 20),
+                offset=arguments.get("offset", 0),
             )
 
         elif name == "cancel_job":

--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -40,16 +40,19 @@ def check_job_status_tool(job_id: str) -> dict[str, Any]:
 def list_jobs_tool(
     status: str | None = None,
     limit: int = 20,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """
-    List all background jobs.
+    List background jobs with offset/limit pagination.
 
     Args:
         status: Filter by status (pending, running, completed, failed, cancelled)
-        limit: Maximum number of jobs to return
+        limit: Maximum number of jobs to return in this page
+        offset: Number of jobs to skip (for paging through results)
 
     Returns:
-        Dictionary with list of jobs
+        Dictionary with the page of jobs plus pagination metadata
+        (total, offset, limit, has_more).
     """
     job_manager = get_job_manager()
 
@@ -78,11 +81,22 @@ def list_jobs_tool(
             "error": "limit must be a positive integer.",
         }
 
-    jobs = job_manager.list_jobs(status=status_filter, limit=limit)
+    if offset < 0:
+        return {
+            "success": False,
+            "error": "offset must be a non-negative integer.",
+        }
+
+    total = job_manager.count_jobs(status=status_filter)
+    jobs = job_manager.list_jobs(status=status_filter, limit=limit, offset=offset)
 
     return {
         "success": True,
         "count": len(jobs),
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "has_more": offset + len(jobs) < total,
         "jobs": [job.to_dict() for job in jobs],
     }
 

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -115,6 +115,59 @@ def test_list_jobs():
     job_manager.delete_job(job3)
 
 
+def test_list_jobs_offset_slicing():
+    """JobManager.list_jobs offset/limit returns the correct newest-first slice."""
+    job_manager = get_job_manager()
+    ids = [job_manager.create_job("fit", f"off{i}", "ARIMA") for i in range(4)]
+
+    try:
+        newest_first = job_manager.list_jobs()
+        first_two = job_manager.list_jobs(limit=2, offset=0)
+        next_two = job_manager.list_jobs(limit=2, offset=2)
+
+        assert [j.job_id for j in first_two] == [j.job_id for j in newest_first[:2]]
+        assert [j.job_id for j in next_two] == [j.job_id for j in newest_first[2:4]]
+        # first and second page must not overlap
+        assert {j.job_id for j in first_two}.isdisjoint({j.job_id for j in next_two})
+    finally:
+        for jid in ids:
+            job_manager.delete_job(jid)
+
+
+def test_list_jobs_tool_pagination_metadata():
+    """list_jobs_tool reports total/offset/limit/has_more and paginates disjointly."""
+    from sktime_mcp.tools.job_tools import list_jobs_tool
+
+    job_manager = get_job_manager()
+    ids = [job_manager.create_job("fit", f"pg{i}", "ARIMA") for i in range(5)]
+
+    try:
+        page1 = list_jobs_tool(limit=2, offset=0)
+        assert page1["success"]
+        assert page1["limit"] == 2
+        assert page1["offset"] == 0
+        assert page1["count"] == 2
+        assert page1["total"] >= 5
+        assert page1["has_more"] is True
+
+        page2 = list_jobs_tool(limit=2, offset=2)
+        assert page2["offset"] == 2
+        assert page2["count"] == 2
+        assert {j["job_id"] for j in page1["jobs"]}.isdisjoint({j["job_id"] for j in page2["jobs"]})
+
+        # Offset beyond the end yields an empty page with has_more False
+        beyond = list_jobs_tool(limit=2, offset=page1["total"] + 10)
+        assert beyond["count"] == 0
+        assert beyond["has_more"] is False
+
+        # Negative offset is rejected
+        bad = list_jobs_tool(offset=-1)
+        assert not bad["success"]
+    finally:
+        for jid in ids:
+            job_manager.delete_job(jid)
+
+
 def test_cancel_job():
     """Test cancelling a job."""
     job_manager = get_job_manager()


### PR DESCRIPTION
list_jobs previously supported only a top-N `limit`, so there was no way to page past the first N jobs. Adds an `offset` parameter (JobManager.list_jobs, list_jobs_tool, and the MCP schema) plus a JobManager.count_jobs helper.

list_jobs_tool now returns pagination metadata alongside the page: total, offset, limit, and has_more. Offset is validated as non-negative.

Adds tests for offset slicing (newest-first, disjoint pages) and the tool-level pagination metadata / beyond-end / negative-offset cases.

Part of #481 (Phase 7), task P7-1.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime-mcp/blob/main/docs/source/dev-guide.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package to keep external dependencies of the core sktime-mcp package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added unit tests and made sure they pass locally (`make check`).

- [ ] I've added the tool to the online documentation in `docs/source/`.
- [ ] I've updated the existing example scripts or provided a new one to showcase how my tool works in `examples/`.


<!--
Thanks for contributing!
-->
