### PR TITLE
feat: retain background task refs and make cancel_job actually cancel

### DIFF
--- a/src/sktime_mcp/runtime/jobs.py
+++ b/src/sktime_mcp/runtime/jobs.py
@@ -4,12 +4,15 @@ Job management for long-running operations in sktime MCP.
 Handles background training jobs with progress tracking and status updates.
 """
 
+import logging
 import threading
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class JobStatus(Enum):
@@ -127,6 +130,10 @@ class JobManager:
 
     def __init__(self):
         self.jobs: dict[str, JobInfo] = {}
+        # Retained references to the background asyncio tasks running each job,
+        # so cancel_job can actually cancel the running coroutine (not just flip
+        # the status). Keyed by job_id.
+        self._tasks: dict[str, Any] = {}
         self.lock = threading.Lock()
 
     def create_job(
@@ -166,6 +173,29 @@ class JobManager:
             )
 
         return job_id
+
+    def register_task(self, job_id: str, task: Any) -> None:
+        """Associate a background asyncio task with a job.
+
+        Retaining the task reference lets ``cancel_job`` cancel the running
+        coroutine, and prevents the event loop from garbage-collecting a
+        still-pending task. A done callback clears the reference and surfaces
+        any exception that would otherwise be swallowed by fire-and-forget.
+        """
+        with self.lock:
+            self._tasks[job_id] = task
+        task.add_done_callback(lambda t: self._on_task_done(job_id, t))
+
+    def _on_task_done(self, job_id: str, task: Any) -> None:
+        """Done callback: drop the task reference and log unhandled errors."""
+        with self.lock:
+            self._tasks.pop(job_id, None)
+        # A cancelled task raises on .exception(); nothing to report there.
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("Background job %s failed with an unhandled exception: %r", job_id, exc)
 
     def update_job(
         self,
@@ -282,6 +312,13 @@ class JobManager:
 
         Returns:
             True if job was cancelled, False if not found or already completed
+
+        Notes:
+            Cancellation is cooperative. The background task is cancelled at its
+            next await point, which stops any remaining job steps. Work already
+            running inside a thread-pool executor (e.g. a single fit call) cannot
+            be force-killed and runs to completion, but its result is discarded
+            because update_job ignores late updates on a CANCELLED job.
         """
         with self.lock:
             if job_id not in self.jobs:
@@ -290,12 +327,18 @@ class JobManager:
             job = self.jobs[job_id]
 
             # Can only cancel pending or running jobs
-            if job.status in (JobStatus.PENDING, JobStatus.RUNNING):
-                job.status = JobStatus.CANCELLED
-                job.end_time = datetime.now()
-                return True
+            if job.status not in (JobStatus.PENDING, JobStatus.RUNNING):
+                return False
 
-            return False
+            job.status = JobStatus.CANCELLED
+            job.end_time = datetime.now()
+            task = self._tasks.get(job_id)
+
+        # Cancel outside the lock: the task's done callback also takes the lock.
+        if task is not None and not task.done():
+            task.cancel()
+
+        return True
 
     def cleanup_old_jobs(self, max_age_hours: int = 24) -> int:
         """
@@ -314,6 +357,7 @@ class JobManager:
 
             for job_id in old_job_ids:
                 del self.jobs[job_id]
+                self._tasks.pop(job_id, None)
 
             return len(old_job_ids)
 
@@ -330,6 +374,7 @@ class JobManager:
         with self.lock:
             if job_id in self.jobs:
                 del self.jobs[job_id]
+                self._tasks.pop(job_id, None)
                 return True
             return False
 

--- a/src/sktime_mcp/tools/data_tools.py
+++ b/src/sktime_mcp/tools/data_tools.py
@@ -98,7 +98,8 @@ def load_data_source_tool(
         # Schedule the async coroutine on the event loop
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(coro)
+            task = loop.create_task(coro)
+            job_manager.register_task(job_id, task)
         except RuntimeError:
             # No running event loop (e.g. sync test or CLI environment)
             loop = asyncio.new_event_loop()

--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -45,7 +45,7 @@ def evaluate_tool(
             dataset_name=y,
             total_steps=3,
         )
-        asyncio.create_task(
+        task = asyncio.create_task(
             executor.evaluate_async(
                 handle_id=estimator_handle,
                 y=y,
@@ -56,6 +56,7 @@ def evaluate_tool(
                 job_id=job_id,
             )
         )
+        job_manager.register_task(job_id, task)
         return {"success": True, "job_id": job_id, "status": "running"}
 
     try:

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -108,7 +108,7 @@ def fit_tool(
             dataset_name=source_name,
             total_steps=2,
         )
-        asyncio.create_task(
+        task = asyncio.create_task(
             executor.fit_async(
                 handle_id=estimator_handle,
                 X_dataset=X_dataset,
@@ -119,6 +119,7 @@ def fit_tool(
                 job_id=job_id,
             )
         )
+        job_manager.register_task(job_id, task)
         return {"success": True, "job_id": job_id, "status": "running"}
     fit_result = executor.fit(estimator_handle, y=y, X=X, fh=fh)
 
@@ -178,7 +179,7 @@ def predict_tool(
             horizon=horizon,
             total_steps=2,
         )
-        asyncio.create_task(
+        task = asyncio.create_task(
             executor.predict_async(
                 handle_id=estimator_handle,
                 horizon=horizon,
@@ -192,6 +193,7 @@ def predict_tool(
                 job_id=job_id,
             )
         )
+        job_manager.register_task(job_id, task)
         return {"success": True, "job_id": job_id, "status": "running"}
 
     X = None

--- a/tests/test_job_cancellation.py
+++ b/tests/test_job_cancellation.py
@@ -1,0 +1,88 @@
+"""Tests for real background-job cancellation and task retention (X-4 + P7-2)."""
+
+import asyncio
+
+import pytest
+
+from sktime_mcp.runtime.jobs import JobStatus, get_job_manager
+
+
+async def test_cancel_job_cancels_registered_task():
+    """cancel_job cancels the running asyncio task, not just the status."""
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job("fit", "handle", "ARIMA")
+    job_manager.update_job(job_id, status=JobStatus.RUNNING)
+
+    started = asyncio.Event()
+
+    async def long_running():
+        started.set()
+        await asyncio.sleep(60)  # long enough to be cancelled mid-flight
+
+    task = asyncio.create_task(long_running())
+    job_manager.register_task(job_id, task)
+    await started.wait()
+
+    assert job_manager.cancel_job(job_id) is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task.cancelled()
+    assert job_manager.get_job(job_id).status is JobStatus.CANCELLED
+
+    job_manager.delete_job(job_id)
+
+
+async def test_task_reference_cleared_on_completion():
+    """The retained task reference is dropped once the task finishes."""
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job("fit", "handle", "ARIMA")
+
+    async def quick():
+        return "done"
+
+    task = asyncio.create_task(quick())
+    job_manager.register_task(job_id, task)
+    assert job_id in job_manager._tasks
+
+    await task
+    await asyncio.sleep(0)  # let the done callback run
+
+    assert job_id not in job_manager._tasks
+    job_manager.delete_job(job_id)
+
+
+async def test_task_exception_is_surfaced(caplog):
+    """A fire-and-forget task exception is logged instead of silently swallowed."""
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job("fit", "handle", "ARIMA")
+
+    async def boom():
+        raise ValueError("kaboom")
+
+    task = asyncio.create_task(boom())
+    job_manager.register_task(job_id, task)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(ValueError):
+            await task
+        await asyncio.sleep(0)  # let the done callback run
+
+    assert "kaboom" in caplog.text
+    job_manager.delete_job(job_id)
+
+
+async def test_cancel_completed_job_returns_false():
+    """A job that already finished cannot be cancelled."""
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job("fit", "handle", "ARIMA")
+    job_manager.update_job(job_id, status=JobStatus.COMPLETED)
+
+    assert job_manager.cancel_job(job_id) is False
+
+    job_manager.delete_job(job_id)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Previously async jobs were dispatched with fire-and-forget asyncio.create_task whose handles were discarded, so cancel_job could only flip the status while the coroutine kept running, and unhandled task exceptions were silently swallowed (and pending tasks risked GC).

X-4: JobManager now retains each job's task via register_task(job_id, task), with a done callback that clears the reference and logs any unhandled exception. All four dispatch sites register their task (fit, predict, evaluate, async data loading).

P7-2: cancel_job now cancels the retained task (outside the manager lock to avoid re-entrancy with the done callback). Cancellation is cooperative — the coroutine stops at its next await, halting remaining job steps; in-flight thread-pool work runs to completion but its result is discarded because update_job ignores late updates on a CANCELLED job. delete_job and cleanup_old_jobs also drop task references.

Adds tests/test_job_cancellation.py: real task cancellation, reference cleanup on completion, exception surfacing, and cancel-of-completed-job.

Part of #481 (Phase 7) task P7-2 and cross-cutting task X-4.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime-mcp/blob/main/docs/source/dev-guide.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package to keep external dependencies of the core sktime-mcp package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added unit tests and made sure they pass locally (`make check`).

- [ ] I've added the tool to the online documentation in `docs/source/`.
- [ ] I've updated the existing example scripts or provided a new one to showcase how my tool works in `examples/`.


<!--
Thanks for contributing!
-->
