### PR TITLE
fix: surface dataset load errors in call_method kwargs

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -621,11 +621,18 @@ class Executor:
             for k, v in list(kwargs.items()):
                 if k.endswith("_dataset") and isinstance(v, str):
                     data_res = self.load_dataset(v)
-                    if data_res.get("success"):
-                        # Replace the kwarg with the actual data (e.g. y_dataset -> y)
-                        actual_key = k.replace("_dataset", "")
-                        kwargs[actual_key] = data_res["data"]
-                        del kwargs[k]
+                    if not data_res.get("success"):
+                        error_res = {
+                            "success": False,
+                            "error": data_res.get("error", f"Unknown dataset: {v}"),
+                        }
+                        if "available" in data_res:
+                            error_res["available"] = data_res["available"]
+                        return error_res
+                    # Replace the kwarg with the actual data (e.g. y_dataset -> y)
+                    actual_key = k.replace("_dataset", "")
+                    kwargs[actual_key] = data_res["data"]
+                    del kwargs[k]
                 elif k.endswith("_data_handle") and isinstance(v, str):
                     if v in self._data_handles:
                         actual_key = k.replace("_data_handle", "")

--- a/tests/test_call_method_dataset_kwargs.py
+++ b/tests/test_call_method_dataset_kwargs.py
@@ -1,0 +1,46 @@
+"""call_method must surface *_dataset kwargs that fail to load.
+
+Previously an unresolvable dataset name was silently left in kwargs, so
+the raw ``y_dataset`` string reached the method and produced a confusing
+"unexpected keyword argument 'y_dataset'" error instead of the load
+failure.
+"""
+
+import contextlib
+
+import pytest
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.runtime.handles import get_handle_manager
+from sktime_mcp.tools.instantiate import instantiate_tool
+
+
+@pytest.fixture
+def splitter_handle():
+    result = instantiate_tool(spec="SlidingWindowSplitter(window_length=24, step_length=12)")
+    assert result["success"], f"Failed to create handle: {result}"
+    yield result["handle"]
+    with contextlib.suppress(KeyError):
+        get_handle_manager().release_handle(result["handle"])
+
+
+def test_unknown_dataset_returns_load_error(splitter_handle):
+    result = get_executor().call_method(
+        handle_id=splitter_handle,
+        method_name="get_n_splits",
+        kwargs={"y_dataset": "no_such_dataset_zzz"},
+    )
+    assert result["success"] is False
+    assert "Unknown dataset: no_such_dataset_zzz" in result["error"]
+    assert "unexpected keyword argument" not in result["error"]
+    assert "available" in result
+
+
+def test_known_dataset_still_resolves(splitter_handle):
+    result = get_executor().call_method(
+        handle_id=splitter_handle,
+        method_name="get_n_splits",
+        kwargs={"y_dataset": "airline"},
+    )
+    assert result["success"], result
+    assert isinstance(result["result"], int)


### PR DESCRIPTION
## Problem

`call_method` silently swallowed an unresolvable `*_dataset` kwarg (BUG-25 from the 2026-07-26 test sweep). The kwarg-rewrite loop only acted `if data_res.get("success")` — on load failure it neither errored nor removed the key, so the raw string reached the method:

```
call_method(handle_id=<splitter>, method_name="get_n_splits",
            kwargs={"y_dataset": "no_such_dataset_zzz"})
-> "BaseWindowSplitter.get_n_splits() got an unexpected keyword argument 'y_dataset'"
```

The real cause (unknown dataset) was hidden behind a misleading signature error. The sibling `*_data_handle` branch already handled this correctly (`Unknown data handle: ...`).

## Fix

Mirror the `*_data_handle` branch: when the dataset fails to load, return the load error immediately, including the `available` dataset list when present:

```json
{"success": false, "error": "Unknown dataset: no_such_dataset_zzz", "available": [...]}
```

## Testing

- New `tests/test_call_method_dataset_kwargs.py`: unknown dataset returns the load error (not the signature error) with the available list; known dataset still resolves and the method executes
- `pytest tests/test_call_method_dataset_kwargs.py` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
