### PR TITLE
fix: declare types for 5 untyped inputSchema properties

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -340,6 +340,8 @@ async def list_tools() -> list[Tool]:
                     },
                     "fh": {
                         "description": "Optional: Forecast horizon (e.g. 12 or [1,2,3]) to pass to fit",
+                        "type": ["integer", "array"],
+                        "items": {"type": "integer"},
                     },
                     "run_async": {
                         "type": "boolean",
@@ -381,10 +383,14 @@ async def list_tools() -> list[Tool]:
                     },
                     "coverage": {
                         "description": "Coverage level for intervals (float or list of floats)",
+                        "type": ["number", "array"],
+                        "items": {"type": "number"},
                         "default": 0.9,
                     },
                     "alpha": {
                         "description": "Alpha values for quantiles (float or list of floats)",
+                        "type": ["number", "array"],
+                        "items": {"type": "number"},
                     },
                     "X_handle": {
                         "type": "string",
@@ -655,6 +661,8 @@ async def list_tools() -> list[Tool]:
                             "steps (e.g. fh=[1,5,10] reserves 10 steps). "
                             "Mutually exclusive with test_size."
                         ),
+                        "type": ["integer", "array"],
+                        "items": {"type": "integer"},
                     },
                 },
                 "required": ["data_handle"],
@@ -787,6 +795,8 @@ async def list_tools() -> list[Tool]:
                     },
                     "markers": {
                         "description": "Marker style(s) for data points (e.g., 'o', ['.', 'x']).",
+                        "type": ["string", "array"],
+                        "items": {"type": "string"},
                     },
                     "x_label": {
                         "type": "string",

--- a/tests/test_schema_types.py
+++ b/tests/test_schema_types.py
@@ -1,0 +1,62 @@
+"""Guard against untyped inputSchema properties.
+
+A property without a type constraint is serialized as a string by some MCP
+clients, which silently breaks the parameter on the Python side. This is
+invisible to unit tests that call the tool functions directly — it only
+appears over the wire — so we lint the schemas instead.
+"""
+
+import asyncio
+
+import pytest
+
+from sktime_mcp.server import list_tools
+
+# A property is considered typed if it has any of these constraint keywords.
+_TYPE_KEYWORDS = {"type", "enum", "anyOf", "oneOf", "allOf", "const"}
+
+
+def _iter_properties(schema, path):
+    """Yield (path, property_schema) for every property, recursively."""
+    if not isinstance(schema, dict):
+        return
+    for prop_name, prop_schema in schema.get("properties", {}).items():
+        prop_path = f"{path}.{prop_name}"
+        yield prop_path, prop_schema
+        yield from _iter_properties(prop_schema, prop_path)
+        if isinstance(prop_schema, dict):
+            yield from _iter_properties(prop_schema.get("items"), f"{prop_path}[]")
+
+
+def _all_tool_properties():
+    tools = asyncio.run(list_tools())
+    for tool in tools:
+        yield from _iter_properties(tool.inputSchema, tool.name)
+
+
+def test_every_schema_property_declares_a_type():
+    untyped = [
+        path
+        for path, prop in _all_tool_properties()
+        if isinstance(prop, dict) and not (_TYPE_KEYWORDS & prop.keys())
+    ]
+    assert not untyped, (
+        "inputSchema properties without a type constraint (clients stringify "
+        f"their values in transit): {untyped}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "prop", "expected_types"),
+    [
+        ("fit", "fh", ["integer", "array"]),
+        ("predict", "coverage", ["number", "array"]),
+        ("predict", "alpha", ["number", "array"]),
+        ("split_data", "fh", ["integer", "array"]),
+        ("plot_series", "markers", ["string", "array"]),
+    ],
+)
+def test_previously_untyped_properties_are_typed(tool_name, prop, expected_types):
+    tools = {t.name: t for t in asyncio.run(list_tools())}
+    prop_schema = tools[tool_name].inputSchema["properties"][prop]
+    assert prop_schema["type"] == expected_types


### PR DESCRIPTION
## Problem

Five `inputSchema` properties in `server.py` declared no `type`/`enum`/`anyOf`/`oneOf`, so MCP clients serialize their values as strings in transit. Every explicit use of these parameters then fails Python-side type checks:

| Param | Observed error |
|---|---|
| `fit.fh` | `Invalid fh. ... found type <class 'str'>, values = 12` |
| `predict.coverage` | `'<' not supported between instances of 'int' and 'str'` |
| `predict.alpha` | same |
| `split_data.fh` | `fh must be an integer or list of integers, got str` |
| `plot_series.markers` | `There must be one marker for each time series` |

Blast radius: `predict_interval`/`predict_quantiles` were usable only with defaults, every `fh` code path in `split_data` was dead, estimators requiring `fh` at fit time could not be fitted through the server at all, and multi-series markers could not be set. (BUG-01 from the 2026-07-26 ~400-case test sweep; found independently by 4 agents.)

## Fix

Give each property an explicit union type matching what the Python side accepts, e.g.:

```python
"fh": {
    "description": "...",
    "type": ["integer", "array"],
    "items": {"type": "integer"},
},
```

## Regression guard

New `tests/test_schema_types.py`:
- walks every property of every tool's `inputSchema` (recursively) and asserts each carries a type constraint — this bug class is invisible to unit tests that call the tool functions directly, it only appears over the wire
- pins the expected types of the five previously-broken properties

The lint test confirms these five were the only untyped properties in the schema set.

## Testing

- `pytest tests/` — 208 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
