### PR TITLE
fix: report evicted handles as "evicted", not "not found" (#532)

### DIFF
--- a/src/sktime_mcp/runtime/executor.py
+++ b/src/sktime_mcp/runtime/executor.py
@@ -9,6 +9,7 @@ import asyncio
 import inspect
 import logging
 import uuid
+from collections import deque
 from typing import Any
 
 import pandas as pd
@@ -196,6 +197,8 @@ class Executor:
         self._handle_manager = get_handle_manager()
         self._job_manager = get_job_manager()
         self._data_handles: dict[str, Any] = {}
+        # Tombstones for data handles evicted under the cap (see _cleanup_oldest_data).
+        self._evicted_data: deque[str] = deque(maxlen=1024)
         from sktime_mcp.config import settings
 
         self._max_data_handles = settings.max_data_handles
@@ -205,7 +208,23 @@ class Executor:
         to_remove = list(self._data_handles.keys())[:count]
         for handle_id in to_remove:
             del self._data_handles[handle_id]
-            logger.debug("Evicted data handle %s (limit=%d)", handle_id, self._max_data_handles)
+            self._evicted_data.append(handle_id)
+            logger.info("Evicted data handle %s (limit %d reached)", handle_id, self._max_data_handles)
+
+    def data_handle_missing(self, handle_id: str) -> dict[str, Any]:
+        """Error body for a missing data handle — distinguishes evicted from unknown.
+
+        Returns the ``error`` string plus the capped available-handles summary,
+        so callers can splat it into a not-found response.
+        """
+        if handle_id in self._evicted_data:
+            error = (
+                f"Data handle '{handle_id}' was evicted (handle limit "
+                f"{self._max_data_handles} reached); reload the source."
+            )
+        else:
+            error = f"Data handle '{handle_id}' not found"
+        return {"error": error, **self.summarize_available_handles()}
 
     def _register_data_handle(self, handle_id: str, data: dict[str, Any]) -> None:
         if len(self._data_handles) >= self._max_data_handles:
@@ -380,7 +399,7 @@ class Executor:
             handle_info = self._handle_manager.get_info(handle_id)
             instance = handle_info.instance
         except KeyError:
-            return {"success": False, "error": f"Handle not found: {handle_id}"}
+            return {"success": False, "error": self._handle_manager.describe_missing(handle_id)}
 
         obj_type = getattr(instance, "get_class_tag", lambda x, y: "")("object_type", "")
         if not hasattr(instance, "fit"):
@@ -448,7 +467,7 @@ class Executor:
         try:
             instance = self._handle_manager.get_instance(handle_id)
         except KeyError:
-            return {"success": False, "error": f"Handle not found: {handle_id}"}
+            return {"success": False, "error": self._handle_manager.describe_missing(handle_id)}
 
         obj_type = getattr(instance, "get_class_tag", lambda x, y: "")("object_type", "")
         if (
@@ -667,7 +686,7 @@ class Executor:
         try:
             instance = self._handle_manager.get_instance(handle_id)
         except KeyError:
-            return {"success": False, "error": f"Handle not found: {handle_id}"}
+            return {"success": False, "error": self._handle_manager.describe_missing(handle_id)}
 
         if not hasattr(instance, method_name):
             obj_type = getattr(instance, "get_class_tag", lambda x, y: "")("object_type", "")
@@ -748,7 +767,7 @@ class Executor:
         try:
             instance = self._handle_manager.get_instance(handle_id)
         except KeyError:
-            return {"success": False, "error": f"Handle not found: {handle_id}"}
+            return {"success": False, "error": self._handle_manager.describe_missing(handle_id)}
 
         if not self._handle_manager.is_fitted(handle_id):
             return {"success": False, "error": "Estimator not fitted"}
@@ -788,7 +807,7 @@ class Executor:
         try:
             instance = self._handle_manager.get_instance(handle_id)
         except KeyError:
-            return {"success": False, "error": f"Handle not found: {handle_id}"}
+            return {"success": False, "error": self._handle_manager.describe_missing(handle_id)}
 
         if not self._handle_manager.is_fitted(handle_id):
             return {"success": False, "error": "Estimator not fitted"}
@@ -932,7 +951,7 @@ class Executor:
             try:
                 instance = self._handle_manager.get_instance(handle_id)
             except KeyError as err:
-                raise ValueError(f"Handle not found: {handle_id}") from err
+                raise ValueError(self._handle_manager.describe_missing(handle_id)) from err
 
             y_res = self._resolve_source(y)
             if not y_res["success"]:
@@ -1259,7 +1278,7 @@ class Executor:
         was never exposed to the caller.
         """
         if data_handle not in self._data_handles:
-            return {"success": False, "error": f"Data handle '{data_handle}' not found"}
+            return {"success": False, **self.data_handle_missing(data_handle)}
 
         data_info = self._data_handles[data_handle]
         y = data_info["y"].copy()
@@ -1424,7 +1443,7 @@ class Executor:
         else:
             return {
                 "success": False,
-                "error": f"Data handle '{data_handle}' not found",
+                "error": self.data_handle_missing(data_handle)["error"],
             }
 
 

--- a/src/sktime_mcp/runtime/handles.py
+++ b/src/sktime_mcp/runtime/handles.py
@@ -6,6 +6,7 @@ Manages references to instantiated estimator objects.
 
 import logging
 import uuid
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -42,6 +43,21 @@ class HandleManager:
     def __init__(self, max_handles: int = 100):
         self._handles: dict[str, HandleInfo] = {}
         self._max_handles = max_handles
+        # Tombstones: ids evicted to stay under the cap, so a later lookup can
+        # say "evicted" instead of an indistinguishable "not found".
+        self._evicted: deque[str] = deque(maxlen=1024)
+
+    def describe_missing(self, handle_id: str) -> str:
+        """Message for a handle that isn't present — distinguishes evicted from unknown."""
+        if handle_id in self._evicted:
+            return (
+                f"Estimator handle '{handle_id}' was evicted (handle limit "
+                f"{self._max_handles} reached); re-create it with instantiate."
+            )
+        return f"Handle not found: {handle_id}"
+
+    def was_evicted(self, handle_id: str) -> bool:
+        return handle_id in self._evicted
 
     def create_handle(
         self,
@@ -67,12 +83,12 @@ class HandleManager:
 
     def get_instance(self, handle_id: str) -> Any:
         if handle_id not in self._handles:
-            raise KeyError(f"Handle not found: {handle_id}")
+            raise KeyError(self.describe_missing(handle_id))
         return self._handles[handle_id].instance
 
     def get_info(self, handle_id: str) -> HandleInfo:
         if handle_id not in self._handles:
-            raise KeyError(f"Handle not found: {handle_id}")
+            raise KeyError(self.describe_missing(handle_id))
         return self._handles[handle_id]
 
     def exists(self, handle_id: str) -> bool:
@@ -113,6 +129,10 @@ class HandleManager:
         )
         for handle_id, _ in sorted_handles[:count]:
             del self._handles[handle_id]
+            self._evicted.append(handle_id)
+            logger.info(
+                "Evicted estimator handle %s (limit %d reached)", handle_id, self._max_handles
+            )
 
 
 _handle_manager_instance: HandleManager | None = None

--- a/src/sktime_mcp/tools/codegen.py
+++ b/src/sktime_mcp/tools/codegen.py
@@ -86,7 +86,7 @@ def export_code_tool(
     try:
         handle_info = handle_manager.get_info(handle)
     except KeyError:
-        return {"success": False, "error": f"Handle not found: {handle}"}
+        return {"success": False, "error": handle_manager.describe_missing(handle)}
 
     if not _is_valid_var_name(var_name):
         return {

--- a/src/sktime_mcp/tools/evaluate.py
+++ b/src/sktime_mcp/tools/evaluate.py
@@ -73,7 +73,10 @@ def evaluate_tool(
     try:
         instance = executor._handle_manager.get_instance(estimator_handle)
     except KeyError:
-        return {"success": False, "error": f"Handle not found: {estimator_handle}"}
+        return {
+            "success": False,
+            "error": executor._handle_manager.describe_missing(estimator_handle),
+        }
 
     y_res = executor._resolve_source(y)
     if not y_res["success"]:

--- a/src/sktime_mcp/tools/inspect_data.py
+++ b/src/sktime_mcp/tools/inspect_data.py
@@ -55,8 +55,7 @@ def inspect_data_tool(data_handle: str) -> dict[str, Any]:
     if data_handle not in executor._data_handles:
         return {
             "success": False,
-            "error": f"Data handle '{data_handle}' not found",
-            **executor.summarize_available_handles(),
+            **executor.data_handle_missing(data_handle),
         }
 
     data_info = executor._data_handles[data_handle]

--- a/src/sktime_mcp/tools/instantiate.py
+++ b/src/sktime_mcp/tools/instantiate.py
@@ -59,7 +59,7 @@ def release_handle_tool(handle: str) -> dict[str, Any]:
     return {
         "success": released,
         "handle": handle,
-        "message": "Handle released" if released else "Handle not found",
+        "message": "Handle released" if released else handle_manager.describe_missing(handle),
     }
 
 

--- a/src/sktime_mcp/tools/plotting.py
+++ b/src/sktime_mcp/tools/plotting.py
@@ -179,9 +179,13 @@ def plot_series_tool(
             missing.append(handle)
 
     if missing:
+        evicted = [h for h in missing if h in executor._evicted_data]
+        detail = f"Data handle(s) not found: {missing}"
+        if evicted:
+            detail += f" (evicted under the handle limit: {evicted}; reload the source)"
         return {
             "success": False,
-            "error": f"Data handle(s) not found: {missing}",
+            "error": detail,
             **executor.summarize_available_handles(),
         }
 

--- a/src/sktime_mcp/tools/save_data.py
+++ b/src/sktime_mcp/tools/save_data.py
@@ -60,8 +60,7 @@ def save_data_tool(
     if data_handle not in executor._data_handles:
         return {
             "success": False,
-            "error": f"Data handle '{data_handle}' not found",
-            **executor.summarize_available_handles(),
+            **executor.data_handle_missing(data_handle),
         }
 
     fmt = format.lower()

--- a/src/sktime_mcp/tools/save_model.py
+++ b/src/sktime_mcp/tools/save_model.py
@@ -60,7 +60,7 @@ def save_model_tool(
     try:
         estimator = handle_manager.get_instance(estimator_handle)
     except KeyError:
-        return {"success": False, "error": f"Handle not found: {estimator_handle}"}
+        return {"success": False, "error": handle_manager.describe_missing(estimator_handle)}
 
     if not handle_manager.is_fitted(estimator_handle):
         handle_info = handle_manager.get_info(estimator_handle)

--- a/src/sktime_mcp/tools/split_data.py
+++ b/src/sktime_mcp/tools/split_data.py
@@ -56,8 +56,7 @@ def split_data_tool(
     if data_handle not in executor._data_handles:
         return {
             "success": False,
-            "error": f"Data handle '{data_handle}' not found",
-            **executor.summarize_available_handles(),
+            **executor.data_handle_missing(data_handle),
         }
 
     if test_size is not None and fh is not None:

--- a/src/sktime_mcp/tools/transform_data.py
+++ b/src/sktime_mcp/tools/transform_data.py
@@ -81,8 +81,7 @@ def transform_data_tool(
     if data_handle not in executor._data_handles:
         return {
             "success": False,
-            "error": f"Data handle '{data_handle}' not found",
-            **executor.summarize_available_handles(),
+            **executor.data_handle_missing(data_handle),
         }
 
     try:

--- a/tests/test_eviction_tombstones.py
+++ b/tests/test_eviction_tombstones.py
@@ -1,0 +1,85 @@
+"""Evicted handles must report "evicted", not an indistinguishable "not found" (#532).
+
+Both handle stores bulk-evict the oldest entries at their cap. Previously the
+caller only saw a generic "not found" — identical to a typo. Now evicted ids
+are tombstoned and the error says so.
+"""
+
+import pandas as pd
+import pytest
+
+from sktime_mcp.runtime.executor import Executor
+from sktime_mcp.runtime.handles import HandleManager
+from sktime_mcp.tools.inspect_data import inspect_data_tool
+
+
+class _Est:
+    """Minimal stand-in with the attributes create_handle stores."""
+
+
+def test_estimator_eviction_message():
+    hm = HandleManager(max_handles=5)
+    ids = [hm.create_handle("Dummy", _Est(), {}) for _ in range(5)]
+    # next create triggers _cleanup_oldest (removes 10, i.e. all present)
+    hm.create_handle("Dummy", _Est(), {})
+    first = ids[0]
+    assert hm.was_evicted(first)
+    msg = hm.describe_missing(first)
+    assert "evicted" in msg.lower()
+    assert "limit 5" in msg
+    # a never-seen id is still a plain not-found
+    assert "not found" in hm.describe_missing("est_never").lower()
+    assert "evicted" not in hm.describe_missing("est_never").lower()
+
+
+def test_get_instance_raises_eviction_message():
+    hm = HandleManager(max_handles=3)
+    ids = [hm.create_handle("Dummy", _Est(), {}) for _ in range(3)]
+    hm.create_handle("Dummy", _Est(), {})
+    with pytest.raises(KeyError) as exc:
+        hm.get_instance(ids[0])
+    assert "evicted" in str(exc.value).lower()
+
+
+def test_data_handle_eviction_message(monkeypatch):
+    ex = Executor()
+    ex._max_data_handles = 5
+
+    def _mk(i):
+        idx = pd.period_range("2020-01", periods=6, freq="M")
+        hid = f"data_test_{i:02d}"
+        ex._register_data_handle(hid, {"y": pd.Series(range(6), index=idx), "X": None,
+                                       "metadata": {}, "validation": {}, "config": {}})
+        return hid
+
+    ids = [_mk(i) for i in range(12)]  # far past the cap -> oldest evicted
+    evicted = [h for h in ids if h in ex._evicted_data]
+    assert evicted, "expected some handles to be evicted past the cap"
+
+    body = ex.data_handle_missing(evicted[0])
+    assert "evicted" in body["error"].lower()
+    assert "n_available_handles" in body
+
+    unknown = ex.data_handle_missing("data_never")
+    assert "not found" in unknown["error"].lower()
+    assert "evicted" not in unknown["error"].lower()
+
+
+def test_inspect_data_surfaces_eviction():
+    from sktime_mcp.runtime.executor import get_executor
+
+    ex = get_executor()
+    ex._max_data_handles = 5
+    idx = pd.period_range("2020-01", periods=6, freq="M")
+    ids = []
+    for i in range(12):
+        hid = f"data_evict_{i:02d}"
+        ex._register_data_handle(hid, {"y": pd.Series(range(6), index=idx), "X": None,
+                                       "metadata": {}, "validation": {}, "config": {}})
+        ids.append(hid)
+    evicted = next(h for h in ids if h in ex._evicted_data)
+    res = inspect_data_tool(data_handle=evicted)
+    assert res["success"] is False
+    assert "evicted" in res["error"].lower()
+    for h in ids:
+        ex._data_handles.pop(h, None)


### PR DESCRIPTION
Fixes #532.

## Problem

Both handle stores silently bulk-evict the oldest entries at their cap (estimator store: 10 oldest via `HandleManager._cleanup_oldest`; data store: oldest ~20% via `Executor._cleanup_oldest_data`), emitting only a `logger.debug`. The caller then got a generic **"not found"** for a handle it had legitimately created — indistinguishable from a typo. (Confirmed live: a session-start data handle vanished after ~52 loads with a plain not-found.)

## Fix

Track evicted ids in a bounded tombstone `deque(maxlen=1024)` in both stores, and route every not-found site through a shared helper:

- `HandleManager.describe_missing(id)` — used by `get_instance`/`get_info` (raise), `evaluate`, `export_code`, `save_model`, `release_handle`.
- `Executor.data_handle_missing(id)` — returns the error string + capped available-handles summary, used by `inspect_data`, `split_data`, `save_data`, `transform_data`, `plot_series`, and the executor's own `format_data_handle` / `release_data_handle`.

When the id was evicted, the message becomes *"'<id>' was evicted (handle limit N reached); reload the source / re-create it with instantiate"* instead of "not found". Eviction is now logged at info level.

## Testing

- New `tests/test_eviction_tombstones.py` (4 tests): estimator + data eviction messages, `get_instance` raises the eviction message, and `inspect_data` surfaces it end-to-end; a never-seen id still reads as a plain "not found".
- Full suite: **254 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
