### PR TITLE
fix: support multi-series X for aligner fit

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -55,6 +55,34 @@ def _get_demo_datasets() -> dict:
     return _DEMO_DATASETS
 
 
+def _as_frame(obj: Any) -> Any:
+    """Series → one-column DataFrame for df-list items."""
+    if isinstance(obj, pd.Series):
+        return obj.to_frame()
+    return obj
+
+
+def _is_single_series_table(obj: Any) -> bool:
+    """True for a lone Series or flat DataFrame (not a MultiIndex panel)."""
+    if isinstance(obj, pd.Series):
+        return True
+    return isinstance(obj, pd.DataFrame) and not isinstance(obj.index, pd.MultiIndex)
+
+
+def _dataset_slot(data_res: dict[str, Any], slot: str) -> Any:
+    """Pick y or X from a load_dataset result. X falls back to y when absent."""
+    if slot == "X":
+        return data_res["X"] if data_res["X"] is not None else data_res["y"]
+    return data_res["y"]
+
+
+_ALIGNER_NEED_LIST_MSG = (
+    "Aligners require multiple series as X, not a single series/table. "
+    "Pass X_handle or X_dataset as a list of at least two ids."
+)
+_X_LIST_MIN_MSG = "X as a list needs at least two series."
+
+
 def _to_period_index_if_possible(obj: Any) -> Any:
     """Return *obj* with a ``PeriodIndex`` when its index is a regular datetime index.
 
@@ -138,7 +166,7 @@ def _get_index_frequency_metadata(
     fallback: str | None = None,
 ) -> str | None:
     """Return a stable frequency label for metadata without assuming datetime-only indexes."""
-    if isinstance(index, (pd.DatetimeIndex, pd.PeriodIndex)):
+    if isinstance(index, pd.DatetimeIndex | pd.PeriodIndex):
         freq = getattr(index, "freq", None)
         if freq is not None:
             return str(freq)
@@ -213,9 +241,7 @@ def _run_evaluate(
 
     # error_score="raise" — sktime's default (np.nan) swallows per-fold
     # exceptions and reports success with all-NaN metrics
-    results = evaluate(
-        forecaster=instance, y=y, X=X, cv=cv, scoring=scoring, error_score="raise"
-    )
+    results = evaluate(forecaster=instance, y=y, X=X, cv=cv, scoring=scoring, error_score="raise")
     if "estimator" in results.columns:
         results = results.drop(columns=["estimator"])
 
@@ -282,7 +308,9 @@ class Executor:
         for handle_id in to_remove:
             del self._data_handles[handle_id]
             self._evicted_data.append(handle_id)
-            logger.info("Evicted data handle %s (limit %d reached)", handle_id, self._max_data_handles)
+            logger.info(
+                "Evicted data handle %s (limit %d reached)", handle_id, self._max_data_handles
+            )
 
     def data_handle_missing(self, handle_id: str) -> dict[str, Any]:
         """Error body for a missing data handle — distinguishes evicted from unknown.
@@ -332,6 +360,94 @@ class Executor:
             data = res[first] if res[first] is not None else res[second]
             return {"success": True, "data": data}
         return res
+
+    def _resolve_x_slot(self, ref: str | list[str], *, kind: str) -> dict[str, Any]:
+        """Resolve X from a handle/dataset id, or a list of ids as df-list."""
+        if isinstance(ref, list):
+            if len(ref) < 2:
+                return {"success": False, "error": _X_LIST_MIN_MSG}
+            items: list[Any] = []
+            for item in ref:
+                if not isinstance(item, str):
+                    return {
+                        "success": False,
+                        "error": f"X list items must be strings, got {type(item).__name__}",
+                    }
+                if kind == "handle":
+                    if item not in self._data_handles:
+                        return {
+                            "success": False,
+                            "error": f"Unknown X data handle: {item}",
+                        }
+                    items.append(_as_frame(self._data_handles[item]["y"]))
+                else:
+                    data_res = self.load_dataset(item)
+                    if not data_res["success"]:
+                        return data_res
+                    items.append(_as_frame(_dataset_slot(data_res, "X")))
+            return {"success": True, "data": items}
+
+        if kind == "handle":
+            if ref not in self._data_handles:
+                return {"success": False, "error": f"Unknown X data handle: {ref}"}
+            return {"success": True, "data": self._data_handles[ref]["y"]}
+
+        data_res = self.load_dataset(ref)
+        if not data_res["success"]:
+            return data_res
+        return {"success": True, "data": _dataset_slot(data_res, "X")}
+
+    def _resolve_fit_inputs(
+        self,
+        X_handle: str | list[str] | None = None,
+        y_handle: str | None = None,
+        X_dataset: str | list[str] | None = None,
+        y_dataset: str | None = None,
+    ) -> dict[str, Any]:
+        """Resolve fit X/y from handles and demo dataset names."""
+        X: Any = None
+        y: Any = None
+
+        if X_handle is not None:
+            res = self._resolve_x_slot(X_handle, kind="handle")
+            if not res["success"]:
+                return res
+            X = res["data"]
+
+        if y_handle is not None:
+            if y_handle not in self._data_handles:
+                return {"success": False, "error": f"Unknown y data handle: {y_handle}"}
+            y = self._data_handles[y_handle]["y"]
+
+        if isinstance(X_dataset, list):
+            res = self._resolve_x_slot(X_dataset, kind="dataset")
+            if not res["success"]:
+                return res
+            X = res["data"]
+            if y_dataset:
+                data_res = self.load_dataset(y_dataset)
+                if not data_res["success"]:
+                    return data_res
+                y = data_res["y"]
+        elif X_dataset and X_dataset == y_dataset:
+            data_res = self.load_dataset(X_dataset)
+            if not data_res["success"]:
+                return data_res
+            y = data_res["y"]
+            X = data_res["X"]
+        else:
+            if X_dataset:
+                res = self._resolve_x_slot(X_dataset, kind="dataset")
+                if not res["success"]:
+                    return res
+                X = res["data"]
+            if y_dataset:
+                data_res = self.load_dataset(y_dataset)
+                if not data_res["success"]:
+                    return data_res
+                y = data_res["y"]
+
+        return {"success": True, "X": X, "y": y}
 
     def instantiate(
         self,
@@ -522,6 +638,12 @@ class Executor:
                     instance.fit(X, y)
                 else:
                     instance.fit(X)
+            elif obj_type == "aligner":
+                # BaseAligner.fit(X, Z=None) - X is panel / df-list
+                panel = X if X is not None else y
+                if panel is None or _is_single_series_table(panel):
+                    return {"success": False, "error": _ALIGNER_NEED_LIST_MSG}
+                instance.fit(panel)
             else:
                 # Assume forecaster or similar default
                 if fh is not None:
@@ -778,7 +900,6 @@ class Executor:
             return result
 
         except Exception as e:
-
             self._job_manager.update_job(
                 job_id,
                 status=JobStatus.FAILED,
@@ -823,35 +944,70 @@ class Executor:
         try:
             method = getattr(instance, method_name)
 
-            # Map data_handle and dataset from kwargs if they exist
-            # This allows the LLM to pass 'dataset': 'airline' and we inject the actual data
+            # Inject *_dataset / *_data_handle (str or list of str for multi-series X)
             for k, v in list(kwargs.items()):
-                if k.endswith("_dataset") and isinstance(v, str):
-                    data_res = self.load_dataset(v)
-                    if not data_res.get("success"):
-                        error_res = {
-                            "success": False,
-                            "error": data_res.get("error", f"Unknown dataset: {v}"),
-                        }
-                        if "available" in data_res:
-                            error_res["available"] = data_res["available"]
-                        return error_res
-                    # Replace the kwarg with the actual data (e.g. y_dataset -> y);
-                    # the prefix selects the dataset component
+                if k.endswith("_dataset"):
                     actual_key = k.replace("_dataset", "")
-                    if actual_key == "X":
-                        value = data_res["X"] if data_res["X"] is not None else data_res["y"]
-                    else:
-                        value = data_res["y"]
-                    kwargs[actual_key] = value
-                    del kwargs[k]
-                elif k.endswith("_data_handle") and isinstance(v, str):
-                    if v in self._data_handles:
-                        actual_key = k.replace("_data_handle", "")
-                        kwargs[actual_key] = self._data_handles[v]["y"]
+                    if isinstance(v, list):
+                        if len(v) < 2:
+                            return {"success": False, "error": _X_LIST_MIN_MSG}
+                        items: list[Any] = []
+                        for name in v:
+                            if not isinstance(name, str):
+                                return {
+                                    "success": False,
+                                    "error": (
+                                        f"X list items must be strings, got {type(name).__name__}"
+                                    ),
+                                }
+                            data_res = self.load_dataset(name)
+                            if not data_res.get("success"):
+                                error_res = {
+                                    "success": False,
+                                    "error": data_res.get("error", f"Unknown dataset: {name}"),
+                                }
+                                if "available" in data_res:
+                                    error_res["available"] = data_res["available"]
+                                return error_res
+                            items.append(_as_frame(_dataset_slot(data_res, actual_key)))
+                        kwargs[actual_key] = items
                         del kwargs[k]
-                    else:
-                        return {"success": False, "error": f"Unknown data handle: {v}"}
+                    elif isinstance(v, str):
+                        data_res = self.load_dataset(v)
+                        if not data_res.get("success"):
+                            error_res = {
+                                "success": False,
+                                "error": data_res.get("error", f"Unknown dataset: {v}"),
+                            }
+                            if "available" in data_res:
+                                error_res["available"] = data_res["available"]
+                            return error_res
+                        kwargs[actual_key] = _dataset_slot(data_res, actual_key)
+                        del kwargs[k]
+                elif k.endswith("_data_handle"):
+                    actual_key = k.replace("_data_handle", "")
+                    if isinstance(v, list):
+                        if len(v) < 2:
+                            return {"success": False, "error": _X_LIST_MIN_MSG}
+                        items = []
+                        for hid in v:
+                            if hid not in self._data_handles:
+                                return {
+                                    "success": False,
+                                    "error": f"Unknown data handle: {hid}",
+                                }
+                            items.append(_as_frame(self._data_handles[hid]["y"]))
+                        kwargs[actual_key] = items
+                        del kwargs[k]
+                    elif isinstance(v, str):
+                        if v in self._data_handles:
+                            kwargs[actual_key] = self._data_handles[v]["y"]
+                            del kwargs[k]
+                        else:
+                            return {
+                                "success": False,
+                                "error": f"Unknown data handle: {v}",
+                            }
 
             result = method(**kwargs)
 
@@ -945,9 +1101,9 @@ class Executor:
     async def fit_async(
         self,
         handle_id: str,
-        X_dataset: str | None = None,
+        X_dataset: str | list[str] | None = None,
         y_dataset: str | None = None,
-        X_handle: str | None = None,
+        X_handle: str | list[str] | None = None,
         y_handle: str | None = None,
         fh: Any | None = None,
         job_id: str | None = None,
@@ -969,37 +1125,16 @@ class Executor:
             )
             await asyncio.sleep(0.01)
 
-            X = None
-            y = None
-
-            if X_handle:
-                if X_handle not in self._data_handles:
-                    raise ValueError(f"Unknown X data handle: {X_handle}")
-                X = self._data_handles[X_handle]["y"]
-
-            if y_handle:
-                if y_handle not in self._data_handles:
-                    raise ValueError(f"Unknown y data handle: {y_handle}")
-                y = self._data_handles[y_handle]["y"]
-
-            if X_dataset and X_dataset == y_dataset:
-                data_res = self.load_dataset(X_dataset)
-                if not data_res["success"]:
-                    raise ValueError(data_res["error"])
-                y = data_res["y"]
-                X = data_res["X"]
-            else:
-                if X_dataset:
-                    data_res = self.load_dataset(X_dataset)
-                    if not data_res["success"]:
-                        raise ValueError(data_res["error"])
-                    X = data_res["X"] if data_res["X"] is not None else data_res["y"]
-
-                if y_dataset:
-                    data_res = self.load_dataset(y_dataset)
-                    if not data_res["success"]:
-                        raise ValueError(data_res["error"])
-                    y = data_res["y"]
+            resolved = self._resolve_fit_inputs(
+                X_handle=X_handle,
+                y_handle=y_handle,
+                X_dataset=X_dataset,
+                y_dataset=y_dataset,
+            )
+            if not resolved["success"]:
+                raise ValueError(resolved["error"])
+            X = resolved["X"]
+            y = resolved["y"]
 
             # Step 2: Fit model
             self._job_manager.update_job(
@@ -1022,7 +1157,7 @@ class Executor:
             if not fit_result["success"]:
                 raise ValueError(fit_result["error"])
 
-            if X_dataset or y_dataset:
+            if y_dataset or (isinstance(X_dataset, str) and X_dataset):
                 try:
                     handle_info = self._handle_manager.get_info(handle_id)
                     handle_info.metadata["training_dataset"] = y_dataset or X_dataset
@@ -1039,7 +1174,6 @@ class Executor:
             return {"success": True, "handle": handle_id}
 
         except Exception as e:
-
             from sktime_mcp.runtime.jobs import JobStatus
 
             self._job_manager.update_job(
@@ -1131,7 +1265,6 @@ class Executor:
             return result
 
         except Exception as e:
-
             self._job_manager.update_job(
                 job_id,
                 status=JobStatus.FAILED,
@@ -1436,7 +1569,7 @@ class Executor:
         if auto_infer_freq:
             freq = getattr(y.index, "freq", None)
 
-            if freq is None and isinstance(y.index, (pd.DatetimeIndex, pd.PeriodIndex)):
+            if freq is None and isinstance(y.index, pd.DatetimeIndex | pd.PeriodIndex):
                 # Try to infer
                 freq = pd.infer_freq(y.index)
 

--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -159,8 +159,8 @@ def sanitize_for_json(obj, _seen=None):
     if _seen is None:
         _seen = set()
 
-    if isinstance(obj, (dict, list, tuple)) or (
-        _PANDAS_AVAILABLE and isinstance(obj, (pd.Series, pd.DataFrame))
+    if isinstance(obj, dict | list | tuple) or (
+        _PANDAS_AVAILABLE and isinstance(obj, pd.Series | pd.DataFrame)
     ):
         obj_id = id(obj)
         if obj_id in _seen:
@@ -200,11 +200,11 @@ def sanitize_for_json(obj, _seen=None):
     # --- Standard Python containers ---
     if isinstance(obj, dict):
         return {str(k): sanitize_for_json(v, _seen) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
+    if isinstance(obj, list | tuple):
         return [sanitize_for_json(item, _seen) for item in obj]
 
     # --- Already JSON-safe scalars ---
-    if isinstance(obj, (str, int, float, bool, type(None))):
+    if isinstance(obj, str | int | float | bool | type(None)):
         return obj
 
     # --- Fallback: objects with __dict__ or anything else ---
@@ -325,7 +325,8 @@ async def list_tools() -> list[Tool]:
             name="fit",
             description=(
                 "Fit an estimator on data. "
-                "Provide explicit X_handle and/y_handle (or datasets) depending on the estimator's scitype."
+                "Provide X_handle/y_handle or datasets for the estimator scitype. "
+                "For multi-series X (aligners), pass X_handle or X_dataset as a list."
             ),
             inputSchema={
                 "type": "object",
@@ -335,16 +336,30 @@ async def list_tools() -> list[Tool]:
                         "description": "Handle from instantiate",
                     },
                     "X_handle": {
-                        "type": "string",
-                        "description": "Optional: Handle from load_data_source for X data (features, panel, etc.)",
+                        "description": "Data handle for X, or list of handles for multi-series X",
+                        "anyOf": [
+                            {"type": "string"},
+                            {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 2,
+                            },
+                        ],
                     },
                     "y_handle": {
                         "type": "string",
                         "description": "Optional: Handle from load_data_source for y data (target, labels, etc.)",
                     },
                     "X_dataset": {
-                        "type": "string",
-                        "description": "Optional: Demo dataset name for X data",
+                        "description": "Demo dataset name for X, or list of names for multi-series X",
+                        "anyOf": [
+                            {"type": "string"},
+                            {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 2,
+                            },
+                        ],
                     },
                     "y_dataset": {
                         "type": "string",
@@ -492,8 +507,11 @@ async def list_tools() -> list[Tool]:
                     },
                     "kwargs": {
                         "type": "object",
-                        "description": "Dictionary of keyword arguments to pass to the method. "
-                        "Pass '_dataset' or '_data_handle' as suffixes in keys to inject memory data (e.g., {'y_dataset': 'airline'}).",
+                        "description": (
+                            "Keyword args for the method. Use '_dataset' or '_data_handle' "
+                            "suffixes to inject data (e.g. {'y_dataset': 'airline'} or "
+                            "{'X_data_handle': ['h1', 'h2']})."
+                        ),
                     },
                 },
                 "required": ["handle_id", "method_name"],

--- a/src/sktime_mcp/tools/fit_predict.py
+++ b/src/sktime_mcp/tools/fit_predict.py
@@ -39,50 +39,15 @@ def _validate_horizon(horizon: Any) -> dict[str, Any]:
 
 def fit_tool(
     estimator_handle: str,
-    X_dataset: str | None = None,
+    X_dataset: str | list[str] | None = None,
     y_dataset: str | None = None,
-    X_handle: str | None = None,
+    X_handle: str | list[str] | None = None,
     y_handle: str | None = None,
     fh: Any | None = None,
     run_async: bool = False,
 ) -> dict[str, Any]:
-    """
-    Fit an estimator on data.
-    """
+    """Fit an estimator. X_handle/X_dataset may be a list for multi-series X."""
     executor = get_executor()
-
-    # We must resolve y and X from the provided handles/datasets
-    X = None
-    y = None
-
-    if X_handle:
-        if X_handle not in executor._data_handles:
-            return {"success": False, "error": f"Unknown X data handle: {X_handle}"}
-        X = executor._data_handles[X_handle]["y"]  # 'y' stores the primary object
-
-    if y_handle:
-        if y_handle not in executor._data_handles:
-            return {"success": False, "error": f"Unknown y data handle: {y_handle}"}
-        y = executor._data_handles[y_handle]["y"]
-
-    if X_dataset and X_dataset == y_dataset:
-        data_res = executor.load_dataset(X_dataset)
-        if not data_res["success"]:
-            return data_res
-        y = data_res["y"]
-        X = data_res["X"]
-    else:
-        if X_dataset:
-            data_res = executor.load_dataset(X_dataset)
-            if not data_res["success"]:
-                return data_res
-            X = data_res["X"] if data_res["X"] is not None else data_res["y"]
-
-        if y_dataset:
-            data_res = executor.load_dataset(y_dataset)
-            if not data_res["success"]:
-                return data_res
-            y = data_res["y"]
 
     if run_async:
         import asyncio
@@ -117,7 +82,17 @@ def fit_tool(
         )
         job_manager.register_task(job_id, task)
         return {"success": True, "job_id": job_id, "status": "running"}
-    fit_result = executor.fit(estimator_handle, y=y, X=X, fh=fh)
+
+    resolved = executor._resolve_fit_inputs(
+        X_handle=X_handle,
+        y_handle=y_handle,
+        X_dataset=X_dataset,
+        y_dataset=y_dataset,
+    )
+    if not resolved["success"]:
+        return resolved
+
+    fit_result = executor.fit(estimator_handle, y=resolved["y"], X=resolved["X"], fh=fh)
 
     if fit_result.get("success") and y_dataset:
         try:

--- a/tests/test_aligner_fit.py
+++ b/tests/test_aligner_fit.py
@@ -1,0 +1,239 @@
+"""Tests for aligner fit with multi-series X (issue #491)."""
+
+import asyncio
+
+from sktime.datasets import load_airline
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.runtime.jobs import JobStatus, get_job_manager
+from sktime_mcp.tools.fit_predict import fit_tool
+from sktime_mcp.tools.instantiate import instantiate_tool
+
+
+async def _wait_for_job(job_manager, job_id: str, timeout: float = 30.0):
+    deadline = int(timeout / 0.05)
+    for _ in range(deadline):
+        job = job_manager.get_job(job_id)
+        if job is not None and job.status in (JobStatus.COMPLETED, JobStatus.FAILED):
+            return job
+        await asyncio.sleep(0.05)
+    raise TimeoutError(f"Job {job_id} did not complete in {timeout}s")
+
+
+def _two_airline_handles(executor):
+    y = load_airline()
+    h1, h2 = "data_align_a", "data_align_b"
+    executor._register_data_handle(h1, {"y": y.iloc[:60], "X": None, "metadata": {}})
+    executor._register_data_handle(h2, {"y": y.iloc[20:80], "X": None, "metadata": {}})
+    return h1, h2
+
+
+def test_aligner_fit_single_series_fails():
+    """Single series cannot fit an aligner (issue #491)."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    out = fit_tool(estimator_handle=r["handle"], y_dataset="airline")
+    assert not out["success"]
+    assert "multiple series" in out["error"]
+    assert "multiple values for argument 'X'" not in out["error"]
+
+
+def test_aligner_fit_single_dataframe_fails():
+    """Single flat DataFrame handle gets the same clear error as Series."""
+    executor = get_executor()
+    y = load_airline().to_frame()
+    hid = "data_align_df"
+    executor._register_data_handle(hid, {"y": y, "X": None, "metadata": {}})
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    try:
+        out = fit_tool(estimator_handle=r["handle"], X_handle=hid)
+        assert not out["success"]
+        assert "multiple series" in out["error"]
+        assert "df-list" not in out["error"]
+    finally:
+        executor._data_handles.pop(hid, None)
+        executor._handle_manager.release_handle(r["handle"])
+
+
+def test_aligner_fit_x_only_no_signature_clash():
+    """X-only single series must not raise 'multiple values for X'."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    out = fit_tool(estimator_handle=r["handle"], X_dataset="airline")
+    assert not out["success"]
+    assert "multiple values for argument 'X'" not in out["error"]
+
+
+def test_aligner_fit_list_of_handles():
+    """List of X_handle ids builds df-list and fits."""
+    executor = get_executor()
+    h1, h2 = _two_airline_handles(executor)
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    try:
+        out = fit_tool(estimator_handle=r["handle"], X_handle=[h1, h2])
+        assert out["success"], out
+        assert out.get("fitted") is True
+        assert executor._handle_manager.is_fitted(r["handle"])
+    finally:
+        executor._data_handles.pop(h1, None)
+        executor._data_handles.pop(h2, None)
+        executor._handle_manager.release_handle(r["handle"])
+
+
+def test_aligner_fit_list_of_datasets():
+    """List of X_dataset names builds df-list and fits."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    out = fit_tool(estimator_handle=r["handle"], X_dataset=["airline", "airline"])
+    assert out["success"], out
+    assert out.get("fitted") is True
+
+
+def test_aligner_fit_list_too_short():
+    """Single-element X list is rejected before sktime."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    out = fit_tool(estimator_handle=r["handle"], X_handle=["only_one"])
+    assert not out["success"]
+    assert "at least two" in out["error"]
+
+
+def test_aligner_call_method_list_data_handles():
+    """call_method injects list of data handles into fit."""
+    executor = get_executor()
+    h1, h2 = _two_airline_handles(executor)
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    try:
+        out = executor.call_method(r["handle"], "fit", {"X_data_handle": [h1, h2]})
+        assert out["success"], out
+        al = executor.call_method(r["handle"], "get_alignment", {})
+        assert al["success"], al
+        assert isinstance(al["result"], dict)
+    finally:
+        executor._data_handles.pop(h1, None)
+        executor._data_handles.pop(h2, None)
+        executor._handle_manager.release_handle(r["handle"])
+
+
+def test_aligner_call_method_list_too_short():
+    """call_method rejects empty/short multi-series lists like fit."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    executor = get_executor()
+    out = executor.call_method(r["handle"], "fit", {"X_data_handle": []})
+    assert not out["success"]
+    assert "at least two" in out["error"]
+
+
+def test_forecaster_fit_string_y_dataset():
+    """Single-string y_dataset for forecasters is unchanged."""
+    r = instantiate_tool("NaiveForecaster()")
+    assert r["success"], r
+    out = fit_tool(estimator_handle=r["handle"], y_dataset="airline")
+    assert out["success"], out
+
+
+def test_forecaster_same_dataset_uses_canonical_y_x():
+    """Merge must keep main's y/X convention (longley target is TOTEMP)."""
+    r = instantiate_tool("NaiveForecaster()")
+    assert r["success"], r
+    out = fit_tool(
+        estimator_handle=r["handle"],
+        y_dataset="longley",
+        X_dataset="longley",
+    )
+    assert out["success"], out
+    fitted_y = get_executor()._handle_manager.get_instance(r["handle"])._y
+    assert fitted_y.ndim == 1 or fitted_y.shape[1] == 1, fitted_y.shape
+
+
+def test_aligner_fit_unknown_dataset_in_list():
+    """Unknown name in X_dataset list surfaces the load error, not a type error."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    out = fit_tool(
+        estimator_handle=r["handle"],
+        X_dataset=["airline", "no_such_dataset_zzz"],
+    )
+    assert not out["success"]
+    assert "Unknown dataset: no_such_dataset_zzz" in out["error"]
+    assert "available" in out
+
+
+def test_aligner_fit_non_string_list_item():
+    """Non-string X list items are rejected before sktime."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    out = fit_tool(estimator_handle=r["handle"], X_handle=[1, 2])
+    assert not out["success"]
+    assert "must be strings" in out["error"]
+
+
+def test_aligner_call_method_list_datasets():
+    """call_method injects a list of demo datasets into fit."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    executor = get_executor()
+    out = executor.call_method(
+        r["handle"],
+        "fit",
+        {"X_dataset": ["airline", "airline"]},
+    )
+    assert out["success"], out
+    al = executor.call_method(r["handle"], "get_alignment", {})
+    assert al["success"], al
+
+
+def test_aligner_call_method_unknown_dataset_in_list():
+    """Failed dataset load in a list returns available names, like a string kwarg."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    out = get_executor().call_method(
+        r["handle"],
+        "fit",
+        {"X_dataset": ["airline", "no_such_dataset_zzz"]},
+    )
+    assert not out["success"]
+    assert "Unknown dataset: no_such_dataset_zzz" in out["error"]
+    assert "available" in out
+    assert "unexpected keyword argument" not in out["error"]
+
+
+async def test_aligner_fit_async_list_of_handles():
+    """run_async list-valued X_handle fits in a background job."""
+    executor = get_executor()
+    job_manager = get_job_manager()
+    h1, h2 = _two_airline_handles(executor)
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    try:
+        out = fit_tool(estimator_handle=r["handle"], X_handle=[h1, h2], run_async=True)
+        assert out["success"], out
+        assert out["status"] == "running"
+        job = await _wait_for_job(job_manager, out["job_id"])
+        assert job.status is JobStatus.COMPLETED, job.errors
+        assert executor._handle_manager.is_fitted(r["handle"])
+    finally:
+        executor._data_handles.pop(h1, None)
+        executor._data_handles.pop(h2, None)
+        executor._handle_manager.release_handle(r["handle"])
+
+
+async def test_aligner_fit_async_unknown_handle_fails_job():
+    """Unknown X_handle with run_async=True fails the job, not the tool call."""
+    r = instantiate_tool("AlignerNaive()")
+    assert r["success"], r
+    job_manager = get_job_manager()
+    out = fit_tool(
+        estimator_handle=r["handle"],
+        X_handle="no_such_handle_zzz",
+        run_async=True,
+    )
+    assert out["success"]
+    assert out["status"] == "running"
+    job = await _wait_for_job(job_manager, out["job_id"])
+    assert job.status is JobStatus.FAILED
+    assert any("Unknown X data handle: no_such_handle_zzz" in err for err in job.errors)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #491

#### What does this implement/fix? Explain your changes.

Aligners need `X` as a panel / df-list (list of series). `fit` only resolved a single series per `X_*` / `y_*` slot and routed `object_type=aligner` through the forecaster-style `fit(y, X=...)` path. That produced the df-list type error on a single series (e.g. airline) and a signature clash when only `X` was set.

This change:

- lets `X_handle` / `X_dataset` be a string or a list of ids
- assembles a df-list for list inputs (Series → one-column DataFrame)
- routes aligners to `fit(X)` with a clear error on a single series/table
- extends `call_method` `*_dataset` / `*_data_handle` injection the same way for multi-series lists

Shared resolve is used by sync `fit` and `fit_async`. Tests use `AlignerNaive` (no soft deps).

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- List resolve for `X_handle` / `X_dataset` and Series → DataFrame for df-list items
- Aligner branch in `Executor.fit` (including single flat DataFrame vs MultiIndex panel)
- `call_method` list injection parity with fit (`len >= 2`)

#### Any other comments?

`make check` is green locally (206 tests). Commit-time pre-commit passed on this branch.

#### PR checklist

##### For all contributions
- [x] I've added unit tests and made sure they pass locally (`make check`).
- [ ] I've added the tool to the online documentation in `docs/source/`. n/a (schema/description only on the existing `fit` tool; no new tool)
- [ ] I've updated the existing example scripts or provided a new one to showcase how my tool works in `examples/`. n/a