### PR TITLE
fix: cap available_handles in not-found error responses

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -166,6 +166,19 @@ class Executor:
             self._cleanup_oldest_data(count=max(1, self._max_data_handles // 5))
         self._data_handles[handle_id] = data
 
+    def summarize_available_handles(self, limit: int = 5) -> dict[str, Any]:
+        """Capped view of data-handle ids for not-found error responses.
+
+        Returns the *limit* most recent handles plus the total count, so
+        error responses stay small and don't enumerate every handle in the
+        process.
+        """
+        handle_ids = list(self._data_handles.keys())
+        return {
+            "available_handles": handle_ids[-limit:],
+            "n_available_handles": len(handle_ids),
+        }
+
     def _resolve_source(self, source: str) -> dict[str, Any]:
         """Resolve a source id to a series, trying data_handle then demo dataset."""
         if source in self._data_handles:

--- a/src/sktime_mcp/tools/inspect_data.py
+++ b/src/sktime_mcp/tools/inspect_data.py
@@ -56,7 +56,7 @@ def inspect_data_tool(data_handle: str) -> dict[str, Any]:
         return {
             "success": False,
             "error": f"Data handle '{data_handle}' not found",
-            "available_handles": list(executor._data_handles.keys()),
+            **executor.summarize_available_handles(),
         }
 
     data_info = executor._data_handles[data_handle]

--- a/src/sktime_mcp/tools/plotting.py
+++ b/src/sktime_mcp/tools/plotting.py
@@ -176,7 +176,7 @@ def plot_series_tool(
         return {
             "success": False,
             "error": f"Data handle(s) not found: {missing}",
-            "available_handles": list(executor._data_handles.keys()),
+            **executor.summarize_available_handles(),
         }
 
     # --- prepare plotting args ---------------------------------------------

--- a/src/sktime_mcp/tools/save_data.py
+++ b/src/sktime_mcp/tools/save_data.py
@@ -61,7 +61,7 @@ def save_data_tool(
         return {
             "success": False,
             "error": f"Data handle '{data_handle}' not found",
-            "available_handles": list(executor._data_handles.keys()),
+            **executor.summarize_available_handles(),
         }
 
     fmt = format.lower()

--- a/src/sktime_mcp/tools/split_data.py
+++ b/src/sktime_mcp/tools/split_data.py
@@ -57,7 +57,7 @@ def split_data_tool(
         return {
             "success": False,
             "error": f"Data handle '{data_handle}' not found",
-            "available_handles": list(executor._data_handles.keys()),
+            **executor.summarize_available_handles(),
         }
 
     if test_size is not None and fh is not None:

--- a/src/sktime_mcp/tools/transform_data.py
+++ b/src/sktime_mcp/tools/transform_data.py
@@ -82,7 +82,7 @@ def transform_data_tool(
         return {
             "success": False,
             "error": f"Data handle '{data_handle}' not found",
-            "available_handles": list(executor._data_handles.keys()),
+            **executor.summarize_available_handles(),
         }
 
     try:

--- a/tests/test_available_handles_cap.py
+++ b/tests/test_available_handles_cap.py
@@ -1,0 +1,60 @@
+"""Not-found error responses must not dump the entire handle store.
+
+available_handles is capped at the 5 most recent handles, with the total
+reported separately — a full dump both enumerates other sessions' handles
+in a shared store and floods the caller's context.
+"""
+
+import pandas as pd
+import pytest
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.tools.inspect_data import inspect_data_tool
+from sktime_mcp.tools.plotting import plot_series_tool
+
+
+@pytest.fixture(autouse=True)
+def _clean_handles():
+    executor = get_executor()
+    executor._data_handles.clear()
+    yield
+    executor._data_handles.clear()
+
+
+def _register_handles(n: int) -> list[str]:
+    executor = get_executor()
+    series = pd.Series(range(10), index=pd.date_range("2020-01", periods=10, freq="MS"))
+    ids = [f"data_test_{i:02d}" for i in range(n)]
+    for handle_id in ids:
+        executor._data_handles[handle_id] = {"y": series}
+    return ids
+
+
+def test_summary_capped_at_five_most_recent():
+    ids = _register_handles(8)
+    summary = get_executor().summarize_available_handles()
+    assert summary["available_handles"] == ids[-5:]
+    assert summary["n_available_handles"] == 8
+
+
+def test_summary_below_cap_lists_all():
+    ids = _register_handles(3)
+    summary = get_executor().summarize_available_handles()
+    assert summary["available_handles"] == ids
+    assert summary["n_available_handles"] == 3
+
+
+def test_inspect_data_not_found_is_capped():
+    _register_handles(8)
+    result = inspect_data_tool(data_handle="nonexistent")
+    assert result["success"] is False
+    assert len(result["available_handles"]) == 5
+    assert result["n_available_handles"] == 8
+
+
+def test_plot_series_not_found_is_capped():
+    _register_handles(8)
+    result = plot_series_tool(data_handles=["nonexistent"])
+    assert result["success"] is False
+    assert len(result["available_handles"]) == 5
+    assert result["n_available_handles"] == 8


### PR DESCRIPTION
## Problem

Every data-handle not-found response included `available_handles` with **all** handles in the process (BUG-13 from the 2026-07-26 test sweep). Observed dumps of 41 and 48 entries; one agent's `save_data` error leaked 5 handles belonging to other concurrent agents. That's cross-session enumeration in a shared store, and very noisy in the caller's context.

Five call sites had the same copy-pasted dump: `inspect_data`, `split_data`, `save_data`, `transform_data`, `plot_series`.

## Fix

New `Executor.summarize_available_handles(limit=5)` helper used by all five sites. Error responses now carry:

- `available_handles` — the 5 most recent handle ids (most likely to be the one the caller mistyped)
- `n_available_handles` — the total count, so truncation is visible

## Testing

- New `tests/test_available_handles_cap.py`: cap at 5 most-recent with 8 registered handles, full list below the cap, and end-to-end through `inspect_data` and `plot_series` error paths
- `pytest tests/` — 206 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
