### PR TITLE
fix: expand and resolve local paths in save_model/load_model

### DIFF
--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -121,6 +121,10 @@ def load_model_tool(path: str) -> dict[str, Any]:
                 "Please install it with: pip install sktime-mcp[mlflow]"
             ),
         }
+    from sktime_mcp.tools.save_model import resolve_model_path
+
+    path = resolve_model_path(path)
+
     try:
         instance = load_model(path)
         estimator_name = type(instance).__name__

--- a/src/sktime_mcp/tools/save_model.py
+++ b/src/sktime_mcp/tools/save_model.py
@@ -4,10 +4,27 @@ save_model tool for sktime MCP.
 Saves estimator instances via sktime's MLflow integration.
 """
 
+import os
 from collections.abc import Callable
 from typing import Any
 
 from sktime_mcp.runtime.handles import get_handle_manager
+
+# MLflow URI schemes that must be passed through untouched
+_MLFLOW_URI_PREFIXES = ("runs:/", "models:/", "mlflow-artifacts:/")
+
+
+def resolve_model_path(path: str) -> str:
+    """Expand ~ and resolve local filesystem paths to absolute form.
+
+    MLflow URIs (runs:/, models:/, mlflow-artifacts:/, scheme://...) are
+    returned unchanged. Without this, "~/model" creates a literal "~"
+    directory in the server cwd, and relative paths land in the server's
+    working directory with no way for the caller to learn where.
+    """
+    if path.startswith(_MLFLOW_URI_PREFIXES) or "://" in path:
+        return path
+    return os.path.abspath(os.path.expanduser(path))
 
 
 def _get_mlflow_save_model() -> Callable[..., Any]:
@@ -58,14 +75,16 @@ def save_model_tool(
     if mlflow_params is not None and not isinstance(mlflow_params, dict):
         return {"success": False, "error": "mlflow_params must be a dictionary"}
 
+    resolved_path = resolve_model_path(path)
+
     try:
         save_model = _get_mlflow_save_model()
-        save_model(sktime_model=estimator, path=path, **(mlflow_params or {}))
+        save_model(sktime_model=estimator, path=resolved_path, **(mlflow_params or {}))
         return {
             "success": True,
             "estimator_handle": estimator_handle,
-            "saved_path": path,
-            "message": f"Model saved successfully to '{path}'",
+            "saved_path": resolved_path,
+            "message": f"Model saved successfully to '{resolved_path}'",
         }
     except Exception as exc:
         return {"success": False, "error": str(exc)}

--- a/tests/test_save_model_fitted_check.py
+++ b/tests/test_save_model_fitted_check.py
@@ -59,3 +59,33 @@ class TestSaveModelFittedCheck:
         assert result["success"], result
         assert result["saved_path"] == str(tmp_path / "model_dir")
         assert "path" in calls
+
+
+class TestResolveModelPath:
+    """Path resolution: local paths expand and absolutize; MLflow URIs pass through."""
+
+    def test_tilde_expanded(self):
+        from sktime_mcp.tools.save_model import resolve_model_path
+
+        resolved = resolve_model_path("~/some_model_dir")
+        assert "~" not in resolved
+        assert resolved.startswith("/")
+
+    def test_relative_path_absolutized(self):
+        import os
+
+        from sktime_mcp.tools.save_model import resolve_model_path
+
+        resolved = resolve_model_path("relative_model_dir")
+        assert resolved == os.path.join(os.getcwd(), "relative_model_dir")
+
+    def test_mlflow_uris_untouched(self):
+        from sktime_mcp.tools.save_model import resolve_model_path
+
+        for uri in (
+            "runs:/abc123/model",
+            "models:/my_model/3",
+            "mlflow-artifacts:/abc/artifacts/model",
+            "s3://bucket/model",
+        ):
+            assert resolve_model_path(uri) == uri


### PR DESCRIPTION
## Problem

Found in the 2026-08-08 sweep:

1. `save_model(path="~/model")` created a **literal `~` directory** in the server cwd (the user's repo checkout) — an `rm -rf ~` cleanup footgun — while reporting success.
2. Relative paths silently resolved against the server's cwd, writing MLflow artifacts into the repo working tree, and `saved_path` echoed the unresolved input so the caller could not learn the real location.

## Fix

New `resolve_model_path`: `os.path.abspath(os.path.expanduser(path))` for local paths; MLflow URIs (`runs:/`, `models:/`, `mlflow-artifacts:/`, any `scheme://`) pass through untouched. `saved_path` and the success message now echo the resolved absolute path. `load_model` applies the same resolution so round-trips agree.

## Testing

- New tests: tilde expansion, relative→absolute, MLflow URI passthrough
- `pytest tests/test_save_model_fitted_check.py` — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
