### PR TITLE
fix: surface per-fold exceptions in evaluate instead of NaN metrics

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -117,7 +117,11 @@ def _run_evaluate(
         win = max(1, n - folds)
     cv = ExpandingWindowSplitter(initial_window=win, step_length=1, fh=[1])
 
-    results = evaluate(forecaster=instance, y=y, X=X, cv=cv, scoring=scoring)
+    # error_score="raise" — sktime's default (np.nan) swallows per-fold
+    # exceptions and reports success with all-NaN metrics
+    results = evaluate(
+        forecaster=instance, y=y, X=X, cv=cv, scoring=scoring, error_score="raise"
+    )
     if "estimator" in results.columns:
         results = results.drop(columns=["estimator"])
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -106,5 +106,39 @@ def test_evaluate_handle_not_found():
     assert "Handle not found" in result["error"]
 
 
+def test_evaluate_per_fold_error_surfaces_as_failure():
+    """Per-fold exceptions must fail the evaluation, not report success with NaN.
+
+    ThetaForecaster coerces to PeriodIndex internally and errors on a
+    DatetimeIndex with a MonthBegin freq — with sktime's default
+    error_score=np.nan every fold error was swallowed and evaluate
+    returned success: true with all-NaN metrics.
+    """
+    import math
+
+    import pandas as pd
+    from sktime.forecasting.theta import ThetaForecaster
+
+    executor = get_executor()
+    idx = pd.date_range("2000-01-01", periods=48, freq="MS")
+    y = pd.Series([100.0 + i + 10 * (i % 12) for i in range(48)], index=idx)
+    executor._data_handles["test_nan_dh"] = {"y": y}
+    handle = executor._handle_manager.create_handle("ThetaForecaster", ThetaForecaster(sp=12), {})
+
+    try:
+        result = evaluate_tool(estimator_handle=handle, y="test_nan_dh", cv_folds=3)
+        assert not result["success"], (
+            "Expected per-fold errors to fail the evaluation, got: "
+            f"{result.get('metrics')}"
+        )
+        assert result["error"]
+        # And in no case may a NaN metric masquerade as a result
+        for value in (result.get("metrics") or {}).values():
+            assert not (isinstance(value, float) and math.isnan(value))
+    finally:
+        executor._handle_manager.release_handle(handle)
+        executor._data_handles.pop("test_nan_dh", None)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

`evaluate` masked per-fold exceptions and returned `success: true` with all-NaN metrics — the worst failure mode found in the 2026-07-26 test sweep (BUG-05, P0, silently-wrong answer).

`_run_evaluate` called sktime's `evaluate()` without `error_score`, so sktime's default `error_score=np.nan` swallowed every per-fold exception:

```json
{"success": true,
 "metrics": {"test_MeanAbsolutePercentageError": NaN},
 "fold_results": [{"test_MeanAbsolutePercentageError": NaN, "pred_time": NaN, "cutoff": null}, ...]}
```

Observed trigger: ThetaForecaster (which coerces to `PeriodIndex` internally) × a handle-loaded `DatetimeIndex` with `freq='MS'` — every fold raised `<MonthBegin> is not supported as period frequency`, and the response still said success. The same defect surfaces honestly in `predict` (`success: false` with the real error); `evaluate` was the only tool hiding it.

## Fix

Pass `error_score="raise"` so fold errors propagate to the existing exception handler and the tool returns `{"success": false, "error": "<real error>"}`. Applies to both the sync tool and the async job path (shared `_run_evaluate`).

## Testing

- New test reproduces the exact trigger (ThetaForecaster + MonthBegin-freq handle) and asserts the evaluation fails with a real error, and that no NaN metric can masquerade as a result
- `pytest tests/test_evaluate.py tests/test_evaluate_async.py tests/test_evaluate_summary.py` — 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
