### PR TITLE
fix: close load_data_source validation gaps (#533)

### DIFF
--- a/src/sktime_mcp/data/adapters/file_adapter.py
+++ b/src/sktime_mcp/data/adapters/file_adapter.py
@@ -78,6 +78,11 @@ class FileAdapter(DataSourceAdapter):
 
         # Set time index
         time_col = self.config.get("time_column")
+        if time_col is not None and time_col not in df.columns:
+            available = ", ".join(repr(c) for c in df.columns)
+            raise ValueError(
+                f"Time column {time_col!r} not found in data. Available columns: [{available}]"
+            )
         if time_col and time_col in df.columns:
             if self.config.get("parse_dates", True):
                 with contextlib.suppress(Exception):
@@ -108,7 +113,9 @@ class FileAdapter(DataSourceAdapter):
 
         # Determine frequency for metadata
         if isinstance(df.index, pd.DatetimeIndex):
-            freq_str = str(df.index.freq) if df.index.freq else pd.infer_freq(df.index)
+            from .pandas_adapter import _safe_infer_freq
+
+            freq_str = str(df.index.freq) if df.index.freq else _safe_infer_freq(df.index)
         else:
             freq_str = "Integer"
 
@@ -161,11 +168,10 @@ class FileAdapter(DataSourceAdapter):
         if path.suffix.lower() == ".tsv":
             csv_options["sep"] = "\t"
 
-        # Parse dates if specified
-        parse_dates = self.config.get("parse_dates", True)
-        if parse_dates and self.config.get("time_column"):
-            csv_options["parse_dates"] = [self.config["time_column"]]
-
+        # Note: the time column is parsed to datetime in load() after we've
+        # confirmed it exists — passing parse_dates=[col] here for a missing
+        # column leaks a raw pandas "Missing column provided to 'parse_dates'"
+        # error (#533 / NB-11).
         try:
             df = pd.read_csv(path, **csv_options)
         except Exception as e:
@@ -215,6 +221,13 @@ class FileAdapter(DataSourceAdapter):
         """Validate file data using pandas adapter validation."""
         from .pandas_adapter import PandasAdapter
 
-        # Reuse pandas validation logic
-        pandas_adapter = PandasAdapter({"data": data})
+        # Reuse pandas validation logic, forwarding the column config so the
+        # target-dtype check applies to file sources too.
+        pandas_adapter = PandasAdapter(
+            {
+                "data": data,
+                "target_column": self.config.get("target_column"),
+                "exog_columns": self.config.get("exog_columns", []),
+            }
+        )
         return pandas_adapter.validate(data)

--- a/src/sktime_mcp/data/adapters/pandas_adapter.py
+++ b/src/sktime_mcp/data/adapters/pandas_adapter.py
@@ -13,6 +13,19 @@ import pandas as pd
 from ..base import DataSourceAdapter
 
 
+def _safe_infer_freq(index: pd.Index) -> str | None:
+    """pd.infer_freq requires >= 3 points and raises otherwise; return None instead.
+
+    A 1–2 row series is a valid (if tiny) time series — it should load with no
+    frequency rather than crash with pandas' "Need at least 3 dates" ValueError.
+    """
+    if len(index) < 3:
+        return None
+    with contextlib.suppress(ValueError, TypeError):
+        return pd.infer_freq(index)
+    return None
+
+
 class PandasAdapter(DataSourceAdapter):
     """
     Adapter for in-memory pandas DataFrames.
@@ -80,8 +93,8 @@ class PandasAdapter(DataSourceAdapter):
             with contextlib.suppress(Exception):
                 df = df.asfreq(freq)
         elif isinstance(df.index, pd.DatetimeIndex) and df.index.freq is None:
-            # Try to infer frequency
-            inferred_freq = pd.infer_freq(df.index)
+            # Try to infer frequency (needs >= 3 points; short series just skip it)
+            inferred_freq = _safe_infer_freq(df.index)
             if inferred_freq:
                 df = df.asfreq(inferred_freq)
 
@@ -89,7 +102,7 @@ class PandasAdapter(DataSourceAdapter):
 
         # Determine frequency for metadata
         if isinstance(df.index, pd.DatetimeIndex):
-            freq_str = str(df.index.freq) if df.index.freq else pd.infer_freq(df.index)
+            freq_str = str(df.index.freq) if df.index.freq else _safe_infer_freq(df.index)
         else:
             freq_str = "Integer"
 
@@ -175,14 +188,28 @@ class PandasAdapter(DataSourceAdapter):
                 f"Very small dataset ({len(data)} rows). Consider using more data for reliable forecasting."
             )
 
+        # Check that the target column is numeric — forecasting cannot use an
+        # object/string target, and this otherwise passes silently and fails
+        # deep inside fit (#533 / NB-07).
+        target_col = self.config.get("target_column")
+        if target_col is None and len(data.columns) > 0:
+            target_col = data.columns[0]
+        if target_col is not None and target_col in data.columns:
+            if not pd.api.types.is_numeric_dtype(data[target_col]):
+                warnings.append(
+                    f"Target column '{target_col}' has non-numeric dtype "
+                    f"'{data[target_col].dtype}'. Forecasting requires numeric values; "
+                    "convert the column before fitting."
+                )
+
         # Check for constant values
         for col in data.columns:
             if data[col].nunique() == 1:
                 warnings.append(f"Column '{col}' has constant values")
 
-        # Check frequency
-        if isinstance(data.index, pd.DatetimeIndex):
-            freq = pd.infer_freq(data.index)
+        # Check frequency (infer_freq needs >= 3 points; short series skip it)
+        if isinstance(data.index, pd.DatetimeIndex) and len(data.index) >= 3:
+            freq = _safe_infer_freq(data.index)
             if freq is None:
                 warnings.append(
                     "Could not infer frequency. Time series may have irregular intervals."

--- a/tests/test_load_validation.py
+++ b/tests/test_load_validation.py
@@ -1,0 +1,111 @@
+"""load_data_source validation gaps (#533).
+
+- NB-07: a non-numeric target must be flagged (not silently valid).
+- NB-06: a 1–2 row series must load, not crash on frequency inference.
+- NB-11: a bad file time_column must give a clean "not found" message,
+  not a leaked pandas parse_dates internal.
+"""
+
+import csv
+import os
+import tempfile
+
+import pytest
+
+from sktime_mcp.runtime.executor import get_executor
+
+
+class TestNonNumericTarget:
+    def test_object_dtype_target_warns(self):
+        ex = get_executor()
+        res = ex.load_data_source(
+            {
+                "type": "pandas",
+                "data": {
+                    "date": ["2024-01-01", "2024-02-01", "2024-03-01"],
+                    "value": ["1", "2", "3"],  # strings -> object dtype
+                },
+                "time_column": "date",
+                "target_column": "value",
+            }
+        )
+        try:
+            assert res["success"]  # still loads
+            warnings = res["validation"]["warnings"]
+            assert any("non-numeric" in w.lower() and "value" in w for w in warnings), warnings
+        finally:
+            ex._data_handles.pop(res.get("data_handle"), None)
+
+    def test_numeric_target_no_warning(self):
+        ex = get_executor()
+        res = ex.load_data_source(
+            {
+                "type": "pandas",
+                "data": {
+                    "date": ["2024-01-01", "2024-02-01", "2024-03-01"],
+                    "value": [1.0, 2.0, 3.0],
+                },
+                "time_column": "date",
+                "target_column": "value",
+            }
+        )
+        try:
+            assert not any("non-numeric" in w.lower() for w in res["validation"]["warnings"])
+        finally:
+            ex._data_handles.pop(res.get("data_handle"), None)
+
+
+class TestShortSeries:
+    @pytest.mark.parametrize("n", [1, 2])
+    def test_short_series_loads(self, n):
+        ex = get_executor()
+        res = ex.load_data_source(
+            {
+                "type": "pandas",
+                "data": {
+                    "date": ["2024-01-01", "2024-02-01"][:n],
+                    "value": [10.0, 20.0][:n],
+                },
+                "time_column": "date",
+                "target_column": "value",
+            }
+        )
+        try:
+            assert res["success"], res
+        finally:
+            ex._data_handles.pop(res.get("data_handle"), None)
+
+
+class TestFileBadTimeColumn:
+    def test_missing_time_column_clean_error(self):
+        ex = get_executor()
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "data.csv")
+            with open(path, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow(["timestamp", "value"])
+                for i in range(5):
+                    w.writerow([f"2024-01-0{i + 1}", i])
+            res = ex.load_data_source(
+                {"type": "file", "path": path, "time_column": "index", "target_column": "value"}
+            )
+        assert not res["success"]
+        err = res["error"]
+        assert "not found" in err.lower()
+        assert "parse_dates" not in err  # no leaked pandas internal
+        assert "timestamp" in err  # lists available columns
+
+    def test_missing_target_column_lists_available(self):
+        ex = get_executor()
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "data.csv")
+            with open(path, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow(["timestamp", "value"])
+                for i in range(5):
+                    w.writerow([f"2024-01-0{i + 1}", i])
+            res = ex.load_data_source(
+                {"type": "file", "path": path, "time_column": "timestamp", "target_column": "nope"}
+            )
+        assert not res["success"]
+        assert "nope" in res["error"]


### PR DESCRIPTION
Fixes #533.

Three related `load_data_source` validation gaps, all verified in the sweeps:

## NB-07 — non-numeric target passed validation silently
An object-dtype target (`value: ["1","2","3"]`) returned `valid: true` and failed much later inside `fit`. `validate()` now **warns** when the target column is non-numeric, naming the column and dtype. The check is forwarded to file sources too — `file_adapter.validate` now passes the target/exog config into the reused `PandasAdapter` validation (previously it constructed one with `{"data": data}` only, so the target was unknown).

## NB-06 — 1–2 row series could not load
`pd.infer_freq` requires ≥3 points and raises `"Need at least 3 dates to infer frequency"`; three call sites hit it unguarded. Added a `_safe_infer_freq` helper that returns `None` for short series, so a tiny (but valid) series loads with no frequency instead of crashing.

## NB-11 — file loader leaked pandas parse_dates internals
A bad `time_column` produced `"Missing column provided to 'parse_dates': 'index'"`. Now the time column's existence is checked up front with a clean *"Time column 'x' not found in data. Available columns: [...]"* message, and `parse_dates=[col]` is no longer wired into `read_csv` — the column is parsed to datetime in `load()` after the existence check (matching the pandas-source path).

## Testing

- New `tests/test_load_validation.py` (6 tests): object-dtype target warns / numeric doesn't; 1- and 2-row series load; bad file `time_column` gives a clean not-found without `parse_dates` in the message and lists available columns; bad `target_column` lists available.
- Full suite: **260 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
