### PR TITLE
fix: validate cv_folds and initial_window instead of silently clamping

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -111,10 +111,20 @@ def _run_evaluate(
 
     n = len(y)
     if initial_window is not None:
+        if not 1 <= initial_window < n:
+            raise ValueError(
+                f"initial_window must be between 1 and n-1={n - 1} "
+                f"(series has {n} observations), got {initial_window}"
+            )
         win = initial_window
     else:
-        folds = max(1, min(int(cv_folds), max(1, n - 1)))
-        win = max(1, n - folds)
+        folds = int(cv_folds)
+        if not 1 <= folds <= n - 1:
+            raise ValueError(
+                f"cv_folds must be between 1 and n-1={n - 1} "
+                f"(series has {n} observations), got {folds}"
+            )
+        win = n - folds
     cv = ExpandingWindowSplitter(initial_window=win, step_length=1, fh=[1])
 
     results = evaluate(forecaster=instance, y=y, X=X, cv=cv, scoring=scoring)

--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -29,6 +29,17 @@ def evaluate_tool(
     y and X accept data_handle ids or built-in demo dataset names.
     Set run_async=True to run as a background job.
     """
+    if initial_window is None and cv_folds < 1:
+        return {
+            "success": False,
+            "error": f"cv_folds must be a positive integer, got {cv_folds}",
+        }
+    if initial_window is not None and initial_window < 1:
+        return {
+            "success": False,
+            "error": f"initial_window must be a positive integer, got {initial_window}",
+        }
+
     executor = get_executor()
 
     if run_async:

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -108,3 +108,53 @@ def test_evaluate_handle_not_found():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestCvFoldsValidation:
+    """cv_folds/initial_window are validated, never silently clamped."""
+
+    def _handle(self):
+        executor = get_executor()
+        return executor, executor._handle_manager.create_handle(
+            "NaiveForecaster", NaiveForecaster(), {}
+        )
+
+    def test_cv_folds_zero_rejected(self):
+        executor, handle = self._handle()
+        try:
+            result = evaluate_tool(estimator_handle=handle, y="airline", cv_folds=0)
+            assert not result["success"]
+            assert "cv_folds" in result["error"]
+        finally:
+            executor._handle_manager.release_handle(handle)
+
+    def test_cv_folds_negative_rejected(self):
+        executor, handle = self._handle()
+        try:
+            result = evaluate_tool(estimator_handle=handle, y="airline", cv_folds=-5)
+            assert not result["success"]
+            assert "cv_folds" in result["error"]
+        finally:
+            executor._handle_manager.release_handle(handle)
+
+    def test_cv_folds_exceeding_series_rejected(self):
+        executor, handle = self._handle()
+        try:
+            # airline has 144 observations; 500 folds is impossible
+            result = evaluate_tool(estimator_handle=handle, y="airline", cv_folds=500)
+            assert not result["success"]
+            assert "cv_folds" in result["error"]
+            assert "143" in result["error"]
+        finally:
+            executor._handle_manager.release_handle(handle)
+
+    def test_initial_window_exceeding_series_rejected(self):
+        executor, handle = self._handle()
+        try:
+            result = evaluate_tool(
+                estimator_handle=handle, y="airline", initial_window=144
+            )
+            assert not result["success"]
+            assert "initial_window" in result["error"]
+        finally:
+            executor._handle_manager.release_handle(handle)


### PR DESCRIPTION
## Problem

`evaluate` clamped `cv_folds` instead of validating it (BUG-16 from the 2026-07-26 sweep):

- `cv_folds=0` → `success: true`, 1 fold
- `cv_folds=-5` → `success: true`, 1 fold (response even echoes `"cv_folds_requested": -5`)
- `cv_folds=500` on n=144 → `success: true`, 143 folds — and the metric mean computed only over surviving folds, a quietly biased number

`initial_window >= n` was passed to the splitter unchecked.

## Suggested merge order

Merge after #524 — both touch `_run_evaluate` (different hunks; validation above, `error_score` at the call).

## Fix

- Tool layer: fast rejection of `cv_folds < 1` / `initial_window < 1` before any work (covers the async path's job creation too)
- `_run_evaluate`: validate `1 <= cv_folds <= n-1` and `1 <= initial_window < n` with the valid range and series length in the message; the silent clamp is gone

## Testing

- New tests: cv_folds 0 / -5 / 500 and initial_window=144 on airline all rejected with informative errors
- `pytest tests/test_evaluate*.py` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
