### PR TITLE
fix: require data for update and roll back on failure

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -671,6 +671,21 @@ class Executor:
         if not self._handle_manager.is_fitted(handle_id):
             return {"success": False, "error": "Estimator not fitted"}
 
+        if y is None:
+            return {
+                "success": False,
+                "error": (
+                    "update requires new data — provide y_handle or y_dataset "
+                    "(and optionally X_handle/X_dataset)."
+                ),
+            }
+
+        # update mutates the live instance in place; snapshot fitted state so
+        # a rejected update does not leave the handle un-fitted
+        import copy
+
+        snapshot = copy.deepcopy(instance)
+
         try:
             kwargs = update_params or {}
             if X is not None:
@@ -683,6 +698,7 @@ class Executor:
                 "message": "Estimator updated successfully",
             }
         except Exception as e:
+            self._handle_manager.replace_instance(handle_id, snapshot)
             return {"success": False, "error": str(e)}
 
     def get_fitted_params(self, handle_id: str) -> dict[str, Any]:

--- a/src/sktime_mcp/runtime/handles.py
+++ b/src/sktime_mcp/runtime/handles.py
@@ -78,6 +78,11 @@ class HandleManager:
     def exists(self, handle_id: str) -> bool:
         return handle_id in self._handles
 
+    def replace_instance(self, handle_id: str, instance: Any) -> None:
+        """Swap the live instance behind a handle (e.g. rollback after a failed update)."""
+        if handle_id in self._handles:
+            self._handles[handle_id].instance = instance
+
     def mark_fitted(self, handle_id: str) -> None:
         if handle_id in self._handles:
             self._handles[handle_id].fitted = True

--- a/tests/test_update_hardening.py
+++ b/tests/test_update_hardening.py
@@ -1,0 +1,60 @@
+"""update must require data and roll back on failure.
+
+Previously update() with no data arguments returned success having done
+nothing, and a REJECTED update left the live instance in sktime's
+mid-update broken state — predict then failed with "has not been fitted
+yet" while the handle manager still reported fitted=True.
+"""
+
+import pandas as pd
+import pytest
+from sktime.forecasting.naive import NaiveForecaster
+
+from sktime_mcp.runtime.executor import get_executor
+from sktime_mcp.tools.fit_predict import update_tool
+
+
+@pytest.fixture
+def fitted_handle():
+    executor = get_executor()
+    idx = pd.date_range("2020-01-01", periods=24, freq="MS")
+    y = pd.Series([float(100 + i) for i in range(24)], index=idx)
+    executor._data_handles["upd_train"] = {"y": y}
+    handle = executor._handle_manager.create_handle("NaiveForecaster", NaiveForecaster(), {})
+    fit_res = executor.fit(handle, y=y)
+    assert fit_res["success"]
+    yield handle
+    executor._handle_manager.release_handle(handle)
+    executor._data_handles.pop("upd_train", None)
+    executor._data_handles.pop("upd_new", None)
+
+
+def test_update_without_data_is_rejected(fitted_handle):
+    result = update_tool(estimator_handle=fitted_handle)
+    assert result["success"] is False
+    assert "requires new data" in result["error"]
+
+
+def test_failed_update_rolls_back_fitted_state(fitted_handle):
+    executor = get_executor()
+    # airline is PeriodIndex; the fitted series is DatetimeIndex — sktime
+    # rejects the update deep inside, after mutating the instance
+    result = update_tool(estimator_handle=fitted_handle, y_dataset="airline")
+    assert result["success"] is False
+
+    # the estimator must still predict from its original fitted state
+    predict_res = executor.predict(fitted_handle, fh=[1, 2])
+    assert predict_res["success"], (
+        f"estimator was corrupted by the failed update: {predict_res.get('error')}"
+    )
+
+
+def test_successful_update_still_works(fitted_handle):
+    executor = get_executor()
+    idx = pd.date_range("2022-01-01", periods=3, freq="MS")
+    executor._data_handles["upd_new"] = {"y": pd.Series([200.0, 210.0, 220.0], index=idx)}
+    result = update_tool(estimator_handle=fitted_handle, y_handle="upd_new")
+    assert result["success"], result
+
+    predict_res = executor.predict(fitted_handle, fh=[1])
+    assert predict_res["success"]


### PR DESCRIPTION
## Problem

Two `update` defects from the 2026-07-26 sweep, combined here because they are the same function's two failure modes:

**BUG-17** — `update(estimator_handle=<fitted>)` with no data arguments returned `{"success": true, "message": "Estimator updated successfully"}`. Nothing happened.

**BUG-18** — sktime's `update()` mutates the live instance in place, so a REJECTED update destroyed the fitted estimator:

```
update(estimator_handle=..., y_dataset="airline")   -> success: false  (index-type mismatch)
predict(estimator_handle=...)
  -> "This instance of NaiveForecaster has not been fitted yet. Please call `fit` first."
```

…while the handle manager's `is_fitted` flag still read True — MCP state and sktime state disagreed.

## Fix

- `update` requires `y` (clear error naming `y_handle`/`y_dataset`)
- The instance is deep-copied before `update` and restored on exception via new `HandleManager.replace_instance`

## Testing

- New `tests/test_update_hardening.py`: no-data update rejected; failed update (DatetimeIndex-fitted × PeriodIndex airline) leaves the estimator predicting from its original state; successful update still works
- `pytest tests/` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
