### PR TITLE
fix: stop transform_data format from destroying the input handle

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -974,12 +974,13 @@ class Executor:
             if getattr(self, "_auto_format_enabled", True):
                 try:
                     format_result = self.format_data_handle(
-                        data_handle, auto_infer_freq=True, fill_missing=True, remove_duplicates=True
+                        data_handle,
+                        auto_infer_freq=True,
+                        fill_missing=True,
+                        remove_duplicates=True,
+                        release_original=True,
                     )
                     if format_result["success"]:
-                        # Free the raw handle — the formatted copy supersedes it
-                        if data_handle in self._data_handles:
-                            del self._data_handles[data_handle]
                         return {
                             "success": True,
                             "data_handle": format_result["data_handle"],
@@ -1099,7 +1100,11 @@ class Executor:
             if getattr(self, "_auto_format_enabled", True):
                 try:
                     format_result = self.format_data_handle(
-                        data_handle, auto_infer_freq=True, fill_missing=True, remove_duplicates=True
+                        data_handle,
+                        auto_infer_freq=True,
+                        fill_missing=True,
+                        remove_duplicates=True,
+                        release_original=True,
                     )
                     if format_result["success"]:
                         data_handle = format_result["data_handle"]
@@ -1140,9 +1145,14 @@ class Executor:
         auto_infer_freq: bool = True,
         fill_missing: bool = True,
         remove_duplicates: bool = True,
+        release_original: bool = False,
     ) -> dict[str, Any]:
         """
         Format data associated with a handle.
+
+        The input handle is preserved unless ``release_original`` is True —
+        that flag is for internal auto-format-on-load, where the raw handle
+        was never exposed to the caller.
         """
         if data_handle not in self._data_handles:
             return {"success": False, "error": f"Data handle '{data_handle}' not found"}
@@ -1252,8 +1262,7 @@ class Executor:
         }
         self._register_data_handle(new_handle, new_data)
 
-        # Release the original to prevent intermediate handles from accumulating
-        if data_handle in self._data_handles:
+        if release_original and data_handle in self._data_handles:
             del self._data_handles[data_handle]
 
         return {

--- a/tests/test_transform_preserves_handle.py
+++ b/tests/test_transform_preserves_handle.py
@@ -1,0 +1,67 @@
+"""transform_data(action='format') must not destroy the caller's input handle.
+
+The tool contract is "transform a loaded data handle and return a NEW
+handle" — the input must stay valid, exactly as action='convert' already
+behaves. Only internal auto-format-on-load may release the raw handle,
+because that handle was never exposed to the caller.
+"""
+
+import pandas as pd
+import pytest
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.tools.transform_data import transform_data_tool
+
+
+@pytest.fixture
+def data_handle():
+    executor = get_executor()
+    idx = pd.date_range("2024-01-01", periods=10, freq="D")
+    executor._data_handles["test_fmt_parent"] = {
+        "y": pd.Series(range(10), index=idx, dtype=float),
+        "X": None,
+        "metadata": {"rows": 10, "frequency": "D"},
+        "validation": {"valid": True, "errors": [], "warnings": []},
+        "config": {},
+    }
+    yield "test_fmt_parent"
+    executor._data_handles.pop("test_fmt_parent", None)
+
+
+def test_format_keeps_input_handle_alive(data_handle):
+    executor = get_executor()
+    result = transform_data_tool(data_handle=data_handle, action="format")
+    assert result["success"], result
+    new_handle = result["data_handle"]
+    try:
+        assert new_handle != data_handle
+        assert data_handle in executor._data_handles, (
+            "format released the caller's input handle"
+        )
+        assert new_handle in executor._data_handles
+    finally:
+        executor._data_handles.pop(new_handle, None)
+
+
+def test_auto_format_on_load_still_releases_raw_handle():
+    """The internal load path must not leak the raw pre-format handle."""
+    executor = get_executor()
+    before = set(executor._data_handles)
+    res = executor.load_data_source(
+        {
+            "type": "pandas",
+            "data": {
+                "date": [f"2024-01-{d:02d}" for d in range(1, 11)],
+                "value": list(range(10)),
+            },
+            "time_column": "date",
+            "target_column": "value",
+        }
+    )
+    assert res["success"], res
+    created = set(executor._data_handles) - before
+    try:
+        # Exactly one new handle: the formatted one; the raw handle is gone
+        assert created == {res["data_handle"]}
+    finally:
+        executor._data_handles.pop(res["data_handle"], None)


### PR DESCRIPTION
## Problem

`transform_data(action='format')` silently destroyed the caller's input handle (BUG-07, P0, silent data loss). `format_data_handle` unconditionally deleted the input after creating the formatted copy:

```
transform_data(data_handle="data_87fcfaf9", action="format")
  -> {"success": true, "data_handle": "data_c2094a4b", ...}
inspect_data(data_handle="data_87fcfaf9")
  -> {"success": false, "error": "Data handle 'data_87fcfaf9' not found"}
```

In the sweep this cascaded: one `format` consumed a handle and four subsequent independent tests failed with not-found. The tool contract says "return a **new** handle", and `action='convert'` preserves its input — the two actions were inconsistent.

## Fix

`format_data_handle` gains `release_original: bool = False`. The deletion now happens only when that flag is set, which the two internal auto-format-on-load paths do (there the raw handle was never exposed to the caller, so releasing it prevents leaked intermediates — behavior unchanged).

## Testing

- New `tests/test_transform_preserves_handle.py`: explicit format keeps the input handle alive; auto-format-on-load still releases exactly the raw intermediate
- `pytest tests/` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
