### PR TITLE
fix: cap fold_results embedded in job status and list responses

### DIFF
--- a/src/sktime_mcp/tools/job_tools.py
+++ b/src/sktime_mcp/tools/job_tools.py
@@ -11,6 +11,33 @@ from sktime_mcp.runtime.jobs import JobStatus, get_job_manager
 
 logger = logging.getLogger(__name__)
 
+# Per-fold rows kept inline in a job-status response. A completed evaluate
+# job can hold hundreds of folds (observed: 120 folds ≈ 15k tokens), and
+# embedding them all floods the MCP client's context.
+_MAX_FOLD_RESULTS_IN_STATUS = 10
+
+
+def _compact_result(result: Any, max_folds: int) -> Any:
+    """Truncate oversized fold_results inside a job result payload.
+
+    The aggregate metrics/summary are always kept intact; only the
+    per-fold rows are capped, with an explicit truncation marker.
+    """
+    if not isinstance(result, dict):
+        return result
+    folds = result.get("fold_results")
+    if not isinstance(folds, list) or len(folds) <= max_folds:
+        return result
+    return {
+        **result,
+        "fold_results": folds[:max_folds],
+        "fold_results_truncated": {
+            "shown": max_folds,
+            "total": len(folds),
+            "note": "metrics and summary cover all folds; rerun evaluate for full per-fold rows",
+        },
+    }
+
 
 def check_job_status_tool(job_id: str) -> dict[str, Any]:
     """
@@ -31,9 +58,11 @@ def check_job_status_tool(job_id: str) -> dict[str, Any]:
             "error": f"Job '{job_id}' not found",
         }
 
+    job_dict = job.to_dict()
+    job_dict["result"] = _compact_result(job_dict.get("result"), _MAX_FOLD_RESULTS_IN_STATUS)
     return {
         "success": True,
-        **job.to_dict(),
+        **job_dict,
     }
 
 
@@ -90,6 +119,13 @@ def list_jobs_tool(
     total = job_manager.count_jobs(status=status_filter)
     jobs = job_manager.list_jobs(status=status_filter, limit=limit, offset=offset)
 
+    job_dicts = []
+    for job in jobs:
+        job_dict = job.to_dict()
+        # the list view is an overview — drop per-fold rows entirely
+        job_dict["result"] = _compact_result(job_dict.get("result"), 0)
+        job_dicts.append(job_dict)
+
     return {
         "success": True,
         "count": len(jobs),
@@ -97,7 +133,7 @@ def list_jobs_tool(
         "offset": offset,
         "limit": limit,
         "has_more": offset + len(jobs) < total,
-        "jobs": [job.to_dict() for job in jobs],
+        "jobs": job_dicts,
     }
 
 

--- a/tests/test_job_result_capping.py
+++ b/tests/test_job_result_capping.py
@@ -1,0 +1,82 @@
+"""Job status/list responses must cap embedded fold_results.
+
+A completed evaluate job can carry hundreds of per-fold rows; embedding
+them all in check_job_status (and once per job in list_jobs) floods the
+MCP client. Aggregate metrics/summary stay intact.
+"""
+
+import pytest
+
+from sktime_mcp.runtime.jobs import JobStatus, get_job_manager
+from sktime_mcp.tools.job_tools import check_job_status_tool, list_jobs_tool
+
+
+@pytest.fixture
+def evaluate_job_with_120_folds():
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job(
+        job_type="evaluate",
+        estimator_handle="est_test",
+        estimator_name="ThetaForecaster",
+        dataset_name="airline",
+        total_steps=3,
+    )
+    result = {
+        "success": True,
+        "metrics": {"test_MeanAbsolutePercentageError": 0.03},
+        "summary": {"test_MeanAbsolutePercentageError": {"mean": 0.03}},
+        "fold_results": [
+            {"test_MeanAbsolutePercentageError": 0.01 * i, "len_train_window": 24 + i}
+            for i in range(120)
+        ],
+        "cv_folds_run": 120,
+    }
+    job_manager.update_job(job_id, status=JobStatus.COMPLETED, result=result)
+    yield job_id
+    job_manager.delete_job(job_id)
+
+
+def test_check_job_status_caps_fold_results(evaluate_job_with_120_folds):
+    res = check_job_status_tool(evaluate_job_with_120_folds)
+    assert res["success"]
+    assert len(res["result"]["fold_results"]) == 10
+    assert res["result"]["fold_results_truncated"]["total"] == 120
+    # aggregates untouched
+    assert res["result"]["metrics"]["test_MeanAbsolutePercentageError"] == 0.03
+    assert res["result"]["cv_folds_run"] == 120
+
+
+def test_list_jobs_drops_fold_results(evaluate_job_with_120_folds):
+    res = list_jobs_tool(status="completed")
+    assert res["success"]
+    job = next(j for j in res["jobs"] if j["job_id"] == evaluate_job_with_120_folds)
+    assert job["result"]["fold_results"] == []
+    assert job["result"]["fold_results_truncated"]["total"] == 120
+    assert job["result"]["metrics"]["test_MeanAbsolutePercentageError"] == 0.03
+
+
+def test_stored_job_result_not_mutated(evaluate_job_with_120_folds):
+    check_job_status_tool(evaluate_job_with_120_folds)
+    stored = get_job_manager().get_job(evaluate_job_with_120_folds)
+    assert len(stored.result["fold_results"]) == 120
+
+
+def test_small_results_pass_through_unchanged():
+    job_manager = get_job_manager()
+    job_id = job_manager.create_job(
+        job_type="predict",
+        estimator_handle="est_test",
+        estimator_name="NaiveForecaster",
+        total_steps=2,
+    )
+    job_manager.update_job(
+        job_id,
+        status=JobStatus.COMPLETED,
+        result={"success": True, "predictions": {"1961-01": 417.0}},
+    )
+    try:
+        res = check_job_status_tool(job_id)
+        assert res["result"] == {"success": True, "predictions": {"1961-01": 417.0}}
+        assert "fold_results_truncated" not in res["result"]
+    finally:
+        job_manager.delete_job(job_id)


### PR DESCRIPTION
## Problem

Found in the 2026-08-08 sweep of the job system: `check_job_status` embeds the job's full `result` payload inline. A completed evaluate job with `initial_window=24` on airline carried **120 `fold_results` rows** (~15k tokens) in every status check, and `list_jobs` repeated the full payload once per job.

## Fix

New `_compact_result` in `job_tools.py`:

- `check_job_status`: `fold_results` capped at 10 rows with an explicit `fold_results_truncated: {shown, total, note}` marker
- `list_jobs`: per-fold rows dropped entirely (it's an overview), same marker
- Aggregate `metrics`/`summary`/`cv_folds_run` are always complete; small results pass through untouched; the stored job record is never mutated

## Testing

- New `tests/test_job_result_capping.py` (4 tests): cap in status, drop in list, stored record unmutated, small results unchanged
- `pytest tests/test_job_result_capping.py tests/test_background_jobs.py tests/test_job_cancellation.py` — 19 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
