### PR TITLE
fix: escape string values in export_code generated code

### DIFF
--- a/src/sktime_mcp/tools/codegen.py
+++ b/src/sktime_mcp/tools/codegen.py
@@ -4,6 +4,7 @@ Code generation tool for sktime MCP.
 Generates Python code to recreate estimators and pipelines.
 """
 
+import json
 import keyword
 from typing import Any
 
@@ -14,7 +15,9 @@ from sktime_mcp.runtime.handles import get_handle_manager
 def _format_value(value: Any) -> str:
     """Format a parameter value for Python code generation."""
     if isinstance(value, str):
-        return f'"{value}"'
+        # json.dumps escapes embedded quotes/backslashes; its output is also
+        # a valid Python string literal
+        return json.dumps(value)
     elif isinstance(value, (list, tuple)):
         if isinstance(value, tuple):
             items = ", ".join(_format_value(v) for v in value)
@@ -23,7 +26,7 @@ def _format_value(value: Any) -> str:
             items = ", ".join(_format_value(v) for v in value)
             return f"[{items}]"
     elif isinstance(value, dict):
-        items = ", ".join(f'"{k}": {_format_value(v)}' for k, v in value.items())
+        items = ", ".join(f"{_format_value(k)}: {_format_value(v)}" for k, v in value.items())
         return f"{{{items}}}"
     elif isinstance(value, bool):
         return str(value)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -73,6 +73,22 @@ class TestFormatValue:
         result = _format_value([[1, 2], [3, 4]])
         assert result == "[[1, 2], [3, 4]]"
 
+    def test_string_with_embedded_double_quotes(self):
+        """Embedded double quotes must be escaped to stay valid Python."""
+        result = _format_value('NaiveForecaster(strategy="mean", sp=12)')
+        assert result == '"NaiveForecaster(strategy=\\"mean\\", sp=12)"'
+        assert eval(result) == 'NaiveForecaster(strategy="mean", sp=12)'
+
+    def test_string_with_backslash(self):
+        """Backslashes must be escaped to stay valid Python."""
+        result = _format_value("a\\b")
+        assert eval(result) == "a\\b"
+
+    def test_dict_key_with_embedded_quotes(self):
+        """Dict keys must be escaped like any other string."""
+        result = _format_value({'say "hi"': 1})
+        assert eval(result) == {'say "hi"': 1}
+
 
 class TestVarNameValidation:
     """Tests for Python variable name validation in code export."""
@@ -151,6 +167,20 @@ class TestExportCodeTool:
             result = export_code_tool(handle, include_fit_example=False)
             assert result["success"]
             assert "load_airline" not in result["code"]
+        finally:
+            self._cleanup_handle(handle)
+
+    def test_spec_with_double_quoted_arg_is_valid_python(self):
+        """Specs with double-quoted string args must export syntactically valid code."""
+        handle = self._create_handle('NaiveForecaster(strategy="mean", sp=12)')
+        try:
+            result = export_code_tool(handle)
+            assert result["success"]
+            compile(result["code"], "<export_code>", "exec")
+            namespace: dict = {}
+            exec(result["code"], namespace)
+            assert namespace["model"].get_params()["strategy"] == "mean"
+            assert namespace["model"].get_params()["sp"] == 12
         finally:
             self._cleanup_handle(handle)
 


### PR DESCRIPTION
## Problem

`export_code` emitted syntactically invalid Python for any spec containing a string argument (BUG-02 from the 2026-07-26 test sweep). `_format_value` wrapped strings in bare double quotes with no escaping:

```python
if isinstance(value, str):
    return f'"{value}"'
```

so exporting `NaiveForecaster(strategy="mean", sp=12)` produced:

```python
model = craft("NaiveForecaster(strategy="mean", sp=12)")
```

→ `SyntaxError: invalid syntax. Perhaps you forgot a comma?`

This hits the common case: any estimator with a string hyperparameter (`strategy=`, `method=`, `averaging_method=`, `init_algorithm=`, …). Quote-free specs exported fine, confirming the trigger is precisely the embedded `"`.

## Fix

Use `json.dumps(value)` — it escapes embedded quotes/backslashes and its output is also a valid Python string literal, while keeping the existing double-quote style. Dict keys are now routed through `_format_value` too, so they get the same escaping (and non-string keys are no longer silently stringified).

## Testing

- New unit tests: embedded double quotes, backslashes, dict keys with quotes — each round-trips through `eval`
- New end-to-end test: instantiate `NaiveForecaster(strategy="mean", sp=12)`, export, `compile()` + `exec()` the generated code, and assert the recreated model's params
- `pytest tests/test_codegen.py` — 29 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
