### PR TITLE
[BUG] lock `HandleManager` against concurrent tool calls

### DIFF
--- a/src/sktime_mcp/runtime/handles.py
+++ b/src/sktime_mcp/runtime/handles.py
@@ -5,6 +5,7 @@ Manages references to instantiated estimator objects.
 """
 
 import logging
+import threading
 import uuid
 from collections import deque
 from dataclasses import dataclass, field
@@ -46,18 +47,24 @@ class HandleManager:
         # Tombstones: ids evicted to stay under the cap, so a later lookup can
         # say "evicted" instead of an indistinguishable "not found".
         self._evicted: deque[str] = deque(maxlen=1024)
+        # Handles are read and written from worker threads (fit_async runs fit
+        # in a thread pool) while the asyncio thread serves other tool calls.
+        # Reentrant because create_handle evicts while already holding it.
+        self._lock = threading.RLock()
 
     def describe_missing(self, handle_id: str) -> str:
         """Message for a handle that isn't present — distinguishes evicted from unknown."""
-        if handle_id in self._evicted:
-            return (
-                f"Estimator handle '{handle_id}' was evicted (handle limit "
-                f"{self._max_handles} reached); re-create it with instantiate."
-            )
-        return f"Handle not found: {handle_id}"
+        with self._lock:
+            if handle_id in self._evicted:
+                return (
+                    f"Estimator handle '{handle_id}' was evicted (handle limit "
+                    f"{self._max_handles} reached); re-create it with instantiate."
+                )
+            return f"Handle not found: {handle_id}"
 
     def was_evicted(self, handle_id: str) -> bool:
-        return handle_id in self._evicted
+        with self._lock:
+            return handle_id in self._evicted
 
     def create_handle(
         self,
@@ -66,73 +73,85 @@ class HandleManager:
         params: dict[str, Any] | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> str:
-        if len(self._handles) >= self._max_handles:
-            self._cleanup_oldest()
+        with self._lock:
+            if len(self._handles) >= self._max_handles:
+                self._cleanup_oldest()
 
-        handle_id = f"est_{uuid.uuid4().hex[:12]}"
-        handle_info = HandleInfo(
-            handle_id=handle_id,
-            estimator_name=estimator_name,
-            instance=instance,
-            params=params or {},
-            created_at=datetime.now(),
-            metadata=metadata or {},
-        )
-        self._handles[handle_id] = handle_info
-        return handle_id
+            handle_id = f"est_{uuid.uuid4().hex[:12]}"
+            handle_info = HandleInfo(
+                handle_id=handle_id,
+                estimator_name=estimator_name,
+                instance=instance,
+                params=params or {},
+                created_at=datetime.now(),
+                metadata=metadata or {},
+            )
+            self._handles[handle_id] = handle_info
+            return handle_id
 
     def get_instance(self, handle_id: str) -> Any:
-        if handle_id not in self._handles:
-            raise KeyError(self.describe_missing(handle_id))
-        return self._handles[handle_id].instance
+        with self._lock:
+            if handle_id not in self._handles:
+                raise KeyError(self.describe_missing(handle_id))
+            return self._handles[handle_id].instance
 
     def get_info(self, handle_id: str) -> HandleInfo:
-        if handle_id not in self._handles:
-            raise KeyError(self.describe_missing(handle_id))
-        return self._handles[handle_id]
+        with self._lock:
+            if handle_id not in self._handles:
+                raise KeyError(self.describe_missing(handle_id))
+            return self._handles[handle_id]
 
     def exists(self, handle_id: str) -> bool:
-        return handle_id in self._handles
+        with self._lock:
+            return handle_id in self._handles
 
     def replace_instance(self, handle_id: str, instance: Any) -> None:
         """Swap the live instance behind a handle (e.g. rollback after a failed update)."""
-        if handle_id in self._handles:
-            self._handles[handle_id].instance = instance
+        with self._lock:
+            if handle_id in self._handles:
+                self._handles[handle_id].instance = instance
 
     def mark_fitted(self, handle_id: str) -> None:
-        if handle_id in self._handles:
-            self._handles[handle_id].fitted = True
+        with self._lock:
+            if handle_id in self._handles:
+                self._handles[handle_id].fitted = True
 
     def is_fitted(self, handle_id: str) -> bool:
-        if handle_id not in self._handles:
-            return False
-        return self._handles[handle_id].fitted
+        with self._lock:
+            if handle_id not in self._handles:
+                return False
+            return self._handles[handle_id].fitted
 
     def release_handle(self, handle_id: str) -> bool:
-        if handle_id in self._handles:
-            del self._handles[handle_id]
-            return True
-        return False
+        with self._lock:
+            if handle_id in self._handles:
+                del self._handles[handle_id]
+                return True
+            return False
 
     def list_handles(self) -> list[dict[str, Any]]:
-        return [info.to_dict() for info in self._handles.values()]
+        with self._lock:
+            return [info.to_dict() for info in self._handles.values()]
 
     def clear_all(self) -> int:
-        count = len(self._handles)
-        self._handles.clear()
-        return count
+        with self._lock:
+            count = len(self._handles)
+            self._handles.clear()
+            return count
 
     def _cleanup_oldest(self, count: int = 10) -> None:
-        sorted_handles = sorted(
-            self._handles.items(),
-            key=lambda x: x[1].created_at,
-        )
-        for handle_id, _ in sorted_handles[:count]:
-            del self._handles[handle_id]
-            self._evicted.append(handle_id)
-            logger.info(
-                "Evicted estimator handle %s (limit %d reached)", handle_id, self._max_handles
+        """Evict the oldest handles. Caller must hold ``self._lock``."""
+        with self._lock:
+            sorted_handles = sorted(
+                self._handles.items(),
+                key=lambda x: x[1].created_at,
             )
+            for handle_id, _ in sorted_handles[:count]:
+                del self._handles[handle_id]
+                self._evicted.append(handle_id)
+                logger.info(
+                    "Evicted estimator handle %s (limit %d reached)", handle_id, self._max_handles
+                )
 
 
 _handle_manager_instance: HandleManager | None = None

--- a/tests/test_handle_thread_safety.py
+++ b/tests/test_handle_thread_safety.py
@@ -1,0 +1,133 @@
+"""``HandleManager`` must serialise access to its handle store (#554).
+
+The store is reachable from worker threads — ``fit_async`` runs ``fit`` in a
+``ThreadPoolExecutor`` and ``fit`` writes via ``mark_fitted`` — while the
+asyncio thread keeps serving other tool calls. Without a lock, two
+``create_handle`` calls at the cap evict the same ids (``KeyError``) and an
+eviction during ``list_handles`` breaks the iteration (``RuntimeError``).
+"""
+
+import contextlib
+import itertools
+import sys
+import threading
+import time
+
+from sktime_mcp.runtime import handles as handles_mod
+from sktime_mcp.runtime.handles import HandleManager
+
+
+class _Est:
+    """Minimal stand-in for a stored estimator instance."""
+
+
+def test_cleanup_oldest_is_atomic():
+    """Two threads evicting at the cap must not delete the same id twice."""
+    mgr = HandleManager(max_handles=10)
+    for _ in range(10):
+        mgr.create_handle("Est", _Est())
+
+    real_sorted = sorted
+    barrier = threading.Barrier(2)
+
+    def instrumented(*args, **kwargs):
+        out = real_sorted(*args, **kwargs)
+        # Both threads hold the same victim list before either deletes. Once
+        # the section is locked this cannot be satisfied, and the barrier
+        # timing out is itself the pass condition.
+        with contextlib.suppress(threading.BrokenBarrierError):
+            barrier.wait(timeout=0.5)
+        return out
+
+    errors = []
+
+    def worker():
+        try:
+            mgr.create_handle("Est", _Est())
+        except Exception as exc:  # recorded, then asserted on below
+            errors.append(exc)
+
+    handles_mod.sorted = instrumented
+    try:
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+    finally:
+        del handles_mod.sorted
+
+    assert not errors, f"concurrent eviction raised {errors[0]!r}"
+
+
+def test_list_handles_survives_concurrent_eviction():
+    """An eviction while ``list_handles`` iterates must not break the walk."""
+    mgr = HandleManager(max_handles=10)
+    for _ in range(10):
+        mgr.create_handle("Est", _Est())
+
+    started = threading.Event()
+    calls = itertools.count()
+    real_to_dict = handles_mod.HandleInfo.to_dict
+
+    def slow_to_dict(self):
+        if next(calls) == 0:
+            started.set()
+            time.sleep(0.3)  # hold the iteration open
+        return real_to_dict(self)
+
+    errors = []
+
+    def lister():
+        try:
+            mgr.list_handles()
+        except Exception as exc:  # recorded, then asserted on below
+            errors.append(exc)
+
+    def evictor():
+        started.wait(timeout=2)
+        try:
+            mgr.create_handle("Est", _Est())  # trips _cleanup_oldest
+        except Exception as exc:  # recorded, then asserted on below
+            errors.append(exc)
+
+    handles_mod.HandleInfo.to_dict = slow_to_dict
+    try:
+        threads = [threading.Thread(target=lister), threading.Thread(target=evictor)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+    finally:
+        handles_mod.HandleInfo.to_dict = real_to_dict
+
+    assert not errors, f"eviction during list_handles raised {errors[0]!r}"
+
+
+def test_concurrent_handle_churn_is_clean():
+    """Uninstrumented churn under a short switch interval must stay quiet."""
+    mgr = HandleManager(max_handles=30)
+    errors = []
+
+    def worker():
+        for _ in range(60):
+            try:
+                handle = mgr.create_handle("Est", _Est())
+                mgr.mark_fitted(handle)
+                mgr.list_handles()
+                mgr.is_fitted(handle)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    previous = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)  # expose interleavings the 5 ms default hides
+    try:
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+    finally:
+        sys.setswitchinterval(previous)
+
+    assert not errors, f"{len(errors)} errors, first was {errors[0]!r}"


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #554.

#### What does this implement/fix? Explain your changes.

`HandleManager` mutated `self._handles` with no synchronisation, while `JobManager` (`runtime/jobs.py:145`) already holds a `threading.Lock()`. The store is reached from worker threads — `fit_async` runs `fit` in a `ThreadPoolExecutor` (`executor.py:988`) and `fit` writes via `mark_fitted` (`executor.py:507`) — while the asyncio thread keeps serving other tool calls.

Two races followed:

- `_cleanup_oldest` snapshotted `sorted(self._handles.items())` and then deleted in a loop, so two `create_handle` calls at the cap picked the same victims and the second delete raised `KeyError`.
- `list_handles` iterated `self._handles.values()`, so an eviction mid-walk raised `RuntimeError: dictionary changed size during iteration`.

Guards the accessors with an `RLock` — reentrant because `create_handle` evicts while already holding it. No behaviour change single-threaded.

#### Does your contribution introduce a new dependency? If yes, which one?

No, `threading` is stdlib.

#### What should a reviewer concentrate their feedback on?

- Whether locking `describe_missing` is wanted, given `get_instance`/`get_info` call it while already holding the lock. Safe under `RLock`, but it reads oddly.
- `Executor._data_handles` (`executor.py:253-278`) has the same list-then-delete and check-then-act shape, but I went looking and could not find a live race there, so I've deliberately not touched it. Nothing off the event loop reaches it: the `run_in_executor` callables (`self.predict`, `_run_evaluate`, `run_fit`, `adapter.load`) all take pre-resolved data and never read `_data_handles`, and none of its critical sections span an `await`. `HandleManager` differs because `fit` runs *inside* the pool and writes through `mark_fitted`. Happy to be told I've missed a path.

#### Any other comments?

The three tests fail on `main` and pass with the change; I checked both directions and reran them 20x for flakiness. The churn test sets `sys.setswitchinterval(1e-6)` and restores it — at the 5 ms default the race stays hidden on an idle machine, which is probably why it hasn't surfaced.

Full suite green locally: **312 passed in 31s**. Worth knowing `make check` is already red on `main` for unrelated files — 7 lint errors in `test_load_validation`, `test_save_model_fitted_check`, `test_transform_deadends`. Happy to clear those separately.

Unrelated dev-env note in case it's useful: `numba` isn't in the `dev` extra, and without it `test_classifier_example_runs` falls back to pure-Python DTW and effectively never finishes — it took me a while to work out that wasn't my change. Installing `numba` takes the suite from "hangs" to 31s.

I used Claude Code to help investigate and draft this; the repro and test results are my own verification.

#### PR checklist

- [x] I've added unit tests and made sure they pass locally.
