### PR TITLE
fix: guard sanitize_for_json against circular references

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -143,7 +143,7 @@ def _apply_response_token_limit(tool_name: str, text: str) -> str:
     return text[:budget] + notice
 
 
-def sanitize_for_json(obj):
+def sanitize_for_json(obj, _seen=None):
     """Recursively convert objects to JSON-serializable format.
 
     Handles:
@@ -151,7 +151,19 @@ def sanitize_for_json(obj):
     - NumPy integer/float scalars and ndarrays
     - Pandas Timestamp, NaT, NA, and Series/DataFrame
     - Arbitrary objects (fallback to str repr)
+    - Circular references (returns a placeholder instead of recursing forever)
     """
+    if _seen is None:
+        _seen = set()
+
+    if isinstance(obj, (dict, list, tuple)) or (
+        _PANDAS_AVAILABLE and isinstance(obj, (pd.Series, pd.DataFrame))
+    ):
+        obj_id = id(obj)
+        if obj_id in _seen:
+            return "<circular reference>"
+        _seen = _seen | {obj_id}
+
     # --- NumPy types ---
     if _NUMPY_AVAILABLE:
         if isinstance(obj, np.integer):
@@ -161,7 +173,7 @@ def sanitize_for_json(obj):
         if isinstance(obj, np.bool_):
             return bool(obj)
         if isinstance(obj, np.ndarray):
-            return [sanitize_for_json(item) for item in obj.tolist()]
+            return [sanitize_for_json(item, _seen) for item in obj.tolist()]
         if isinstance(obj, np.complexfloating):
             return str(obj)
 
@@ -178,15 +190,15 @@ def sanitize_for_json(obj):
         except AttributeError:
             pass
         if isinstance(obj, pd.Series):
-            return sanitize_for_json(obj.tolist())
+            return sanitize_for_json(obj.tolist(), _seen)
         if isinstance(obj, pd.DataFrame):
-            return sanitize_for_json(obj.to_dict(orient="records"))
+            return sanitize_for_json(obj.to_dict(orient="records"), _seen)
 
     # --- Standard Python containers ---
     if isinstance(obj, dict):
-        return {str(k): sanitize_for_json(v) for k, v in obj.items()}
+        return {str(k): sanitize_for_json(v, _seen) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):
-        return [sanitize_for_json(item) for item in obj]
+        return [sanitize_for_json(item, _seen) for item in obj]
 
     # --- Already JSON-safe scalars ---
     if isinstance(obj, (str, int, float, bool, type(None))):

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -137,3 +137,30 @@ class TestEdgeCases:
     def test_nan(self):
         result = sanitize_for_json(np.float64("nan"))
         json.dumps(result, default=str)
+
+    def test_circular_dict(self):
+        d = {"a": 1}
+        d["self"] = d
+        result = sanitize_for_json(d)
+        assert result["self"] == "<circular reference>"
+        json.dumps(result)
+
+    def test_circular_list(self):
+        lst = [1, 2]
+        lst.append(lst)
+        result = sanitize_for_json(lst)
+        assert result[2] == "<circular reference>"
+        json.dumps(result)
+
+    def test_indirect_cycle(self):
+        a = {}
+        b = {"a": a}
+        a["b"] = b
+        result = sanitize_for_json(a)
+        assert result["b"]["a"] == "<circular reference>"
+        json.dumps(result)
+
+    def test_sibling_containers_not_falsely_flagged(self):
+        shared = {"x": 1}
+        result = sanitize_for_json({"left": shared, "right": shared})
+        assert result == {"left": {"x": 1}, "right": {"x": 1}}


### PR DESCRIPTION
Closes #189.

## Problem

`sanitize_for_json` recurses into dicts/lists/tuples/Series/DataFrames
with no cycle detection. An object graph containing a back-reference
(e.g. a dict that (indirectly) contains itself) blows the recursion
limit and crashes with `RecursionError` instead of returning any
usable response to the calling tool.

## Fix

Track the `id()` of containers visited along the current recursion
path in a `_seen` set (passed as an internal-only kwarg, not part of
the public signature). On revisiting an already-seen container id,
return the placeholder string `"<circular reference>"` instead of
recursing again. Each recursive branch gets its own copy of `_seen`
(immutable set union), so sibling branches that legitimately share the
same nested object are not falsely flagged as circular.

## Tests

Added 4 regression tests to `tests/test_sanitize.py`:
- direct self-reference in a dict
- direct self-reference in a list
- indirect two-hop cycle (`a -> b -> a`)
- sibling containers sharing the same nested object are NOT flagged as circular (guards against an overly aggressive fix)

Full suite passes locally: 201 passed.