### PR TITLE
fix: materialize generator results in call_method

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -636,6 +636,11 @@ class Executor:
 
             result = method(**kwargs)
 
+            # Materialize generators (e.g. splitter.split) so the caller gets
+            # the actual values instead of a useless repr string
+            if inspect.isgenerator(result):
+                result = list(result)
+
             from sktime_mcp.server import sanitize_for_json
 
             if hasattr(result, "to_dict"):

--- a/tests/test_call_method_generators.py
+++ b/tests/test_call_method_generators.py
@@ -1,0 +1,51 @@
+"""call_method must materialize generator results.
+
+Splitter methods like split/split_loc return generators; without
+materialization the caller gets a useless repr string such as
+"<generator object BaseSplitter.split at 0x...>".
+"""
+
+import contextlib
+
+import pytest
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.runtime.handles import get_handle_manager
+from sktime_mcp.tools.instantiate import instantiate_tool
+
+
+@pytest.fixture
+def splitter_handle():
+    result = instantiate_tool(spec="SlidingWindowSplitter(window_length=24, step_length=12)")
+    assert result["success"], f"Failed to create handle: {result}"
+    yield result["handle"]
+    with contextlib.suppress(KeyError):
+        get_handle_manager().release_handle(result["handle"])
+
+
+def test_split_returns_materialized_folds(splitter_handle):
+    result = get_executor().call_method(
+        handle_id=splitter_handle,
+        method_name="split",
+        kwargs={"y_dataset": "airline"},
+    )
+    assert result["success"], result
+    folds = result["result"]
+    assert isinstance(folds, list)
+    assert len(folds) > 0
+    assert "generator object" not in str(folds)
+    # Each fold is a (train_indices, test_indices) pair of JSON-safe int lists
+    train, test = folds[0]
+    assert all(isinstance(i, int) for i in train)
+    assert all(isinstance(i, int) for i in test)
+    assert len(train) == 24
+
+
+def test_non_generator_results_unchanged(splitter_handle):
+    result = get_executor().call_method(
+        handle_id=splitter_handle,
+        method_name="get_n_splits",
+        kwargs={"y_dataset": "airline"},
+    )
+    assert result["success"], result
+    assert isinstance(result["result"], int)


### PR DESCRIPTION
## Problem

`call_method` returned generators unmaterialized (BUG-24 from the 2026-07-26 test sweep). The result sanitization path had no generator branch, so generator results fell through to `repr()`:

```
call_method(handle_id=<SlidingWindowSplitter>, method_name="split", kwargs={"y_dataset": "airline"})
-> {"success": true, "result": "<generator object BaseSplitter.split at 0x726df47b6140>"}
```

Splitters are the headline use case in the tool's own description, yet `split`/`split_loc` were useless — `get_n_splits` was the only working path.

## Fix

Materialize generators to lists before sanitization:

```python
if inspect.isgenerator(result):
    result = list(result)
```

`sanitize_for_json` already handles lists, tuples, and ndarrays recursively, so the folds come back as JSON-safe nested int lists.

## Testing

- New `tests/test_call_method_generators.py`: `split` on a `SlidingWindowSplitter` over the airline dataset returns actual materialized folds (pairs of int index lists, train window length verified); non-generator results (`get_n_splits`) unchanged
- `pytest tests/test_call_method_generators.py` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
