### PR TITLE
fix: reject empty data_handles in plot_series

### DIFF
--- a/src/sktime_mcp/server.py
+++ b/src/sktime_mcp/server.py
@@ -760,6 +760,7 @@ async def list_tools() -> list[Tool]:
                     "data_handles": {
                         "type": "array",
                         "items": {"type": "string"},
+                        "minItems": 1,
                         "description": "List of data handle IDs to plot (e.g., train, test, forecasts).",
                     },
                     "labels": {

--- a/src/sktime_mcp/tools/plotting.py
+++ b/src/sktime_mcp/tools/plotting.py
@@ -160,6 +160,12 @@ def plot_series_tool(
             "error": "matplotlib and sktime plotting utils are required.",
         }
 
+    if not data_handles:
+        return {
+            "success": False,
+            "error": "data_handles must contain at least one data handle ID.",
+        }
+
     executor = get_executor()
 
     # --- resolve data handles -----------------------------------------------

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -95,6 +95,11 @@ class TestPlotSeriesTool:
         assert "not found" in result["error"]
         assert "available_handles" in result
 
+    def test_empty_data_handles(self):
+        result = plot_series_tool(data_handles=[])
+        assert result["success"] is False
+        assert "at least one" in result["error"]
+
     def test_unsupported_format(self):
         _register_series("s1", _make_airline_like())
         result = plot_series_tool(data_handles=["s1"], image_format="bmp")


### PR DESCRIPTION
## Problem

`plot_series(data_handles=[])` raised a raw `IndexError` — `"list index out of range"` — leaked from sktime's plotting internals instead of a domain error (BUG-22 from the 2026-07-26 test sweep). `plotting.py` never checked for an empty list.

## Fix

Two layers:

- **Server-side**: `plot_series_tool` returns `{"success": false, "error": "data_handles must contain at least one data handle ID."}` before touching the executor.
- **Schema-side**: `"minItems": 1` on the `data_handles` property, so conformant MCP clients reject the call before it ever reaches the server.

## Testing

- New test: `plot_series_tool(data_handles=[])` returns a structured error
- `pytest tests/test_plotting.py` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
