### PR TITLE
fix: pin mcp below 2.0 to unbreak CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
     "sktime>=0.24.0",
     "pandas>=1.5.0",
     "numpy>=1.21.0",


### PR DESCRIPTION
## Problem

Every PR since 2026-07-28 fails CI at test collection with:

```
AttributeError: 'Server' object has no attribute 'list_tools'
  File ".../src/sktime_mcp/server.py", line 206, in <module>
    @server.list_tools()
```

`pyproject.toml` declares `mcp>=1.0.0` with no upper bound. **mcp 2.0.0** (released 2026-07-28, three days after main's last green CI run) removed the low-level `Server.list_tools` decorator API, so any fresh install breaks at import. Local environments with mcp 1.x are unaffected, which is why tests pass locally — CI logs confirm `Downloading mcp-2.0.0-py3-none-any.whl`.

## Fix

Pin `mcp>=1.0.0,<2` until the server is migrated to the mcp 2.0 API. Migration is a separate, larger piece of work.

## Note

This unblocks CI for #517–#522, which currently fail with this exact error on code they didn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
